### PR TITLE
Make content compatible with es6 queries

### DIFF
--- a/group/Cloud Foundry.json
+++ b/group/Cloud Foundry.json
@@ -1,6312 +1,7254 @@
 {
-  "chartExports" : [ {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Percentage of Firehose messages lost",
-      "id" : "DiVXJg_AYAI",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Firehose Loss Rate",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "% Messages Lost",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : 100.0,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : "sf_metric",
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "DopplerServer.listeners.totalReceivedMessageCount - Sum",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "DopplerServer.TruncatingBuffer.totalDroppedMessages - Sum",
-          "label" : "B",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "DopplerServer.doppler.shedEnvelopes - Sum",
-          "label" : "C",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Percentage Lost",
-          "label" : "D",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('DopplerServer.listeners.totalReceivedMessageCount', rollup='sum').sum().publish(label='A', enable=False)\nB = data('DopplerServer.TruncatingBuffer.totalDroppedMessages', extrapolation='zero').sum().publish(label='B', enable=False)\nC = data('DopplerServer.doppler.shedEnvelopes', extrapolation='zero').sum().publish(label='C', enable=False)\nD = ((B+C)/A).scale(100).publish(label='D')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Rate of change in app instances being started or stopped on the platform",
-      "id" : "DiVXRPQAgAI",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Rate of Change of Running App Instances",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale" : null,
-        "colorScale2" : null,
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "bbs.LRPsRunning - Mean(1h)",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "bbs.LRPsRunning - Timeshift 1h - Mean(1h)",
-          "label" : "B",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Change in # of Running Apps (1 Hour Average)",
-          "label" : "C",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "None",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('bbs.LRPsRunning').mean(over='1h').publish(label='A', enable=False)\nB = data('bbs.LRPsRunning').timeshift('1h').mean(over='1h').publish(label='B', enable=False)\nC = (A-B).publish(label='C')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "0=healthy, 1=unhealthy",
-      "id" : "DiVXNGOAgD0",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Diego Cell Health",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale2" : null,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : true,
-            "property" : "host"
-          }, {
-            "enabled" : false,
-            "property" : "sf_originatingMetric"
-          }, {
-            "enabled" : false,
-            "property" : "sf_metric"
-          }, {
-            "enabled" : true,
-            "property" : "job"
-          }, {
-            "enabled" : false,
-            "property" : "metric_source"
-          }, {
-            "enabled" : false,
-            "property" : "bosh_id"
-          }, {
-            "enabled" : false,
-            "property" : "deployment"
-          } ]
-        },
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "rep.UnhealthyCell",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "sortBy" : "",
-        "type" : "List",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('rep.UnhealthyCell').publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXRB-AcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : " ",
-      "options" : {
-        "markdown" : "<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGIAAAAwCAYAAADq46/yAAAABGdBTUEAALGPC/xhBQAAACBjSFJN\nAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAsTAAALEwEAmpwY\nAAABWWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpu\nczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9\nImh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRm\nOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8v\nbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3Rp\nZmY6T3JpZW50YXRpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+Cjwv\neDp4bXBtZXRhPgpMwidZAAAS00lEQVR4Ae1bCXSWVXp+QvaF7CsJAQIhrBq0oyKiQC2MWlkUHZmj\nWGhPW/S4zdgep60zHoWZHo8cPe2MDnawgoJKReCAgoCCOOwwhFQIIWTfyb5Bdvo898+Nn+EXl2P+\nhLb3JPm//977ve+9z/Mu997vi9clFlylpe/Qvby8rtKZAD5X28gFvn4Fel/gTRsnJDr6tg32eV41\nRFjrdxLQ3tmBzs4uYnwJQ4Z4w8/XF0N6vMLZf7CToPFdFURYD9CAGy+0ILeoEFlFBSiuKENTSxO6\nuy8hMCAA8dGxGDt8BNJGjEJ8VLS6G++Ri9B/zPfB+mfQE9Hd3U1rH4KW1lZ8fuIYNh/8DKvOfgG0\nttCM/PjbMwX2Q2c7cfbC3KTRmPtnU3HnzbciITrGkMGANqjDlRetbdAma0tCadV5/G7jO/jN/h3A\n0EgMDR6KKIYiBaVO/moC3vz1ZVhqJyFlbReBuvO4I3ks/vn+xZh2zRS2urxjsOaOQUtE9yV6gtcQ\n5BQX4eerVmJreTFSYhPRRqBru7vQ5sZ+RIj8I5weFOrtg1yGLTTXY+vSJ3HXtNuMRzjDnMgZLGVQ\nEmE9oby6Co//+7/i/coSjI6MQ157K3HzMtb/dW6sTKC2LhKV5OOLC11dqK0uwZ7HfokZ19/AfOIK\ndYOFADuOIfZioD9lqQJJn8oJbR0d+P2W/8L7RbkYSxJy21pJgBc04K8jQXOwbQpTJVxVBXkzaIXH\n4ul3VqOQyV2yu6hHHtdNXbb/QM9/wImwKUqxWyB1EqQugnQgMwPPH/wEiQxHhe1t8GG7QDN7hJ7P\nK4HH1G3uERkpgcE4XluJjZ/uRBu/e1OPwp6WupInQga6DOiqycZrwZBfWoIzBbk4V1KE+uYmfFaQ\nw8Qcjhbmgw62W8CckBFHeohaXEXgf+kTrkv1Kexoh29ELF770wG0dnYiITzSrKZGD0/GqGFJ8JHX\n9HjHQCXzAckRTi8oOV+JbX/cg9UH9uBYbQURJyhcESEkFCGM8c1K2gR7KBENYQL27sFdhHRy/yCi\nmgmiLCrStNNzZOFf8mMu21lXx3zR2VADkBjpmBgWhcXXT8W86TO590ihBPExMMvcASNClnfoi5N4\n+q3Xsb+iiCjGIdnP3wCoZWlTVzeaLnUZEhIIcInAa6oniG2Ci/0YVf2DgKAQ+BHUdhIGrZJ4j/zE\n9OFfI1BtfgEIDgwiWd5GppK5kdlQDQQEYcv9S3HXrbNItItIT3uGx4lQPFZsPvRFJqb+23IDQiqt\nv4pAy7Jd4cUgaCw5miBX1ldjEvssGJ+OkbHx8CNhzS3NOF1WjF2FOTjDvJJCoOcmjUQQjzk6aPmm\n0Ctk4b5DSCRJfKuilKQxWbvoQTDHEUmvq6buppJz2LD057hv9p3mVk97hkeJsCQUlpdh0SvLcZDH\nFSncnOURCFmioonNAbqOImiVddVYMX027p85G6MSh5tEa5Din3bG+5M52bj/P17BZMb91x/7R0SH\nhnFVdMn0kywB6sfd97GsU/jRK88jNjQSDfQQbQRV5BkxxkuASi6T9zz+rFnmepoIjyVrTUyeIPDe\n2fkhDlaXY0xsEs5xRaSlpjzBkqDPWIJTXleFl//8biy79wH4+/qhsrYW2UzoF3lPGEPS5NQ0BPn7\no6ChFtdGxbCPLxOvDyprKtBy8SLJ8DbLVB0GVtRUcfvtQwK+umTVaqyKHpSooxLmjBc+WIdxI1PM\nWZUnyfAoEYq7Wh394ug+REfEoUxLyR4SZJ0qIkHhqJzesiApBYtm32VIyMw5g1+sXYWPygp6Gfub\nCTy6ILhc9xpv6mJeUdmwazt+tmcbfhSTgGbqoFugiuFL+aSR15Zw9dW1yCilgYyhd35anIMjpzIx\nl/nCk8VjRNjk90XuWSbdOgSHhKGah3TapNmiK4WvAAKrPvN+vABxkVGoa2rEi++/jY9K8jE6PhkX\nuVJqYXj5Q142D5h48Md9gsC2OppbedZUdhZHRZLOndROkDVZJwlWr+qku9mQFYp9mSdw+43TjLd5\nyis8QoSdTAet7lxxAcEL4N6A07cI9CCir7JOswIiiCMThpmW/LISrCvOQwI3d5XMJ6280ZctsSTT\nnyGsuKnBIQGYPHoMfnnP3yGEqyT5SkFtNVbnZ6OTnmbI7unt/BCJRi9XUHtKC1FTX4eguHhnl369\n9ggRdgbKD+UNdUTb11j+l75ge7gWnnq+oD5BAYGmofnCBbP21467nSToPm3yznd1ItKwyfsIpC3z\nZ8yGfm3JyD6NtS8fw6WhERhC0ZIh0p1Fd3fSq+Dti5KWBjRyU4n/rUTIM7SiYQxxYvCVawHkNYTt\n3Z1obdOegRvsIO4XGIK8uHfwY1pXrXYKsfSaQHpELa+dwJ4tzEd9UxO8vdmfhJ4uzEOnr3/PguBy\nEni7KeLBsEzCdR7lyeJRj/D18UYEwwVoye6emImeDqLhp80aQ1BpVaXBYkRCEn6amIL1uaeQGj+c\nm70uA+r5lkYXqSROJLtQBM+UPsY/bV0DJI5hjuCJrV8ghjDkcK3+tdiqxezamfD9uCcJ9A/42r79\n0SDD6vdik6gvl5EpPNsBj7PtIZ5TuYGJ3tJJi0RQGLZnHENdcyMiQ0PxDwt/ijmxw5BTXoSKqjKc\nryzC4qRReEorJ3qOCVg9QPsLxKhEjOZZVWhYtMkVpMqpyu21ltHg0nhqVByiIsLd9umvSo95hH0O\nMCEllabHpEnQRIaKEyJZhtb18dxJr835b8zYuxsP/+U9SE+bgDeefg6nzp3FhYsXEBEWZurKuT94\n+djnlOE6Ppc8AzpDizZrbSL1G4pGob5BTOagl81IHY8w6vdk8RgR1ivSuFn623FT8Hr+GSSFRvC8\np+My7xAxdQQwPDwaS7e+i9b2dszlwVxiTByG8Rm0LVrq1ubnwjdoqHmBQEfogl2git4ufvCEyuQT\ne4+7T/UOoFG0c1ksI5mWfr1rf0N5Opr3RPHsEUfPxA7yWcPNrzyH5Ohh3A9cQg0B6BuqBI7qgmnf\nddxhz4pLxB0T0pHIHbQvwWqiV5zhWdOOc1nIpAeNYVy/d3QagrnT3pefg93cbev09qIhxT2U8gTp\nEXFp/oHILs3Dyjn34rGfPEgdPibvWANyL+GHq/UoEZq0Ji9LXvvRFix5+7cYPSKNZAAV3AGrzbkM\nVX/tF6IISpk2adzkKdGborDGJKyNWgCPJ1pJsjmd5WoLIeFmN67EL5nuimRrHMG0+CSuqLKZc5ak\nXoMXlz2F6LBwj5Kg8XmUCCm0m7s2hpv/3LYJyzav4aPMGIwMDjUrpjZ6h9bzAspZBFiAYrijqM8F\nEiOr11YtlJ6iI5Mm1unlAnckqE6bPJ3Cagdfz9BYX1WCh9LS8fySR8wm0uYzh6p+v/Q4EZqRJUPH\n1Z8dP4LffbQJm/NPu54vcJnpOj9yA6OQV7WTpb7dbB8pclfUrlygFxEucK9B7/ntzLuw8PYfG08Y\nCBI0zAEhQootGbquqqvDET4kOpiVieOlRajjs4b2LnMIouYfsOjZhDf8mU/GR8fjxjHjcEv6dUhN\nHmlCokKVMzT+gIq/UdSAEaGRuTZhtAbFe5ZWbuLqGhtxkUfYnTYXmJYf7o9eGvDz90P40FCEBvEw\nsKcMlCdY/QNKhB1EX0JsfX9/KkpdYpL3Yq7oG+H6W3df+YOCCDsoS4j93t+f1hP7W8+3ke+xDZ0G\n48wL7gbXCwxj9ZUOBt3d27dO1j7QVt53TFf63usRfa1RoHwTcFcS/G3b3On9tvd+l37S49Sl+fUS\n/10E/YB97XjMWPhFxnNZUfV3HeiV7lFbJ59H+HDzJblX6qt+6uPNfcH3KUq8XVwaW13fR8b3uUfj\nVpHe71q8n2MRKIWFhcjJyUFtLZ9MBQXCn0cFmZmZRl5ISIh5L9UCaJVYonS/irt2C3hDQwOOHTuG\nxMREA7C9V3qPHz+OgoICHj/rmYMX1q1bh5iYGJ41hV+m16nDXttPqysrKws7d+3C+HHjekGprDyP\nc+dyUFFRgZKSErS0tCAiIuKycVtZ+lT5urmpzfbVtcoHH3yA5uYWDB+eZMatOmcf57XkNjQ0Gvk6\nlTYnWmJy7969ZnANDfXYuHEjampqDBiBga6nZHZg+rS/sjo7eVnhqdOnOZDm3nbV2Ym0cyctMOx3\nDXLPnj144sknCVAujh49iu07dpj79+3bZ5aw6qNDN63vrU7V9b22dfaAro77kowTGV/RdfjwYSy8\n7z58/PHHBGxTr5FJlsbpTqaVqzbnte1r527bT57MxHm+uaiisdh6d/1b+Y83Z8+eRXl5uRmn8SEB\nKuu78cYbEMgHNwoJpwlqamoqqqqqUMb3kNLGppkBnzlzxlh1ZWWlESQlN9xwA8Tqhvc2YMLECZh2\n8824SEVnaJkC8aabboIv3dXPz7cXHHnAvzz7LH7/2muYPHmyCVsah4gMGcoH/ZSnsn37dvzpxAla\nWTLuWTDfjG3Hjo9x2223Qp66c+dOXHfddUhISMAnn3yCrKwzKOS/doWHh5n75azCsYv7kp899RQe\neeQRE7bUKAJkDEeOHEF8fDzmzZuH4OBg7Nq9G9dTpuq2b9+B9PRr+cijDUdoLPoXsdOns7Bg/nyk\njUsz+Gzdtg0X6GEZGScwZ85sknGecveavZCMPCY6GiNHjsSECROQm5uLbBIwa+ZMJCcP740CxiME\nZidBaGhoMkCUlpYabxDoCilSXMN3igRSdnY21J6RkYFp06YZsnbv/sQAOWnSRBMO5PJ6l2j69OlI\nGTUK+//4OSevA2qXZQkEWcPMGTMwfvx4fTXWo3CoIu8RcQJWRNyzYAHKqPOdd99FIx+BLl+xHPX1\n9abfmjVr0chN4MGDB/Hmm29i5kzKZEhqb+chIufFH1MUtwX4tm0fYsuWLcbjDh86jLfeegt33323\nmdsbb7xhosLmTZsMwDKMNWveNNcKaStW/BqRkZE0Oh+8vX6duWfVqlV8CNiKWbNmIZQvt6nUEqsH\nHviJkXUjjbSJY16/fr1p28WQmUcyAvQ/fyRa8lSMR8gDmjgZWYdCUVJSEsaOHYtixlLFam9OoiA/\nn7kjCCPJrBSlp6ebGCvQi4tLeFRdh9hYPi8YNsxYVTeBz8k9Z/q6CHA9uLHHedIpYm2ocibmABIi\nEPbvP4BFixYZskJChmL58hcMecbDSLRyyigSLcs+cOAAHnzwQUyaNMkQpNzjLCJFBLfyFFdWKgvf\nRwN5+OGHzT2xsbGUv5zzqEVKSoqRLfKSR4ww3q453HffQtxyyy0YSo/dtHkzQ20lTjAErl79BxNR\nJtIQXf/lCjz66KNY/NBDBvBwYnTo0CF6a5YxYulU0bhtODUeoUkH0SWnT78Fd955hwkl6tDBk0l1\nTh0zBmeZyCVI4Uptcj8V9Wnke0cKTU1888Fa9abNmxDB8DBp4kQmTFeY6eZhG23U3Cc3VdwW+R0d\nnSZxSab0SaaAi4qKZP44Z/oX81+4QvnIVOCXlZWRxBZDfjnDpkgM4xM7LTZUJEcynEXAT506FQsX\nLqS1PkDZUQjhnOWZKkVFRcYoFJqrq6uNFSsalJWWmXaNvZVHLyo6gukgqRqLXjJQhHDlwErz4oPw\n1KtDIlyGFkeSFT5/9avnjBckJycbOZqjLcYjtOaRq4RyMhIuMNRJ4cWQRE/QoFWvuDyR4CpkyGKV\n3GPpNcOHDzdhay+T/pQpUxDNuuKSUhNiamprcIGvxLhIcilXTH/11Vfx0ksr8SnJUKhRXHbF6RCO\nyAvzGYcVDgoLizjZEvz9smXG45SDVvx6hekvT5TlzpkzB48/8QSNoRmNXI0oR1hv02RlKDrK0BxU\nZEwLGPJefPFFvEBPKC4uxl/RUuXRCpfPP/8Cbv+L282iRfJFtiKCijAS0NGM/UuXLsEzzzxj9FeU\nV5gcordNQnmWJQwt2DKCxYsXmzxlMbbeIJlmQ6eE2sw4JkVSaotChyYgAGUFKoGBervBywCrhKt7\nRtB9pVBgy4ITE5NooaHG2mR5kmEno9DnHICsTstJtQsEyVPok/VLr4CWtcbFxRlr0hgUc+UVki2r\nkzdIrjyhjsvvmFjX41QtQKwu5RH1VSjVWO2KR/oVxgSq9KtoaStiIim/m9YtOTJILUCiWScs1Ef3\nqD4vL8+MVYleBi3SmpqajUdbMk6dOkWjewkrV640ecHqNwr5p3dnbSvcffa9qe933eOuzp0sZ903\n3dO3Xd9VrJV9F1nOvva6r3zVu6uz/b/Ppwzgww8/xHsb3sPSJX+NuXPvdqujlwh3A3BO3HltB+wc\nmLUyZ527674gSq5TtlOOvVa7ru299h77XXr69rV1dgxOHbZOn1aWrq332DqnfLWrWD3Oa/Xv21d1\nkqf9QsbJk8bjr73mGhMd3PXvJcJo+f8//Y6AOxKk9MuE0O9D+L+rQOBbAvp6jkXlfwCQnGFDn0fk\n9QAAAABJRU5ErkJggg==' /><br><h3>Diego Auctioneer Metrics</h3>\n\n<a href=\"https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#auctioneer\">https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#auctioneer</a>",
-        "type" : "Text"
-      },
-      "packageSpecifications" : "",
-      "programText" : "",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "percentile distribution",
-      "id" : "DiVXN6PAYJs",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Memory Used %",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "memory %",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : 100.0,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "AreaChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "system.mem.percent",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Minimum",
-          "label" : "B",
-          "paletteIndex" : 14,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "P10",
-          "label" : "C",
-          "paletteIndex" : 15,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "P50",
-          "label" : "D",
-          "paletteIndex" : 2,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "P90",
-          "label" : "E",
-          "paletteIndex" : 9,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Maximum",
-          "label" : "F",
-          "paletteIndex" : 7,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('system.mem.percent', filter=filter('metric_source', 'cloudfoundry')).publish(label='A', enable=False)\nB = (A).min().publish(label='B')\nC = (A).percentile(pct=10).publish(label='C')\nD = (A).percentile(pct=50).publish(label='D')\nE = (A).percentile(pct=90).publish(label='E')\nF = (A).max().publish(label='F')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "RAM and swap usage",
-      "id" : "DiVXO0sAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Memory Usage",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "Percent",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : 100.0,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "system.swap.percent",
-          "label" : "A",
-          "paletteIndex" : 2,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "system.mem.percent",
-          "label" : "B",
-          "paletteIndex" : 14,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('system.swap.percent').publish(label='A')\nB = data('system.mem.percent').publish(label='B')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXPiYAgAM",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : " ",
-      "options" : {
-        "markdown" : "<h3>Diego router-emitter Metrics</h3>\n\n<a href=\"https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#route_emitter\">https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#route_emitter</a>",
-        "type" : "Text"
-      },
-      "packageSpecifications" : "",
-      "programText" : "",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "1=healthy, 0=unhealthy",
-      "id" : "DiVXOclAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "System Health",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "AreaChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Health",
-          "label" : "A",
-          "paletteIndex" : 14,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('system.healthy').publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXEqkAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "# Running Tasks by controller",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale2" : null,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : true,
-            "property" : "host"
-          }, {
-            "enabled" : false,
-            "property" : "sf_originatingMetric"
-          }, {
-            "enabled" : false,
-            "property" : "sf_metric"
-          } ]
-        },
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Running Tasks",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "sortBy" : "",
-        "type" : "List",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('cc.tasks_running.count', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'cloud_controller')).sum(by=['host']).publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXNM3AYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "# Active Hosts",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale" : null,
-        "colorScale2" : null,
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "system.cpu.sys - Count",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "None",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('system.cpu.sys', filter=filter('metric_source', 'cloudfoundry'), rollup='latest').count().publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Total number of LRP instances that are desired but have no record in the BBS (5 Min. Average)",
-      "id" : "DiVXQ3nAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Fewer App Instances Than Expected",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 10.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 16
-        }, {
-          "gt" : 5.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 10.0,
-          "paletteIndex" : 18
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 5.0,
-          "paletteIndex" : 14
-        } ],
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Missing LRPs (5 Min. Average)",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('bbs.LRPsMissing').mean(over='5m').publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXQitAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Total Memory",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "Bytes",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "AreaChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "rep.CapacityRemainingMemory - Sum - Scale:1048576",
-          "label" : "A",
-          "paletteIndex" : 4,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Total",
-          "label" : "C",
-          "paletteIndex" : 14,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Used",
-          "label" : "D",
-          "paletteIndex" : 11,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 3600000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Binary"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('rep.CapacityRemainingMemory', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry')).sum().scale(1048576).publish(label='A', enable=False)\nC = data('rep.CapacityTotalMemory', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry')).sum().scale(1048576).publish(label='C')\nD = (C - A).publish(label='D')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXDmlAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Rate of outstanding requests",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "outstanding %",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        }, {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "growth %",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Metric",
-        "defaultPlotType" : "AreaChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Requests Outstanding",
-          "label" : "A",
-          "paletteIndex" : 4,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Requests Completed",
-          "label" : "B",
-          "paletteIndex" : 14,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "outstanding request %",
-          "label" : "C",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "C - Timeshift 1d",
-          "label" : "D",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "C - Timeshift 1w",
-          "label" : "E",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "day-over-day growth %",
-          "label" : "F",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 1
-        }, {
-          "displayName" : "week-over-week growth %",
-          "label" : "G",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 1
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 3600000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('cc.requests.outstanding').publish(label='A', enable=False)\nB = data('cc.requests.completed').publish(label='B', enable=False)\nC = ((B/A+B) * 100).publish(label='C')\nD = (C).timeshift('1d').publish(label='D', enable=False)\nE = (C).timeshift('1w').publish(label='E', enable=False)\nF = (A/D-1).publish(label='F')\nG = (A/E-1).publish(label='G')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Maximum delta over a 5-minute window of the total number of messages received across all Doppler listeners",
-      "id" : "DiVXCx0AYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Firehose Throughput",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : "metric_source",
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Maximum delta per minute over a 5-minute window",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('DopplerServer.listeners.totalReceivedMessageCount').delta().max(over='1m').max(over='5m').publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXJcuAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Diego Cell Container Capacity - Info",
-      "options" : {
-        "markdown" : "Metric(s): <code>rep.CapacityRemainingContainers / rep.CapacityTotalContainers</code>\n\nPercentage of remaining container capacity for a given cell. Monitor this derived metric across all cells in a deployment. \n\nThe metric <code>rep.CapacityRemainingContainers</code> indicates the remaining number of containers this cell can host.\nThe metric by <code>rep.CapacityTotalContainer</code> indicates the total number of containers this cell can host.\n\nA best practice deployment of Cloud Foundry includes three availability zones (AZs). For these types of deployments, Pivotal recommends that you have enough capacity to suffer failure of an entire AZ. \n\nThe Recommended threshold assumes a three AZ configuration. Adjust the threshold percentage if you have more or less AZs.\n\nRecommended thresholds:<br>\n<b>< avg(30%)</b>",
-        "type" : "Text"
-      },
-      "packageSpecifications" : "",
-      "programText" : "",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXF6eAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Diego Cell Disk Capacity - Info",
-      "options" : {
-        "markdown" : "Metric(s): <code>rep.CapacityRemainingDisk / rep.CapacityTotalDisk</code>\n\nPercentage of remaining disk capacity for a given cell. Monitor this derived metric across all cells in a deployment. \n\nThe metric <code>rep.CapacityRemainingDisk</code> indicates the remaining amount in MiB of disk available for this cell to allocate to containers.\n\nThe metric <code>rep.CapacityTotalDisk</code> indicates the total amount in MiB of disk available for this cell to allocate to containers.\n\nA best practice deployment of Cloud Foundry includes three availability zones (AZs). For these types of deployments, Pivotal recommends that you have enough capacity to suffer failure of an entire AZ. \n\nThe Recommended threshold assumes a three AZ configuration. Adjust the threshold percentage if you have more or less AZs.\n\nRecommended thresholds: <br>\n<b>< avg(30%) </b>",
-        "type" : "Text"
-      },
-      "packageSpecifications" : "",
-      "programText" : "",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXQErAgAE",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : " ",
-      "options" : {
-        "markdown" : "<h3>Diego nsync_bulker Metrics</h3>\n\n<a href=\"https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#nsync_bulker\">https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#nsync_bulker</a>",
-        "type" : "Text"
-      },
-      "packageSpecifications" : "",
-      "programText" : "",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Top memory usage by host",
-      "id" : "DiVXNIgAcC0",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "System Memory Used %",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale2" : null,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : true,
-            "property" : "host"
-          }, {
-            "enabled" : true,
-            "property" : "job"
-          }, {
-            "enabled" : false,
-            "property" : "sf_originatingMetric"
-          }, {
-            "enabled" : false,
-            "property" : "metric_source"
-          }, {
-            "enabled" : false,
-            "property" : "sf_metric"
-          }, {
-            "enabled" : false,
-            "property" : "role"
-          }, {
-            "enabled" : false,
-            "property" : "bosh_id"
-          }, {
-            "enabled" : true,
-            "property" : "index"
-          }, {
-            "enabled" : false,
-            "property" : "deployment"
-          } ]
-        },
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "system.mem.percent - Top 10",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "sortBy" : "-value",
-        "type" : "List",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('system.mem.percent').top(count=10).publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Rate of change of server errors (5xx responses)",
-      "id" : "DiVXJ_rAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Router Error: Server Error",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "Error Rate of Change",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Rate of change in server errors per minute",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('gorouter.responses.5xx').mean(over='1m').rateofchange().publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Percentage of RAM available for containers",
-      "id" : "DiVXGYlAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Diego Cell Memory Capacity",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 30.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 14
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 30.0,
-          "paletteIndex" : 16
-        } ],
-        "maximumPrecision" : 4,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Total",
-          "label" : "A",
-          "paletteIndex" : 14,
-          "plotType" : "AreaChart",
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Remaining",
-          "label" : "B",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Used",
-          "label" : "C",
-          "paletteIndex" : 4,
-          "plotType" : "AreaChart",
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Binary"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('rep.CapacityTotalMemory', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'diego_cell')).sum().scale(1048576).publish(label='A', enable=False)\nB = data('rep.CapacityRemainingMemory', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'diego_cell')).sum().scale(1048576).publish(label='B', enable=False)\nC = (B/A).scale(100).publish(label='C')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXPmjAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : " ",
-      "options" : {
-        "markdown" : "<h3>Diego Cell Metrics</h3>\n\n<a href=\"https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#cell\">https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#cell</a>",
-        "type" : "Text"
-      },
-      "packageSpecifications" : "",
-      "programText" : "",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXO7fAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "CPU Load",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "# cores",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "AreaChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "User",
-          "label" : "A",
-          "paletteIndex" : 6,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "System",
-          "label" : "B",
-          "paletteIndex" : 5,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Wait",
-          "label" : "C",
-          "paletteIndex" : 7,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : true,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('system.cpu.user').publish(label='A')\nB = data('system.cpu.sys').publish(label='B')\nC = data('system.cpu.wait').publish(label='C')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXP6qAgAM",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Auctioneer Task Placement Failures",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 1.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 16
-        }, {
-          "gt" : 0.5,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 1.0,
-          "paletteIndex" : 18
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 0.5,
-          "paletteIndex" : 14
-        } ],
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "auctioneer.AuctioneerTaskAuctionsFailed",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "A - Delta",
-          "label" : "B",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "B - Mean(5m)",
-          "label" : "C",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('auctioneer.AuctioneerTaskAuctionsFailed', extrapolation='zero').publish(label='A')\nB = (A).delta().publish(label='B')\nC = (B).mean(over='5m').publish(label='C')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXFRQAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Logging Rates",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "Log Messages/sec",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Error",
-          "label" : "A",
-          "paletteIndex" : 5,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Fatal",
-          "label" : "B",
-          "paletteIndex" : 4,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Warning",
-          "label" : "C",
-          "paletteIndex" : 6,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 3600000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('cc.log_count.error').publish(label='A')\nB = data('cc.log_count.fatal').publish(label='B')\nC = data('cc.log_count.warn').publish(label='C')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXEn8AgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "# Running Tasks + growth",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "# Tasks",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        }, {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "growth %",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Metric",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : true,
-            "property" : "host"
-          }, {
-            "enabled" : true,
-            "property" : "sf_originatingMetric"
-          }, {
-            "enabled" : true,
-            "property" : "sf_metric"
-          }, {
-            "enabled" : true,
-            "property" : "metric_source"
-          }, {
-            "enabled" : true,
-            "property" : "job"
-          } ]
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Running Tasks",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "A - Timeshift 1d",
-          "label" : "B",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "A - Timeshift 1w",
-          "label" : "C",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Day-over-day growth %",
-          "label" : "D",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 1
-        }, {
-          "displayName" : "Week-over-week growth %",
-          "label" : "E",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 1
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 86400000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('cc.tasks_running.count', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'cloud_controller')).sum().publish(label='A')\nB = (A).timeshift('1d').publish(label='B', enable=False)\nC = (A).timeshift('1w').publish(label='C', enable=False)\nD = (A/B-1).publish(label='D')\nE = (A/C-1).publish(label='E')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Total number of LRP instances that are no longer desired but still have a BBS record.",
-      "id" : "DiVXQzkAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "More App Instances Than Expected",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 10.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 16
-        }, {
-          "gt" : 5.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 10.0,
-          "paletteIndex" : 18
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 5.0,
-          "paletteIndex" : 14
-        } ],
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Extra LRPs (5 Min. Average)",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('bbs.LRPsExtra').mean(over='5m').publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXQ3lAgAE",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Top containers per cell",
-      "options" : {
-        "colorBy" : "Metric",
-        "colorScale2" : null,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : false,
-            "property" : "sf_originatingMetric"
-          }, {
-            "enabled" : false,
-            "property" : "sf_metric"
-          }, {
-            "enabled" : false,
-            "property" : "metric_source"
-          }, {
-            "enabled" : true,
-            "property" : "host"
-          }, {
-            "enabled" : false,
-            "property" : "job"
-          }, {
-            "enabled" : true,
-            "property" : "bosh_id"
-          }, {
-            "enabled" : false,
-            "property" : "deployment"
-          } ]
-        },
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : null
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "rep.ContainerCount - Top 10",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "sortBy" : "-value",
-        "type" : "List",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('rep.ContainerCount', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'diego_cell'), rollup='latest').top(count=10).publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "percentile distribution",
-      "id" : "DiVXNFuAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Total CPU load",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "# cores used",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Metric",
-        "defaultPlotType" : "AreaChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "system.cpu.sys",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "system.cpu.user",
-          "label" : "B",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "A+B - Mean by host",
-          "label" : "C",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Minimum",
-          "label" : "E",
-          "paletteIndex" : 14,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Maximum",
-          "label" : "F",
-          "paletteIndex" : 7,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "P10",
-          "label" : "G",
-          "paletteIndex" : 2,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "P50",
-          "label" : "H",
-          "paletteIndex" : 6,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "P90",
-          "label" : "I",
-          "paletteIndex" : 5,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('system.cpu.sys', filter=filter('metric_source', 'cloudfoundry')).publish(label='A', enable=False)\nB = data('system.cpu.user', filter=filter('metric_source', 'cloudfoundry')).publish(label='B', enable=False)\nC = (A+B).mean(by=['host']).publish(label='C', enable=False)\nE = (C).min().publish(label='E')\nF = (C).max().publish(label='F')\nG = (C).percentile(pct=10).publish(label='G')\nH = (C).percentile(pct=50).publish(label='H')\nI = (C).percentile(pct=90).publish(label='I')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXK5NAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Routing Rates",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "Responses/sec",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        }, {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "Requests/sec",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Responses",
-          "label" : "A",
-          "paletteIndex" : 2,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Requests",
-          "label" : "B",
-          "paletteIndex" : 4,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 1
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('gorouter.responses').publish(label='A')\nB = data('gorouter.total_requests').publish(label='B')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXJVqAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Diego Cell Memory Capacity - Info",
-      "options" : {
-        "markdown" : "Metric(s):\n<code>rep.CapacityRemainingMemory / rep.CapacityTotalMemory</code>\n\nPercentage of remaining memory capacity for a given cell. Monitor this derived metric across all cells in a deployment. \n\nThe metric <code>rep.CapacityRemainingMemory</code> indicates the remaining amount in MiB of memory available for this cell to allocate to containers.\n\nThe metric <code>rep.CapacityTotalMemory</code> indicates the total amount in MiB of memory available for this cell to allocate to containers.\n\nA best practice deployment of Cloud Foundry includes three availability zones (AZs). For these types of deployments, Pivotal recommends that you have enough capacity to suffer failure of an entire AZ. \n\nThe Recommended threshold assumes a three AZ configuration. Adjust the threshold percentage if you have more or less AZs.\n\nRecommended thresholds:<br>\n<b>< avg(30%)</b>",
-        "type" : "Text"
-      },
-      "packageSpecifications" : "",
-      "programText" : "",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXGUJAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Firehose Loss Rate - Info",
-      "options" : {
-        "markdown" : "Metric(s): <code>(DopplerServer.TruncatingBuffer.totalDroppedMessages + DopplerServer.doppler.shedEnvelopes) / DopplerServer.listeners.totalReceivedMessageCount</code>\n\nThis derived value represents the firehose loss rate, or the total messages dropped as a percentage of the total message throughput.\n\nExcessive dropped messages can indicate the Dopplers are not processing messages fast enough. \n\nThe recommended scaling indicator is to look at the total dropped as a percentage of the total throughput and scale if the derived loss rate value grows greater than 0.1.\n\nRecommended thresholds:\t\n<b>Scale indicator: ≥ 0.1\nIf alerting:\nYellow warning: ≥ 0.05\nRed critical: ≥ 0.1</b>\n\n\n\nHow to scale up:\tScale up the Firehose log receiver and Dopplers.",
-        "type" : "Text"
-      },
-      "packageSpecifications" : "",
-      "programText" : "",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Time that the Diego Cell Rep took to sync the ActualLRPs that it claimed with its actual garden containers.",
-      "id" : "DiVXQ3qAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Cell Rep Time to Sync",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "Seconds",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : "metric_source",
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Cell Sync Time (15 Min. Max)",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('rep.RepBulkSyncDuration').max(over='15m').scale(1e-9).publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Total # of containers in the Garden",
-      "id" : "DiVXNDGAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Total Containers",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Total Containers",
-          "label" : "A",
-          "paletteIndex" : 13,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('container.cpu_percentage').count().publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Total number of LRP instances that have crashed (5 Min. Average)",
-      "id" : "DiVXP9lAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Crashed App Instances",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale" : null,
-        "colorScale2" : null,
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Crashed LRPs (5 Min. Average)",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('bbs.CrashedActualLRPs').mean(over='5m').publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "1=healthy, 0=unhealthy",
-      "id" : "DiVXO9DAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "System Health",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 0.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 14
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 0.0,
-          "paletteIndex" : 16
-        } ],
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Health",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "None",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('system.healthy').publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "The current total number of routes registered with the Gorouter",
-      "id" : "DiVXKnhAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Number of Gorouter Routes Registered",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : "metric_source",
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "5 minute average of the deltas",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('gorouter.total_routes').delta().mean(over='5m').publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "The time in milliseconds that the Gorouter takes to handle requests to its app endpoints",
-      "id" : "DiVXKPaAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Router Handling Latency",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 200.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 16
-        }, {
-          "gt" : 100.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 200.0,
-          "paletteIndex" : 18
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 100.0,
-          "paletteIndex" : 14
-        } ],
-        "maximumPrecision" : 5,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "gorouter.latency - Mean(30m)",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('gorouter.latency').mean(over='30m').publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Top ephemeral disk usage by host",
-      "id" : "DiVXNIyAgAE",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Ephemeral Disk Used %",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale2" : null,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : true,
-            "property" : "host"
-          }, {
-            "enabled" : true,
-            "property" : "job"
-          }, {
-            "enabled" : true,
-            "property" : "index"
-          }, {
-            "enabled" : false,
-            "property" : "ip"
-          }, {
-            "enabled" : false,
-            "property" : "sf_originatingMetric"
-          }, {
-            "enabled" : false,
-            "property" : "sf_metric"
-          }, {
-            "enabled" : false,
-            "property" : "metric_source"
-          }, {
-            "enabled" : false,
-            "property" : "role"
-          }, {
-            "enabled" : false,
-            "property" : "bosh_id"
-          }, {
-            "enabled" : false,
-            "property" : "deployment"
-          } ]
-        },
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "system.disk.ephemeral.percent - Top 10",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "sortBy" : "-value",
-        "type" : "List",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('system.disk.ephemeral.percent').top(count=10).publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "No data",
-      "id" : "DiVXQGxAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Auctioneer App Instance Starts",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale" : null,
-        "colorScale2" : null,
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "auctioneer.AuctioneerLRPAuctionsStarted - Mean(1m)",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "A - Delta",
-          "label" : "B",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "B - Mean(5m)",
-          "label" : "C",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('auctioneer.AuctioneerLRPAuctionsStarted', extrapolation='zero').mean(over='1m').publish(label='A')\nB = (A).delta().publish(label='B')\nC = (B).mean(over='5m').publish(label='C')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Top 10 consumers of RAM among Garden Containers",
-      "id" : "DiVXNFhAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Memory Utilization (%)",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale2" : null,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : false,
-            "property" : "sf_originatingMetric"
-          }, {
-            "enabled" : false,
-            "property" : "sf_metric"
-          }, {
-            "enabled" : true,
-            "property" : "app_name"
-          }, {
-            "enabled" : false,
-            "property" : "app_id"
-          }, {
-            "enabled" : true,
-            "property" : "app_instance_index"
-          }, {
-            "enabled" : false,
-            "property" : "bosh_id"
-          }, {
-            "enabled" : false,
-            "property" : "metric_source"
-          }, {
-            "enabled" : false,
-            "property" : "host"
-          }, {
-            "enabled" : false,
-            "property" : "job"
-          }, {
-            "enabled" : false,
-            "property" : "deployment"
-          }, {
-            "enabled" : false,
-            "property" : "app_org"
-          }, {
-            "enabled" : false,
-            "property" : "app_space"
-          } ]
-        },
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "container.memory_bytes",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "container.memory_bytes_quota",
-          "label" : "B",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Percentage Memory Used",
-          "label" : "C",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "sortBy" : "",
-        "type" : "List",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('container.memory_bytes').publish(label='A', enable=False)\nB = data('container.memory_bytes_quota').publish(label='B', enable=False)\nC = (A/B).scale(100).top(count=10).publish(label='C')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXQNpAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Auctioneer App Instance Placement Failures",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 1.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 16
-        }, {
-          "gt" : 0.5,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 1.0,
-          "paletteIndex" : 18
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 0.5,
-          "paletteIndex" : 14
-        } ],
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "auctioneer.AuctioneerLRPAuctionsFailed - Mean(1m)",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "A - Delta",
-          "label" : "B",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "B - Mean(5m)",
-          "label" : "C",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('auctioneer.AuctioneerLRPAuctionsFailed', extrapolation='zero').mean(over='1m').publish(label='A')\nB = (A).delta().publish(label='B')\nC = (B).mean(over='5m').publish(label='C')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXL-yAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Total Disk",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "Bytes",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Metric",
-        "defaultPlotType" : "AreaChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : true,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "rep.CapacityRemainingDisk - Sum - Scale:1000000",
-          "label" : "A",
-          "paletteIndex" : 14,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Total",
-          "label" : "E",
-          "paletteIndex" : 14,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Used",
-          "label" : "F",
-          "paletteIndex" : 11,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 3600000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Binary"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('rep.CapacityRemainingDisk', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry'), rollup='latest').sum().scale(1000000).publish(label='A', enable=False)\nE = data('rep.CapacityTotalDisk', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry')).sum().scale(1000000).publish(label='E')\nF = (E - A).publish(label='F')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Time in milliseconds since the last route register was received",
-      "id" : "DiVXLYnAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Time Since Last Route Register Received",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 30000.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 16
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 30000.0,
-          "paletteIndex" : 14
-        } ],
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "gorouter.ms_since_last_registry_update - Maximum(5m)",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('gorouter.ms_since_last_registry_update').max(over='5m').publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXMJHAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Total Memory",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "Bytes",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "AreaChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "rep.CapacityRemainingMemory - Sum - Scale:1048576",
-          "label" : "A",
-          "paletteIndex" : 4,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Total",
-          "label" : "C",
-          "paletteIndex" : 14,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Used",
-          "label" : "D",
-          "paletteIndex" : 11,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 3600000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Binary"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('rep.CapacityRemainingMemory', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry')).sum().scale(1048576).publish(label='A', enable=False)\nC = data('rep.CapacityTotalMemory', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry')).sum().scale(1048576).publish(label='C')\nD = (C - A).publish(label='D')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Top system disk usage by host",
-      "id" : "DiVXNRZAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "System Disk Used %",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale2" : null,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : true,
-            "property" : "host"
-          }, {
-            "enabled" : true,
-            "property" : "job"
-          }, {
-            "enabled" : true,
-            "property" : "index"
-          }, {
-            "enabled" : false,
-            "property" : "ip"
-          }, {
-            "enabled" : false,
-            "property" : "sf_originatingMetric"
-          }, {
-            "enabled" : false,
-            "property" : "sf_metric"
-          }, {
-            "enabled" : false,
-            "property" : "metric_source"
-          }, {
-            "enabled" : false,
-            "property" : "role"
-          }, {
-            "enabled" : false,
-            "property" : "bosh_id"
-          }, {
-            "enabled" : false,
-            "property" : "deployment"
-          } ]
-        },
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "system.disk.system.percent - Top 10",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "sortBy" : "-value",
-        "type" : "List",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('system.disk.system.percent').top(count=10).publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Time in seconds that the nsync-bulker took to synchronize CF apps and Diego DesiredLRPs.",
-      "id" : "DiVXQ3nAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Nsync-bulker Time to Sync",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 20.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 16
-        }, {
-          "gt" : 10.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 20.0,
-          "paletteIndex" : 18
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 10.0,
-          "paletteIndex" : 14
-        } ],
-        "maximumPrecision" : 3,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Seconds that the nsync-bulker took to synchronize CF apps and Diego DesiredLRPs",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('nsync_bulker.DesiredLRPSyncDuration').max(over='5m').scale(1e-9).publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "percentile distribution",
-      "id" : "DiVXOHfAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Ephemeral Disk Used %",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "ephemeral disk %",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : 100.0,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "AreaChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "system.disk.ephemeral.percent",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Minimum",
-          "label" : "B",
-          "paletteIndex" : 14,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "P10",
-          "label" : "C",
-          "paletteIndex" : 2,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "P50",
-          "label" : "D",
-          "paletteIndex" : 6,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "P90",
-          "label" : "E",
-          "paletteIndex" : 5,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Maximum",
-          "label" : "F",
-          "paletteIndex" : 7,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 86400000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('system.disk.ephemeral.percent', filter=filter('metric_source', 'cloudfoundry')).publish(label='A', enable=False)\nB = (A).min().publish(label='B')\nC = (A).percentile(pct=10).publish(label='C')\nD = (A).percentile(pct=50).publish(label='D')\nE = (A).percentile(pct=90).publish(label='E')\nF = (A).max().publish(label='F')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Top 10 CPU users among Garden Containers",
-      "id" : "DiVXMZjAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "CPU Utilization (%)",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale2" : null,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : false,
-            "property" : "sf_originatingMetric"
-          }, {
-            "enabled" : false,
-            "property" : "sf_metric"
-          }, {
-            "enabled" : true,
-            "property" : "app_name"
-          }, {
-            "enabled" : false,
-            "property" : "app_id"
-          }, {
-            "enabled" : true,
-            "property" : "app_instance_index"
-          }, {
-            "enabled" : false,
-            "property" : "bosh_id"
-          }, {
-            "enabled" : false,
-            "property" : "metric_source"
-          }, {
-            "enabled" : false,
-            "property" : "host"
-          }, {
-            "enabled" : false,
-            "property" : "job"
-          }, {
-            "enabled" : false,
-            "property" : "deployment"
-          }, {
-            "enabled" : false,
-            "property" : "app_org"
-          }, {
-            "enabled" : false,
-            "property" : "app_space"
-          } ]
-        },
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "CPU Utilization",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "sortBy" : "",
-        "type" : "List",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('container.cpu_percentage', filter=filter('metric_source', 'cloudfoundry')).top(count=10).publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "This should stay below 60-70% for all routers for best performance",
-      "id" : "DiVXF-uAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Router VM CPU Load",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 70.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 16
-        }, {
-          "gt" : 60.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 70.0,
-          "paletteIndex" : 18
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 60.0,
-          "paletteIndex" : 14
-        } ],
-        "maximumPrecision" : 4,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Maximum CPU Load",
-          "label" : "A",
-          "paletteIndex" : 4,
-          "plotType" : "LineChart",
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('system.cpu.user', filter=filter('job', 'router')).max().publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "No data",
-      "id" : "DiVXQ3wAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Auctioneer Time to Fetch Cell State",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 10.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 16
-        }, {
-          "gt" : 5.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 10.0,
-          "paletteIndex" : 18
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 5.0,
-          "paletteIndex" : 14
-        } ],
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "auctioneer.AuctioneerFetchStatesDuration - Maximum(5m) - Scale:1e-9",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('auctioneer.AuctioneerFetchStatesDuration', extrapolation='zero').max(over='5m').scale(1e-9).publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXEKKAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Requests",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "Requests/sec",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        }, {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "AreaChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Requests Outstanding",
-          "label" : "A",
-          "paletteIndex" : 4,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Requests Completed",
-          "label" : "B",
-          "paletteIndex" : 14,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 3600000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('cc.requests.outstanding').publish(label='A')\nB = data('cc.requests.completed').publish(label='B')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXMRcAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Container Count",
-      "options" : {
-        "colorBy" : "Metric",
-        "colorScale" : null,
-        "colorScale2" : null,
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : null
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "rep.ContainerCount - Sum",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('rep.ContainerCount', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'diego_cell'), rollup='latest').sum().publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXDKWAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Memory Allocated",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "Bytes Allocated",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Metric",
-        "defaultPlotType" : "AreaChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Bytes Allocated Heap",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Bytes Allocated Stack",
-          "label" : "B",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : true,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Binary"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('DopplerServer.memoryStats.numBytesAllocatedHeap').publish(label='A')\nB = data('DopplerServer.memoryStats.numBytesAllocatedStack').publish(label='B')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXDihAcAg",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "CPU Utilization",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "% CPU Load",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : 100.0,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : false,
-            "property" : "app_id"
-          }, {
-            "enabled" : true,
-            "property" : "app_name"
-          }, {
-            "enabled" : true,
-            "property" : "app_instance_index"
-          }, {
-            "enabled" : false,
-            "property" : "app_org"
-          }, {
-            "enabled" : false,
-            "property" : "app_space"
-          }, {
-            "enabled" : false,
-            "property" : "deployment"
-          }, {
-            "enabled" : false,
-            "property" : "host"
-          }, {
-            "enabled" : false,
-            "property" : "id"
-          }, {
-            "enabled" : false,
-            "property" : "job"
-          }, {
-            "enabled" : false,
-            "property" : "sf_originatingMetric"
-          }, {
-            "enabled" : false,
-            "property" : "metric_source"
-          }, {
-            "enabled" : true,
-            "property" : "sf_metric"
-          } ]
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : "app_instance_index",
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "container.cpu_percentage",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('container.cpu_percentage').publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Max. # of Unhealthy Cells averaged over 5 minutes",
-      "id" : "DiVXRPWAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Unhealthy Cells",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 0.99,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 16
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 0.99,
-          "paletteIndex" : 14
-        } ],
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "# Unhealth Cells (5 Min. Window)",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "None",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('rep.UnhealthyCell').sum(over='5m').max().publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Percentage of disk space remaining on all Diego cells",
-      "id" : "DiVXG9IAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Diego Cell Disk Capacity",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 30.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 14
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 30.0,
-          "paletteIndex" : 16
-        } ],
-        "maximumPrecision" : 4,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Remaining",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Total",
-          "label" : "B",
-          "paletteIndex" : 14,
-          "plotType" : "AreaChart",
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Used",
-          "label" : "C",
-          "paletteIndex" : 4,
-          "plotType" : "AreaChart",
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Binary"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('rep.CapacityRemainingDisk', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry')).sum().scale(1048576).publish(label='A', enable=False)\nB = data('rep.CapacityTotalDisk', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry')).sum().scale(1048576).publish(label='B', enable=False)\nC = (A/B).scale(100).publish(label='C')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Top CPU usage by host",
-      "id" : "DiVXNIxAYC0",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Top CPU load",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale2" : null,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : true,
-            "property" : "host"
-          }, {
-            "enabled" : true,
-            "property" : "job"
-          }, {
-            "enabled" : false,
-            "property" : "metric_source"
-          }, {
-            "enabled" : false,
-            "property" : "sf_metric"
-          }, {
-            "enabled" : false,
-            "property" : "role"
-          }, {
-            "enabled" : false,
-            "property" : "bosh_id"
-          }, {
-            "enabled" : true,
-            "property" : "index"
-          }, {
-            "enabled" : false,
-            "property" : "deployment"
-          } ]
-        },
-        "maximumPrecision" : 2,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "system.cpu.user",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "system.cpu.sys",
-          "label" : "B",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "A + B - Top 10",
-          "label" : "C",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "sortBy" : "-value",
-        "type" : "List",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('system.cpu.user').publish(label='A', enable=False)\nB = data('system.cpu.sys').publish(label='B', enable=False)\nC = (A + B).top(count=10).publish(label='C')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXNPCAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Container Count",
-      "options" : {
-        "colorBy" : "Metric",
-        "colorScale" : null,
-        "colorScale2" : null,
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : null
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "rep.ContainerCount - Sum",
-          "label" : "A",
-          "paletteIndex" : 2,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "None",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('rep.ContainerCount', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'diego_cell'), rollup='latest').sum().publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Top swap usage by host",
-      "id" : "DiVXNFjAcCs",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "System Swap Used %",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale2" : null,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : true,
-            "property" : "host"
-          }, {
-            "enabled" : true,
-            "property" : "job"
-          }, {
-            "enabled" : false,
-            "property" : "sf_originatingMetric"
-          }, {
-            "enabled" : false,
-            "property" : "metric_source"
-          }, {
-            "enabled" : false,
-            "property" : "sf_metric"
-          }, {
-            "enabled" : false,
-            "property" : "role"
-          }, {
-            "enabled" : false,
-            "property" : "bosh_id"
-          }, {
-            "enabled" : true,
-            "property" : "index"
-          }, {
-            "enabled" : false,
-            "property" : "deployment"
-          } ]
-        },
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "system.swap.percent - Top 10",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "sortBy" : "-value",
-        "type" : "List",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('system.swap.percent').top(count=10).publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Gorouter Metrics",
-      "id" : "DiVXLruAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : " ",
-      "options" : {
-        "markdown" : "<h3>Gorouter Metrics</h3>\n\n<a href=\"https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#gorouter\">https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#gorouter</a>",
-        "type" : "Text"
-      },
-      "packageSpecifications" : "",
-      "programText" : "",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Percentage of remaining container capacity across all Diego cells",
-      "id" : "DiVXFwQAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Diego Cell Container Capacity",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 30.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 14
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 30.0,
-          "paletteIndex" : 16
-        } ],
-        "maximumPrecision" : 4,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "rep.CapacityRemainingContainers - Sum",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Total Capacity",
-          "label" : "B",
-          "paletteIndex" : 14,
-          "plotType" : "AreaChart",
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Used Capacity",
-          "label" : "C",
-          "paletteIndex" : 4,
-          "plotType" : "AreaChart",
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('rep.CapacityRemainingContainers', filter=filter('job', 'diego_cell')).sum().publish(label='A', enable=False)\nB = data('rep.CapacityTotalContainers', filter=filter('job', 'diego_cell')).sum().publish(label='B', enable=False)\nC = (A/B).scale(100).publish(label='C')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXEKgAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Number of workers",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale" : null,
-        "colorScale2" : null,
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "system.healthy - Count",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "None",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('system.healthy', filter=filter('job', 'cloud_controller_worker')).count().publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "How many messages were dropped due to either slow consuming nozzle or overburdened Doppler servers",
-      "id" : "DiVXC13AgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Firehose Dropped Messages",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "DopplerServer.doppler.shedEnvelopes",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "DopplerServer.TruncatingBuffer.totalDroppedMessages",
-          "label" : "B",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Dropped Messages",
-          "label" : "C",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('DopplerServer.doppler.shedEnvelopes', extrapolation='zero').publish(label='A', enable=False)\nB = data('DopplerServer.TruncatingBuffer.totalDroppedMessages').publish(label='B', enable=False)\nC = (A+B).publish(label='C')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "The lifetime number of bad gateways, or 502 responses, from Gorouter itself",
-      "id" : "DiVXLieAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Router Error: 502 Bad Gateway",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "gorouter.bad_gateways - Delta",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Maximum Bad Gateway delta over a 5 minute window",
-          "label" : "B",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('gorouter.bad_gateways').delta().publish(label='A')\nB = (A).max(over='5m').publish(label='B')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXQAaAYAE",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : " ",
-      "options" : {
-        "markdown" : "<h3>Diego BBS Metrics</h3>\n\n<a href=\"https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#bbs\">https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#bbs</a>",
-        "type" : "Text"
-      },
-      "packageSpecifications" : "",
-      "programText" : "",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "The lifetime number of requests completed by the Gorouter VM",
-      "id" : "DiVXLy6AgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Router Throughput",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : "sf_originatingMetric",
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "gorouter.total_requests - Delta",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Sum over all indexes",
-          "label" : "B",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Divided by 5",
-          "label" : "C",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Average over the last 5 minutes",
-          "label" : "D",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('gorouter.total_requests').delta().publish(label='A', enable=False)\nB = (A).sum().publish(label='B', enable=False)\nC = (B/5).publish(label='C', enable=False)\nD = (C).mean(over='5m').publish(label='D')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "This should stay below 10s",
-      "id" : "DiVXPp4AYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "BBS Time to Run LRP Convergence",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 20.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 16
-        }, {
-          "gt" : 10.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 20.0,
-          "paletteIndex" : 18
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 10.0,
-          "paletteIndex" : 14
-        } ],
-        "maximumPrecision" : 3,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Max Duration (15 Min. Window)",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('bbs.ConvergenceLRPDuration').max(over='15m').scale(1e-9).publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXRLCAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Total Disk",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "Bytes",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Metric",
-        "defaultPlotType" : "AreaChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : true,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "rep.CapacityRemainingDisk - Sum - Scale:1000000",
-          "label" : "A",
-          "paletteIndex" : 14,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Total",
-          "label" : "E",
-          "paletteIndex" : 14,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Used",
-          "label" : "F",
-          "paletteIndex" : 11,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 3600000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Binary"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('rep.CapacityRemainingDisk', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry'), rollup='latest').sum().scale(1000000).publish(label='A', enable=False)\nE = data('rep.CapacityTotalDisk', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry')).sum().scale(1000000).publish(label='E')\nF = (E - A).publish(label='F')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXJgNAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : " ",
-      "options" : {
-        "markdown" : "<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAABjCAYAAADeg0+zAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAsTAAALEwEAmpwYAAABWWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgpMwidZAAAwR0lEQVR4Ae1dB3xUVdY/EBJaAgkklNASEnqXqoIggmABxC6CIMWCiLufrLtr110L/Na2omJ3sQC6K4ggKlKkSJEiSCdAIBA6JISS0Ob7/8/MmbxMJoSQUEzmQN6bd8u57Zx7yr33vWIugAQg0AOBHvDbA8X9hgYCAz0Q6AHtgQCDBAgh0ANn6IESZ4gLRF3AHsim6RYTKYZ/Abi4PRBgkIvQ/2QG/uN/QrFibkawO8MsjZdxkKa4Jx3jA3BheqAYBiBgpF+YvpbT7Gr8FS9+bpqtMg3yk5GczHSBql8kiwkwyAUYdjIGZYSTqI9kZMjBtFTZm3JQDqSmCp/Tj2fIqVMnJTg4REqFlJSw0qUlKjxCIsuHS3hYmIQEZQr806dPBxjlAoxdZo9fgMKKWhFkDMoKU42OZKTLxqRtsmTDWlm4ZaP8vHO7JBzcK3LsiAgIXlz8g5ShKkUpUxzDE1pe2kdWlnbVaknb+HrSAn8xVatKkEcKmQLgZL6i1s/ns70BCXIeetdUIVOldkNKLFi9UiYuXShjN6wSOXJIJLikSMnSUgKSIhqSIRhMEaSqE3gFPHIKjJIOhkk+eUIEjCUZxxBxSqRiFXm88WVyfcu20rxOPSlbspS2gBLFyjsPTSqyKAMMUsBDb1KDUiD1yBH5/tcF8vKs7+W3bRtFSpURKRMmsSWCVT3KAAMcATccwf0k6uE2BnmFQY5rCO6hxYtJmWLFlYGOgwmSoIbJkVStdf8mbWRw525yecMmKlECapd2S4FeAgxSgN3pnMVXbk6Qf0wcL//9bb5IRCWJKR0KJnDJMTBEChiCEoKgBjfv+uS+u2PcDAOly6N2gb/ANuXAMKXBMCcoXVIPiJzIkH907S1DrusplWGvBFQuT0cW0C3AIAXUkcYclCCT5v8st0z4SOT4cWlQIUoOnjole6EekfD5d24+LHde5icz0XisBknkAqMk7t4u7eMbyZt33SvN4+oihmoa7B/aMgHIVw8EGCRf3efObMxxFOrPmCkT5dFvPlNboU5IKdl44jjFhBK0SYYCKFKZ5CSYoCSkSVxwsKxJ2Q+uKSHf939IurVqq0UEmCT/PR1gkHz2oTEHPVQvffmZvPDj1xIbHQMDW2QnXLYlwBwFyRjO6lI+UAUjI8TDNZyQDkM+7YB8PfBP0vvKjpqUKlfAw+Xstbz9Pldpn7dSCmnq01Bv6Dk6ARXq1a8nyAs//FfqV68t+2FMn2/mYJeS8VTdAhMmQFLVhEerTHiU3PzBKzJt8QLtdTKH2SUaELjkqQcCDJKn7spMTKIrDvWGMG7mj/L0d+PBHPGy7eRJOQQGOZ+SI7MW7l9kFJa3DS7hirBL6BS4/pPRsmzjek0QYBDfHjv75wCDnH1fZUmpe6kQsmDNKun/1UcSVbmW7IEhfvQCM4dVikzCtZQkMEkcbB/CI+M/Ea7BUMpRFQxA3nsgwCB57zMlNkqPPakp8tjXn+uiX9kSQXIAqhaJlMR6MYAswPI3Qd2qW76CzNu8Rj7+carbcwYmCUiSvI9KgEHOos9IWPbHmdiM3v/OmSnzElZJnbBwSYRqRTXnYs/TLJ/12wNJUqFiVfn7T5Nl4ZrftZWsu7UjwCxnMfBIEmCQHPqJBEQjnHcSnP1RXeHvDduT5KGZU6HvV5YUqFY0li+W5PBtQhACUsAMEXD7Et6f8b3QBR0UFORtB9vgbqOb+TVh4JKtBwIM4tMlSjQeKUE1ioREyMCMnHr0iOw/lKp6/f/mzxY5nCq1sJeKXqtLqSPJqFwkpCetSvmK8vHvi2Xh6t+VgU9yP5cH2Dam452uYk4IAcjaA4F1EE9/kDH4Zxv+SGS7Dx6QxJ3JsnrrFlmRtEW2w+bYj/WOxKOHZRt24JbBJkMsA6pa5WajrJ17MZ9YH+7vCgfxp4C5W5aLkPY1YqQcNkiWK11GqlWoKHWq15AaUZUlEltUuFGSYCqkTQwaWIQvAQYhUZAxPATCPVKrt2yS75cuks9XLZOVyYnYMoINgiGlYQGHYGqGAgNVpQx+kwD5d6kxB6qk4GYSF5ikuKRwRR8ST7fUw5mgO4OxP6xl1ZrSo05DubpJc7msbn0JLYV2AgKMot0gRZpBKCVcVI9gVxDWJW2V8XNmyHMLZrmJKSxCapQuK2XBEMfBOMehgpxEJu6q4loHNqJfssyhDfLUj0xcEW0MB3OTaTgZsMUpcCzsSsdZFG6/R1zfJq1lYMeuckXjplKS6ykAStWiLE2KLINw4AkcfNoW9EgN/n4itmocFCkfKfWwKn0Y+vpuzLbc8+ROrDncROYOydOVWDyYFMeFlDy0LqzNVmnu44oMKo4t9UGqhu1OS4FIPCEPt+kkD3bvIQ1qxmhSShObRCxvUbkXSQYxQiFzbEreIU9M+I9MWI5t6ZHRWGQrKalgjH1UQwB6iMlDDUbcnscz3owZyASci0uirBDPzM04SqQM/FEKOdP6Mk1eygSqLOCLy/eZTEP1khAKCRNJSQlmSD64TwR2yle3DdA9XTy9WFSZpMgxiBKjZ0ZcnbhZmr37qpzau1MaREXLHnh96JEiuB2kmTO+Bp7FhfiJIQzMUA6ExUNPx6Ca7YI6I8CPaZxiS+2YykHBUprEh/RM41TbiIcEXRVES8ZSOjYKZ6QBw/w8k/mPoS27wOy5ediIgtMBdwfwcBZPOCYcxynGPdvllZvvlWE9b5EQuIyLIpMUOQaxQU5IxhmKt0bJ7gP7pFFEpKwGQcCpq0RptJeXO4mMuj7XIKqDwKie7aduz/PmJWDclw2TmmVCJQJb049COm2EWqdGMw486fFbxFeF4U8GpWcMOYAPrtdUqHwkVjBSnoCMDvspNDRcjinpn729REdFFbQhDIezNm5PkNdvHSTDet2m0tTp0MhTff6giYsUgxhzcH9Sv3delemJG6R+hUqyDl6q/GwuVOYAUamaAn0+kSf9IC3ubNhCujVqik2MtaRi+fJShmfQIRG43nA0PV0OYE1l865kWZSwXl5bj7PqfIEDtoiUB45UMFFJzNr/bNNBKuOtJschgczT5hYZJjp4J5gYca9pMO+mPbvk2SXzUWYJZVwy8NkAWfEE2lMeTBmFuiTs3CKf9n9E+l7TTbMXJcO9yDCIzXwktKc//0hGzpoijXBuYzXWNQqCOSJASNjtJPsP7JbbG7WSBzt3l5b1GuDVPTiHngscBzPt2LtHZv62FKvz30kwZv/DqCdf+7P+sWelKiTcucCqxE3SZNTTOAofqmraEdXTzg6TMQntkmI4Jrw3ZY/MeeRp6QB3cFFiEFO1z67X/qCpTJ9n9b9bNF9GzpgkdaNry1pIDs7KNvfmtXlutQrrDGCOk5AKafACvXfrALmjUxcsxpVVdKehalG3D0KarEoO1CeqQYAQzNSxVaKle+tgyZg1TTIY7qnXiRPueZ94ikPlIY2bk0Ez+7lQQpWAfaN5z7F9rBk3PtJZUQtqoZQKlYFf/kdmR1eTahWjiow9kkfF1s9o/AGCuNZBozVp7265Z8pXun+KBrFKlXzUn0RUElYLDfK0A3vkszsG4uUJvZQ5+AK4U6ehFoExgvB+K+r1aceOysHDh3A/IidRPuP4Z7AIW+cFDgN60sgJqjyZBoVEZI5iMKItX053MgehZAgsGQ8eBxqNO5sL20fpuvXECakbWk4StkPVmvGDTih0++bGqGdTxqWeptBLEM7e5sOfsnC+pO1KkrjKNWQz/P35Ua04sNjKKDVggCfs2SGjrr9V7up8rY73STAHbQ1KjIOH02T+qhWyYP0a2bR/j6TiRQ5hWISLrRgpjWvESAu8ZKFxbG0wzCmZtnIZKDLYs+3DLdeMsPmkW+xTDshvmzZKsOLX4rJdTkMlKgXmWIOFT67+00NFt/K5AHNxctmP+klElPx97o9yfat20rR2vDII4wozFH4GAbEUg2qSvH+fvLl4HvyvEer+5KCeG8m4yYESoSaIOQFqVRe8UWTAtTeoF4ySw5hj2cZ18rf/fi7T1y2HHoVDTHxZHL1RVKHWw1dFDxbCX+rSQ+KrVpfvsd9LYC/QPZsJHgL0EDj3hnV7/iGRqFpuPH5bgTwuEHQpeLHKllcvFko6Zw8d1Qx61+Ih2RIO7tFtOE3AICZFCjOTFHoGscFbvnG9rE3eItF4MyHfS5WfeY+MVQaETruDbtxH8PK2qHLhoHtse9cZtZis2LxRWv77RX0rYsPoWLwgDltTQOTMy7Ipvbi+kYQ9Un//ASv4mOnL4DWjJcB0TJsJzJEJwfBISXRdaQBv1zHFlzXeUrIMxu8BLhJ4ftqrOIGLazWcYN797Vfp06mrVI+qVOilSKFmEK/nCrP6nLU4NAT9vQx0/mQQpe1eNYLKy53kyw2AyWCOxnhJw2V1G2h2M45TjqTJM//7QpmjGRYgV6QfVcZxEinJmuwSBkarjjTpYK5dIGZjoJzqoywG9XAv2rQPREsbIxuA8TiwjCkoI5P9tRMGe204HzZjolmFRVYyCCeEwuzVKtQMosSDAeQb1Kdu2aALZ+n+CCobhZ05gERHD49go1/vOliniKigGewlDovWrpZvVi+RulVqyQq8U9e2qzhJmczCZUm6XnlElhKFYZrGyUmKOfOiEgr7xKpDXYvkjO4AYwguUiaBmI1JHEnO+SerRLWSHjfCEqzddMX7t9i2wmysF24GIREDdu7bK6v3JEsEVBjuszK1SyPP4UIfkc71mMWb1IwBkXCvEt2wQSCi07IIb2/n7lhd2ANR6SzrpxwSNGuYF2fBCW5Z2bpKfouKATeBQYDfC2wv1TPYMeXQ1sOeOHcveFPl6wdfSiHYJr9w22Y5hHcPR4SG5ir18lXgRc5caBmEs5qpF9vBIJztK4ZHSgLUk0zH6rn1Pgk6nYQCe6EKDh4RbBZNO3pUlu3Ypi+qzmps51yWg8RzTuSJ4Yr8M3cNl1AYzFnzQflCQLBnBf2ttSulFH7Tg4Wa5htYFhk9je3GjoCpmHD4fRMySGGGQssgOmgeCcK3j5B6SNi85zSjn+1Ak/F0VRou3rKeA0ZGrMewMr8BhMP9V9ytSxFhcWeL3186t9RzSVx0dXmmzwB/SZRJqeYtWrdK3lr2i4TiFCHetajGekFIEXe7T0sVTAy7Du2XFLiwCzsUbgbB6JE4uUBHA72ggMSmZ0TAcPYhG8NNSaIr4QgoCMYwvM479gc5HzN/exhSRUlmaIH90nYDWym4zQV20+FjZD+3mqg/CuGl4KjmEu0cen24/wpio8AIluRZitIIdofaBI62h2BbRjVKFcSVIEXlQMuOLGf9Uz1YFElkdj9/xTyr8sHcGgL7hMUXcBW0Odz1TCbMYL8Wcij0EoS+oRIkHAwoiaUg4BSInmc9DmEWPcRt6wDDHYoNhs2iqsjcrQmwZct743Ljk9wImfmxyUT2HUqRdVsTdTEyE6f7FwVISTDHcqzB8Aw9VbyTqJnVTStTABctjdKTk0QhhyLAIDgtVwqr2D4u0fyM6wnMoyGcwSEltu3Zrajc21mwxQPu15ax8SLzp7tdwYg9E/EzjkY0Xaj0emUnOU8IqR+wBScgO/zzTzhkHo2MfsxvpoMBH4qvWR1GPSk3s+NUVHm+sAZUOVS9xKRTBu7mwg6FnkE4gJHl3DM5Fw4LQtVyKxYgOzDDUmwpvwuSpCT3PMHtG4SV7nYNGmElMVLWw2Cvihl9J1SRnFy5JLaykEaVYPjuQ/40j2qUSXhuxrBntXnKR0l1bCHhjgA/LKKeKx6SKijGsLJZkzJgYtaTn5MrX7asRjG8oMuyMi/2vdDaIOqp8sy63J7NPU+HsHhWGgOcleTyPgTMz+8L8sTe6I1rdJcwsRje+jVi5L3uveV08mapgJmWe7a4dsI/upg5K9GGKQ8pVAebCoNRzy3YDZwGF3QYwqjCnRGAMwiGMhfteNbd/rh1hS9i4CJmbijOiD+HSK79hAL/MUwIjfHlrIiwcjmkLDzBhZZBOES2NhEdFSWlK1aWXTi6GoEBVkmSjzEkkXPzXizWA2T/Lvl55W+KjZsUT0HtIvTB6bunbuwjqxPXyDZsPQkF0UaCsCsjDU/p8RjVARDaxp3bJOVomvypbUfpBKJLwxkVdQAolhwuKCMDmzC5ZT8FzGV/qfobpxVxL+gZXfGB63hqUo4dlquia+m323OoYaEJLtQMYlTCrSD9a8EuwBsR+ZIEQn4JiKrRUUoRvCJo8E/f4p1aiV6sp7GTlp9nfvyOvjJx2NNyNXbq7sWu3+37dkLaJOOeLHtxLDcKpw0f79xDlv35aXmh32C5vGasvqMq9Axb2Vl3AuvPlvj7y2/biD8n0LUkTDRt4urA3grRZOezvJzqcaHCC7UNQpOXUqQ0jNaO9RvLmMWzdQcuVRHaEfkZWBIK35kVCwfAFnwf8Pn/jZPRgx+SCjhYpIelip1Sg/0mfAqtY7MWsmnHdt1yn47zIHQFVwoPl5qVq0hVqH/cqkKoDe8Xz7KfHwVJizjnC/uLx4o3QsJxRy/PsRDsnL8+FMJL4WYQEDEHkPZI63oNYa1Xla0wnCuDYXYjPD9bTqjjk0m24LRdPAzycXhBdJUJ5eSpO+7B9oswJRUenKJnKgJM04rl+wWs00DVCsFs3DimNgyVEDl2CpIJ+QimDvLO+rrVRnfc+bAztFCfi5aG8ivgGygHsYI+EG9gjKtW3Z3KU0+fLIXm0T11FZrmZG+Ie4sGZmecpX6+RTssq6fAa+RmjfxIEJZEAuVawCYY17F46dxri2bL0PfflKU4KOXe+l5CNzAyJTcz2p8Lv/nnxgBj26Oq8Bgu9znp6T8P9dM7RgiGoU8I4Z2qHSqf3/orwrO4oDTYRfgWI+sHCdK71eWqQpJZdUPmWeD4oyYp1BKEg0IGMTXgFqg7Ty+cJZtxki8C58RTQWgFQWTEkQhpEYtvA47f8LuMf32NPNXuarmxdTt9g3q5sqGelzZkJRPu/E3BGXWqX/PwkZuxyxer6/i0p1IkQJ6EpEp2LCND1x124cit4Mw5100uhARhVVhWZWx83IrXsvZo0ELa480mBNbPJiANKISXIvHaH+dAjpk6SR6c8J40rBYnazAb5rQ+kdexJrFypq2FdRB+TNOVyu+Wh8g1NWrLFTC+q0ZUlHCsG5SCBDiEPUypcBjswXuxFsC4n7ktAatveAlp2XJqL/F4LIHEWQfrDaVgtFPF4mx9GOn4ueeCqrcWdIYL20XXOD+jsAOvNJo9/Cnp2LSFd9I5Q9ZCEVUkGIQjZVIk5chhGTTmNfl6/e9SH67f/L40zpcK+JKfCsWC9KRgCqRKKk4T6tsVyQCc80Hoal/QMOfxWZytqABvVhjUPnrF6D4mY/CPxHkK9ol7F4AnBOmoZrmdyUhwHoEl0lvXCGtIq3dsklE9+8qIW+9y160ISA92bZFhEDbWmGR90jap/8Y/sdqXIbXxys/NIEIurlECFAQQD4mLq85cWOP5dVo9DCOQ8Akkch5A4uo5Tzoyn69RyMVEbnpkHuanfXKIxInf5wuIW5kT5TSEu3oN3tpyR6OWMua+4ZCCod5+PF/lX0p4ixSDUNUiUG/+BZ8ku/Ktl3SFPR5qTAKYxN/R2PwOFolerQWjcEPororWxZcpLAnvnmTOoPPOHOo+MObACn/zKjVk0tARUqtS5SLFHOz0M41NlkEpDA9Og/KKRk1k+uA/YwpPkwS8ZJozJYmRL4wuSGAHlwBJ02bQO3/bM8JyGwDO5r5/BVk/X1xUqbjq34SSA4uaUXh38bhBw4okc7BvipQEMWJwGu1z8VK3q8aOEdm3Cwt10fq9jt2wHaD5K5hqVLBsYzW5eHdT0SjhTCWkMc63uh9G+/fs2iY9m7aVf/UZJHWw5uGUvhev1he+5CLJIOxmJ5NswRvWR8O79eq872E04zMFOMdBaXMEtsFB2Ah0cyqAqmxDuhGYO+KPcWUr3C3B1dMk7iqIgI1UGrbOUazN7KH3Dc9vdL8Vb3PvLhXCwnRNh+12SuA/RovzX8siyyDsOuesyFOHc1culzd+mirfrsPmQ25EhIcpFgt1VI9oRNNA5h/VsAvhRcr/8GZiIENTGrIt/KiPffGKu5K3cfsIv2UCGNqyvQwGY7SIr6fP5tjQhyJ4KdIMwvHWWRVSwt7fm4JX2ZBRxi2cK+M2rXF/5Iar1zDk+RYTvs5HvxwFQvujAZmc78zClmMYW2AKuqDRdp5dGd6gudx2xVXSun5D7wc8izpzcHyLPIMYkTulCcPSsBi3aXuSfiN9WWKC/LJ9qyzEqrd+7YkzLjYqqvVsCP4Id667YB8aj+N2wbfRL8ciZovYOGlQK1Ziq1bTD/awGWQMqlNFUaXyHcYAg/j0iG4OhFjhtzgMMrDIl3L4sBzFCjh342bAJcyNiG6wdB6l3ss1l9Iz102K6TuzuO+rdEm8rgiLk+HYVFnCs/2fbQkwhmdIHbcAgzg6w/mTmw2pf5nq5YwrTL8pOVV6QmIU9o2H5zJuAQbJpdcoB5SAQEgKHtvD5EYu2S+ZaJNnyvXepgTUqNwGKMAgufVQIL5I90BuC7lFunMCjQ/0QIBBAjQQ6IEz9ECAQc7QOYGoQA8EGCRAA4EeOEMPBBjkDJ0TiAr0QIBBAjQQ6IEz9AD2Hpw7+G7POHdM5ydnQa8MexfVUN2LuYB4qdTj/IxadqzO9l7oLTDZ1kGclXFW9UJXzFl2fn+zTWfaV+RsszOdbz5nHOvkG5/fep5N/ryU6WxXTrgvJqPnVCdnuL/2+gtz5jmX38Rp4BznLAySW8GGxInAkJ6Pe37L+/333/G29SBp2LBhjsScW5ud7Tp48KBs2rwZXz04Jc2aNZOSJfGdwFyYz5m/oH4fQD22oB4nUY8WzZtLCF6AnZ965CdvQbXJHx6r13Hsf0tMTJRdu3ZJfHy8REdH56u9/srKKcyrYlllSAQ7duzQCjCMnR+GQzOVK1fGR+5LaDiRncLgvP/+BxIZFSm33nKL4jccORWWl/BzxeXM9/HHn0iTJo2VQfyV7UzLzt+6davs378fbTuNNodKZGSU1KxZQ9vPSWHhwoVy/fXXy919+8o7b799QRnEWdeFCxbIDTfcIH379pMxY97RMfLXvh07kiUFn8DmJFEMmy/5z8Dw1axZU0rh9an2bPGXwt3qxDEZNHiIzJs7RxYsWHheGOTQoUOSnp4upfEBJNK7gZdBLGD16jXSoUN76XN3XwS5JP1Yuuzdt08aNWooDz7wgDRt2lSTUr9PTNyi76G1vDnd2VCCU/JYmHWCM87ScubgX1m8T4rxllaR4cJnxeyZxX1xhILIS6HB/oD1p3rBjpn87bcyduynMv3HH7IlvePOO+Xpp55SJmMeQmTFyCxtsUxaH0dbfevDdExD8I2z8JziDDfrbGkjI7PXg3GGe8qUKfLAA/dLdI1akpy0Vcv1vWzfvl2qVavm7Vsrx9L5U8GsfCvH0lo4ny3O8PGZf/ZsaSyd4bA709kY8V7GM47BwZkka7gMB58Nr+GxOHvm3dLxN+NTUlIwOW7TcGoF0dFVpTy+Jsx0maUxNYAvXr6p983y+muvSig+8XvkyFE5is+MTZkyVdWKFStWKJNQmvzjH//IYqz6qwxx+oZbw51xVmmmtfjly5fLzFmz5LG//MU9CyKO4EyrIT7hmsgunk6zR94N/xEcjho5apS8+MILGv3ww8OlWXOoTpCa7LTvf/hBJowfLy+9+KIzu7d8C8xSH09dGOcMt7S+fZFbuNXVmY99TzD8hsP3HhKCA16AZpCiPW64TvvQhc8mFA8qjjeIHtfZUr9niDTExT+W4yyL+S2cvwm+8e5Q/+FOfP7a4oubz1aGtZN1DMaYEJzD6cRteTRRLhdn/akJcRIuiSMA69atl8sua6GShFKEk0M2BmEFya0RERGqUlHk4HtfMnTog5rx3/9+U95++y0V6xTdbLSzUTnVzdIw3malo/imeAbeTUUJQVWOQHzWgNTUVNm2LUkHViM9F4tn2sM4p0HcYfiYC89wOMthZ7q7OzM34638b775RpmjZes28vSTT0iXLl2kTBmcHPTArbfeKsnJyVKjRg0NsXxZy8jER4ZjfdAAFdM26zE968w760wgLmuHhfPOcP7xt6XjbzLs8eMnpFy5MPSZ+5USuiVfUzkvmWpUcYwPgWomJxm27cQJvFDbc9aF5XN8iZ9jSTgGjSEt7ZCGcVw4SVrd7e6vDcxLYnO2gWFMy35hXuJimgMHDuizSUDmMdy8E0gbhw7huyqhZTW/i8cPFDJH9CSOSR8+fAT0U0bIRPug6TA/iZvtoX5RgofEfIDlsR4EY0KG1atXV4551Cwb6+y5oafyy63kKma2RvP31Vd3kk8/+1xIuFH4KM2HH30klXDv1auXjBs3TsNIZARrNH//gJmYh41633QTH2XX7t3y1VdfybJly5SCWZkbbrherrvuOh0wlj1r9mz5csKXcgiD9corr2h9ypcPlwED+msnzIJkoXTZs2cvBvWo1KpVS4YMHoxGus9Ssxx2dSa5MCSzXklJSfLBhx9p2AP3DZGePXvqb+elSpUqwj8jCBs8J1IOBAfzxx9/lG8mT5Y5c+dhgikjV155udzU6ybp3PlqL/OzzPfee18ZYPCQwVLTw3jM/+mnn8rvq1bJPf36Sdu2bb2ERuP064kTZeaMmbLi91VyWYvmSjSs50kQuy946EuDre18ty9VBo6hzneOTCQi2ibs859//lkmTpoks2fPURq48orLpceNN0r37t10EmM2Evf7H3yAft8j9993vxIVw0msX375pcyZM1dugU3atWsXpZ3x4yfI62+8IY899hdpBGfJRx9/LEuWLFUivu667tIP9hwJmnTGvjwGOvlx+nSZ8u0UmffLLxKOeteBYU7GJRhh01YeM+ZdWbJ0qQx/eJjs3btXnnn2OalTp47cddedYPI0Wblypdxy882g26t1DEln6ZiQx30xThb/uliu695dx71ChQo6+bDvSLcUDgT+9sMg7DD/4GaWzPPb69atUwJn6pIw9F548SW54oordKYiUbHBnD1efOlleeLxvytSOgD63dMfs/U1MuLRRzUtZ2k2jvbPE088rgTEjomCA4BE2ahxYxDDCWUeznhz5syRd8aMkWHDhimRMc24cePl3kGDZfKkiTCuI7VxLDBzvtHiFR9/rV27VmbNnCFXtu+gkoNhHGTW2cDJ5BZmd8YROKCjR4+Wv/71r1IqNFweHDJQpci7qB//PvroY7mnfz99eTWlywsv/FPz9elzl955Ybk/o03jMcl079ZdwzmYGzduRN4BsnDBL9K+w1VyNwaeTLZk6TIJr1gJ6Xxb5x5ULyMrppwvHCOWQ7Xrs88+k0GDBmniYcMe1vvo0W/Kfz75WEaOHCXDhz+sxjwN2ffe/1C2bNoIQsxsA/tjJbyG7747Rtq0aa35iZ8EvATE+Nmnn8nkyd9IfJ16yuBzflkEJpgMiVhO+t59t/Y7tYm34fwYMWKE5h869CGdXGajb4wm7XMQnOk/hBOG9TiF/vsWuAjr1q6BtBwhmzZtkrcwLoS2bduBzty2aDIcFwMH3qvhZE4CJ47q1avpOPA3wcbeD4NA/INITOVxEswkzC7k+ooVKyoSU8P40KljR6H6tWr1amnTurWXQFfjmZ3Qvn17zfP666+Dc7vJXyDyDWJjY8HVn8vV13SRdu3a6ezDWZSzAl213bt1s6R6p4uVxEQVwOBxMODixYuFdkvXrl1RvjvGOpZP1mj+3rVrN2/SAjMyGYpAYnESl/02ZtBEuOgzpxvAzz/PUea4sUcPef7556Vxo8aY5U5Kr5t6yeAh9+tgNG3aRFq2bKn469ZroPqus19ZThQ8ZoQSJdwMSqny3nvvKXM8+eRTamxTmpFAJ0yYoMRcApLBF6zODDfJRzWV6iQN0NNghpM4QmxjQg/WkqVLFF+Ly1rKG2+8Lm3btFG0t99+m/zt74+jfY9Jq1YtIQ07axsaNqivhMlPzhmw3HKebxYSJ4FhEeHh+psOkzlz56J/GqkG8u6778rLL78scxHWC9KbUmQ2tAYyByetl196UVqDjkiwlAQPeZjWTj3y3rxZUymFNv26bLl8CY2E9aZkadCggXpdw/AyisnfTpWhDz7o9WSuBQMRHn74YaieTfS3TRS+zMHIbFtN2Kh0zIp0rdHDQ0KipHjuuefl60nfyAP3369IeSGhmD5LMUVxNh3ikWCFzZg5Ex3QQyXFhg0bZOq076VPnz6a5gSkAitHyUSV7flnn5H/ff0/6Ml80bNo+cX4kmcAy2Ja3sPR6U7mYDhn4bj4OFV3mB7NUMg+x7rD7Uw5iYaMcSZwMhnTnYYbOBgDx3pOnTpVs3IW5JoEvSwkkG7XXiv3D3HPyPPmzdM0/ALuhvVrJU3tJg3yXlh/AttCoIT717/+JbXj68qdkBz0NJGp2O4aNWpqGiczaIDPxXBRdaM91QNM3KtXT1WBBt13n66jMMsMqG+EgffeKx0wkXFy5F+HDh3k7rvdY8U07HuOK7UCAh69wDj7PiOZkMAwqyPVGeLmpBoTEyOdOnXSNHQWsP/ZfuvL/vf00wmVY8M20wY0tcc7sMhNybF2zSp5ZdTLchvaR5c1J0/WvXr16jL0gcGStHWL/PYbXuMEoISaP3++/qbaRaYkWB1ZX+czf2eTIEQ+CWpKaYgkGoUkggzMWu3bXynTpk5RXV+xeC6GnI+cYQbBDhjQv78OaHLyTswQ89QjxvgkuBTbYlYwCcTOZn4byLi4eEn+5D+qorBDqBeHwLtAcJbDZzLVmjVrZClE+N69+/QlCj9hEHuCCJzgS9wWx5mHsBc2THo6vr3hMM4tDe/sNHabEw+NYw4qVab169dr8vj4Ono3HZlta9zYPUPZulIQvEduIDYHdXlCeTNm3blzl4Ze1eFKqQ7mIJCIiJf9ouAfhTsOV5tc6tevhxlzmHrn2B7mL49Jhn1ASbUNL/MmNIBkIFgbSJy0Gwhbt23VtKyfEVKWNtiMxMTOzuIzwRNP3MRbgq9QAnCiYpto165es1bD6tdvoHfSHo1vErbRiLfbgM8mlQYN3HVkeuImUBXvDCYYCSk1c+YsnSCokbz00kvStFlzaY7JjEC81ue+NMb4bAzCQjtd3VntA3JYcbwHKjy8vJeonQiJwAl169aRZlgnWbRosdx8c2+oO8tUpNauHafJ2G+sjFWEHW2/mUClkaOjyaD29SXGMz3zs8NooJE5br/jdrn88st1NtiyZUsm8TCDD7Asqz9nG8LYcV/JQw8Nhd7cBvjx3XH3BO7NaZ3nDXD8YH2MWKzaWdtjDGGZ3JSjvnzLgCjffmBqfo2KUNwjQfnbiZvP/sCJyxgyrnZtNYZJiL5AGyqzje76Ocvx/nYwo1Xd4rQf0HHehUhHWivP5elYI2CvB86TljiMMQ2/5eXdH89ZMaYNEDfbYsxEadKt+3Xy4YcfQKUfoQvgxNUHtpN5Jq0NDPcHviOoYje6alXo5i3UIxAXVzsLc2RBiBqiXQqsFLmdYnwGjF/qyvPhhbj22q6YIdxcTTVqKWwEzhYE5tHO9SChhKlUKUrdgYxnw+mfJljn8fd3332HWWEmbJ435EasKNNzxe0HVL1OnnQTFtNx7rf68dkJjaAL9+t3j8iJo/IFvBr0zlAFYgc7/8iMVrbhYh+w7lR3YmJjFG1CQoLeLS/btX6DW7pQPWIe6v5lylWQ7Tt3ZxlwqhJMTzAjlG0hLFi4SHbu3Km/jbisTzTQ5+IcH6uv2+7IqsJZeVQHq8K2IajTBXdrA8OsXbVq1VQpy77gpEkwQmSZ1Dy8hO2gZrf8RWJvpGb1tp95iYcSvEaN6hq5fv0GvZOeCKyjMYM3o8a4Qx3Faaj1AXd/9IYtSPgBXsbp03/S39SGOFmwXEurEX4u2RiEnVMMfxS9BEoUImKHMs4JQSB8Ljo5oXXrVsoc42FIUr8koxnUrVtXmsAjNcWjt7OSrCAHnurK6NFvqR1jHXMcxGmGqM0OxEXPCBnPiIhhVBtoL9EnTmB9id+3znxmHFW4IXC1EmiYjhw5ErrqCrW9aOhx68mMGTPUxcw1CIINNgma/cK7eZ0+/+IL4SIqCYhxs2FwvvXOGM3X4aqr9M5LTE2oSxhX6sIHD6aoUcly1sM+U/BQNd2V199wo+rY7Et6+qhCsF5L6R4HmITQBz8XGxuboHyTsB/Y1x3gISN8Ck8W68X6sx1LliyRsfA+Ebp06apjZXkYNmfOXHWkcMKji3jZcreu75UkSGPrEL7jYOqfe20GEwcYxBw5NLh/weTKyYnLA1wO4JhU4FeAPf1DpiDjEHyJnM/GvPSqEuiC/uDjT7BD5G5p4FEbNSK3CxqsgA7R+/SffnJ17NTZBQbJEu5OBSUE05HB3/72Nxc8LdnSwddN1naNHz/enRR5DP+qVas0Dls7XNDNXdALXZi5XPfdd7/riSefdKFTDL0LnhfXjT16ukAcLmx3ccHm0PJ/+mmG4vj1119dcCS4EhMTXf8ZO1bD4KP3lvWnP/3Zhf1Yis9Zb/vN+4QJX2o+1pd/13Tp6rqpd29Xs+YtvOHwxCmOiRMnatg9/fu7QBQaBuZxPTpihIZXrlrd9eijI1wPPTTMm3fsp596+wzGrQur9RpXvWaMq/M1XVwxteP1ud3lV+idZRh8881kLx6ova4hQ+5zxdWp6w278667XJhYNLmzTZafY8M2DX/kERdUKQ22ceCD5WGfjxo1yov34eHDXX/+v//zPr/22mvecQGTul4eOVLjasbUBq1c7WrcpJk+YyLQO9Z6tCxMWq6/gkZYhw8++FDD7PLdtGkafsstt7ogvTUY2z20/5m+QmRl1733DnT16NlT0+HjjXqHTatpsUXG1bBREw3DHjkN89c20jHHJ6pKtKYl3RHYdmu/BuRwCXoWgAopkPP2Q9WgLn4lOI8zMPL55VBmSEpKUncaJQPB0oZC9eAqaN++d+ssT7WBuPlXqVIlue322+ETnyxcRJqNmWcaPFvXXNNZ7oeHjMYVGqozP92am7dslrffeUcXyjjL0hNSr15dqQ29+tXXXpdfl/yK2WaBrqsMGTJEXobP/jJIrapQE8E46t+Ox0ITgeXb3epKVetmeN/YhvDwCOzW3SLb4SunuO99U2+4HR+Fsd1Y68WV2iOQrG2w8k5JydmXs1irVq2Qvx4k51EZ+8WXUImShS5SblHhQhulHwZD1RDWhWpgBj5HTefCoIED1JCkLcB0vbC4aKpGXFycujrRfbIVfU3f/jNPPSkDBtyLckuq65iuUJO41sfaSFyomnHRly5zetg4ntZ+u7MfGE59nX/BePPiJLhGl69YKbdhwe9ZeBbvuOMObSfHhWlrx8ZqWzir09NJN/ybWDOhvUj66d37Jt11S9zbse4VBJXsqo5XSV1IRYP96EuuZbDvWD+qaFzMbNeuLbSAUPTRCZk08WtdXH7uuefQv3XgIKL3q6PSHBf8Dh9Ok3g4djpiiYF0ZWNqZfDOvuHugQ/ee1cua9lKHnlkuJoMTOsr1Zz57HeW7e4MpHg19cEIyhL73ikCWYgNkFWQd8ZRBXHisHgrhwSnHhV0DDuHYGnsngHVKRmdzHLo/aLebzjpiqZqRhezuewYxnK5rcG3flqA42JlWLm0Q7j3DLUAjlK6rYMMa/EkEKo5rItb5840+pnGnf+IxrM9rIPlZZ2tPKqv9KgQB/Vk4uMz6832kVEsLfO7CTFNtwBFwUYjEAfTWT000OfCunIsnfX1SaKPzrKoTrJPCVwr4R/B0tidfbsbOyJYB9qWrAf7ns9st02uHF9ODnw2OiE+1su3L524SRt8Jm72C21aPrMclkGcxM0w4iV+JxguhnERtB92KDz9zDNYsH5ccTjjnfl8f2dhkLPN5IvE+ZwbDsbzj4PmC2y0MzwnXP7CmZdEaMzjL41veXxmOv45y3WmYxzB8Drj7LdvvS3cX16G+eLyF0YcOYUb/oK859wG1iP3cSmouvqrhy9u32d3P3CcfM11Uc/Vgw8O1ZX2H374UW1X//n992YWtuPAMTP/ciIYJxqmIzgH3ImDxr5vlRnvTGP4GOZbpr90TJNTOHE5GcVf/aw8uxOXP3wW76yT9Y3lcaaxOAvj3ZnXwpmXdTQwXBZmz4znb1+8DCNY2/yVoQk8aZjOidPifO/E41sW0zCvbxm+9TL8/tpgOC2NlZtTOMuCeYBkmbTFvNlwI9pcxYabaZifqv+0adMkJiYGe65+Vea4HWpiy5aXafHWJ1aXM92zSJAzJQzEBXrgUu4BEj2BzDIJ22psYyzDqlavKVMnT1KPqjMd43KDAIPk1kOB+D9cD/AQGLylwqPJ3MncDA4K7ggm5EV6MH2AQdgLASgSPZBX5mCnZLeUi0RXBRpZmHuAjGCqFNtJ2+RcmIN5AxKEvRCAQtcDTgahXXKukMWLda5IAvkCPXCp9UB+mMLZloCK5eyNwO9AD/j0wP8DtYt/fOhzihIAAAAASUVORK5CYII=' />\n\nThese metrics help you determine when you need to scale up your deployment.  \n\nSee [Key Capacity Scaling Indicators](https://docs.pivotal.io/pivotalcf/1-10/monitoring/key-cap-scaling.html).",
-        "type" : "Text"
-      },
-      "packageSpecifications" : "",
-      "programText" : "",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Ephemeral and system disk usage",
-      "id" : "DiVXOcWAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Disk Usage",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "Percent",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : 100.0,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "System",
-          "label" : "A",
-          "paletteIndex" : 14,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Ephemeral",
-          "label" : "B",
-          "paletteIndex" : 4,
-          "plotType" : "LineChart",
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('system.disk.system.percent').publish(label='A')\nB = data('system.disk.ephemeral.percent').publish(label='B')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXDgPAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Disk Util/Quota",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "Disk Space (Bytes)",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : false,
-            "property" : "app_id"
-          }, {
-            "enabled" : true,
-            "property" : "app_name"
-          }, {
-            "enabled" : true,
-            "property" : "app_instance_index"
-          }, {
-            "enabled" : false,
-            "property" : "app_org"
-          }, {
-            "enabled" : false,
-            "property" : "app_space"
-          }, {
-            "enabled" : false,
-            "property" : "deployment"
-          }, {
-            "enabled" : false,
-            "property" : "host"
-          }, {
-            "enabled" : false,
-            "property" : "id"
-          }, {
-            "enabled" : false,
-            "property" : "job"
-          }, {
-            "enabled" : false,
-            "property" : "sf_originatingMetric"
-          }, {
-            "enabled" : false,
-            "property" : "metric_source"
-          }, {
-            "enabled" : true,
-            "property" : "sf_metric"
-          }, {
-            "enabled" : true,
-            "property" : "bosh_id"
-          } ]
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : "app_instance_index",
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "container.disk_bytes",
-          "label" : "A",
-          "paletteIndex" : 4,
-          "plotType" : "AreaChart",
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "container.disk_bytes_quota",
-          "label" : "B",
-          "paletteIndex" : 1,
-          "plotType" : "AreaChart",
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Binary"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('container.disk_bytes', filter=filter('app_name', 'pivotal-account')).publish(label='A')\nB = data('container.disk_bytes_quota', filter=filter('app_name', 'pivotal-account')).publish(label='B')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXDgTAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Memory Util/Quota",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "RAM",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : false,
-            "property" : "app_id"
-          }, {
-            "enabled" : true,
-            "property" : "app_name"
-          }, {
-            "enabled" : true,
-            "property" : "app_instance_index"
-          }, {
-            "enabled" : false,
-            "property" : "app_org"
-          }, {
-            "enabled" : false,
-            "property" : "app_space"
-          }, {
-            "enabled" : false,
-            "property" : "deployment"
-          }, {
-            "enabled" : false,
-            "property" : "host"
-          }, {
-            "enabled" : false,
-            "property" : "id"
-          }, {
-            "enabled" : false,
-            "property" : "job"
-          }, {
-            "enabled" : false,
-            "property" : "sf_originatingMetric"
-          }, {
-            "enabled" : false,
-            "property" : "metric_source"
-          }, {
-            "enabled" : true,
-            "property" : "sf_metric"
-          }, {
-            "enabled" : true,
-            "property" : "bosh_id"
-          } ]
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : "app_instance_index",
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "container.memory_bytes",
-          "label" : "A",
-          "paletteIndex" : 4,
-          "plotType" : "AreaChart",
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "container.memory_bytes_quota",
-          "label" : "B",
-          "paletteIndex" : 1,
-          "plotType" : "AreaChart",
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Binary"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('container.memory_bytes').publish(label='A')\nB = data('container.memory_bytes_quota').publish(label='B')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "This should stay below 5s",
-      "id" : "DiVXQ34AgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "BBS Time to Handle Requests",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 10.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 16
-        }, {
-          "gt" : 5.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 10.0,
-          "paletteIndex" : 18
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 5.0,
-          "paletteIndex" : 14
-        } ],
-        "maximumPrecision" : 3,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Max Latency (15 Min. Window)",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('bbs.RequestLatency').scale(1e-9).max(over='15m').publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXNJlAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Authentication Failures",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "Failures/sec",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "uaa.audit_service.client_authentication_failure_count",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "uaa.audit_service.principal_authentication_failure_count",
-          "label" : "B",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "uaa.audit_service.user_authentication_failure_count",
-          "label" : "C",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "uaa.audit_service.user_not_found_count",
-          "label" : "D",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "uaa.audit_service.user_password_failures",
-          "label" : "E",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "uaa.audit_service.principal_not_found_count",
-          "label" : "F",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Failures",
-          "label" : "G",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('uaa.audit_service.client_authentication_failure_count', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'uaa')).publish(label='A', enable=False)\nB = data('uaa.audit_service.principal_authentication_failure_count', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'uaa')).publish(label='B', enable=False)\nC = data('uaa.audit_service.user_authentication_failure_count', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'uaa')).publish(label='C', enable=False)\nD = data('uaa.audit_service.user_not_found_count', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'uaa')).publish(label='D', enable=False)\nE = data('uaa.audit_service.user_password_failures', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'uaa')).publish(label='E', enable=False)\nF = data('uaa.audit_service.principal_not_found_count', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'uaa')).publish(label='F', enable=False)\nG = (A+B+C+D+E+F).sum().publish(label='G')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Time in seconds that the active route-emitter took to perform its synchronization pass",
-      "id" : "DiVXQ3yAYAE",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Route Emitter Time to Sync",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : null
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : "metric_source",
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Last 15min max (in seconds) that the active route-emitter took to perform its synchronization pass",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('route_emitter.RouteEmitterSyncDuration').max(over='15m').scale(1e-9).publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Top 10 consumers of disk capacity among Garden Containers",
-      "id" : "DiVXMXXAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Disk Usage (%)",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale2" : null,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : false,
-            "property" : "sf_originatingMetric"
-          }, {
-            "enabled" : false,
-            "property" : "sf_metric"
-          }, {
-            "enabled" : true,
-            "property" : "app_name"
-          }, {
-            "enabled" : false,
-            "property" : "app_id"
-          }, {
-            "enabled" : true,
-            "property" : "app_instance_index"
-          }, {
-            "enabled" : false,
-            "property" : "bosh_id"
-          }, {
-            "enabled" : false,
-            "property" : "metric_source"
-          }, {
-            "enabled" : false,
-            "property" : "host"
-          }, {
-            "enabled" : false,
-            "property" : "job"
-          }, {
-            "enabled" : false,
-            "property" : "deployment"
-          }, {
-            "enabled" : false,
-            "property" : "app_org"
-          }, {
-            "enabled" : false,
-            "property" : "app_space"
-          } ]
-        },
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "container.disk_bytes",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "container.disk_bytes_quota",
-          "label" : "B",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "% Disk Used",
-          "label" : "C",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "sortBy" : "",
-        "type" : "List",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('container.disk_bytes').publish(label='A', enable=False)\nB = data('container.disk_bytes_quota').publish(label='B', enable=False)\nC = (A/B).scale(100).top(count=10).publish(label='C')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Whether CF App requests from the CC are synced to the BBS (< 1 indicates a problem)",
-      "id" : "DiVXQhZAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Cloud Controller and Diego in Sync",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 0.99,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 14
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 0.99,
-          "paletteIndex" : 16
-        } ],
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Average Status in Last 5 Minutes",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "None",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('bbs.Domain.cf-apps', extrapolation='zero').mean(over='5m').publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Consul health status. 0  is healthy, and 1 means that Consul is down",
-      "id" : "DiVXPiXAYCg",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Consul Up or Down",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 0.99,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 16
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 0.99,
-          "paletteIndex" : 14
-        } ],
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Last 5 minute status of Consul health",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "None",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('route_emitter.ConsulDownMode').mean(over='5m').publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXDJPAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Messages Sent Through Firehose",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "# Messages/sec",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Dimension",
-        "defaultPlotType" : "LineChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "Messages/sec",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('DopplerServer.sentMessagesFirehose').publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXLqpAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "# Routes",
-      "options" : {
-        "colorBy" : "Metric",
-        "colorScale" : null,
-        "colorScale2" : null,
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "gorouter.total_routes - Sum by host",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "None",
-        "showSparkLine" : false,
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('gorouter.total_routes', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'router'), rollup='latest').sum(by=['host']).publish(label='A')",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Doppler Server Metrics",
-      "id" : "DiVXDNmAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : " ",
-      "options" : {
-        "markdown" : "<h3>Doppler Server Metrics</h3>\n\n<a href=\"https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#doppler-server\">https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#doppler-server</a>",
-        "type" : "Text"
-      },
-      "packageSpecifications" : "",
-      "programText" : "",
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "DiVXJRMAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Router VM CPU Utilization - Info",
-      "options" : {
-        "markdown" : "Metric(s): <code>system.cpu.user</code> of Gorouter VM(s)\n\nHigh CPU utilization of the Gorouter VMs can increase latency and cause throughput, or requests per/second, to level-off. Pivotal recommends keeping the CPU utilization within a maximum range of 60-70% for best Gorouter performance. \n\nIf you want to increase throughput capabilities while also keeping latency low, Pivotal recommends scaling the Gorouter while continuing to ensure that CPU utilization does not exceed the maximum recommended range.\n\nExcessive dropped messages can indicate the Dopplers are not processing messages fast enough. \n\nThe recommended scaling indicator is to look at the total dropped as a percentage of the total throughput and scale if the derived loss rate value grows greater than 0.1.\n\nRecommended thresholds:\t\n<b>Scale indicator: ≥ 60%\n\nIf alerting:\nYellow warning: ≥ 60%\nRed critical: ≥ 70%</b>\n\nHow to scale up:\tResolve high utilization by scaling the Gorouters horizontally or vertically (the Router VM in the Resource Config pane of the Elastic Runtime tile).",
-        "type" : "Text"
-      },
-      "packageSpecifications" : "",
-      "programText" : "",
-      "tags" : null
-    }
-  } ],
-  "dashboardExports" : [ {
-    "dashboard" : {
-      "chartDensity" : "DEFAULT",
-      "charts" : [ {
-        "chartId" : "DiVXDKWAYAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 0,
-        "width" : 6
-      }, {
-        "chartId" : "DiVXDJPAcAA",
-        "column" : 6,
-        "height" : 1,
-        "row" : 0,
-        "width" : 6
-      }, {
-        "chartId" : "DiVXDNmAgAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXCx0AYAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXC13AgAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      } ],
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : null,
-      "description" : "Key metrics related to the Doppler logging/metric component of CF.",
-      "discoveryOptions" : {
-        "query" : "metric_source:cloudfoundry AND job:(loggregator_trafficcontroller doppler)",
-        "selectors" : [ "_exists_:host", "job:(loggregator_trafficcontroller doppler)", "sf_key:host" ]
-      },
-      "eventOverlays" : null,
-      "filters" : {
-        "sources" : null,
-        "time" : null,
-        "variables" : null
-      },
-      "groupId" : "DiVXCtHAgAA",
-      "id" : "DiVXCwFAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "locked" : false,
-      "maxDelayOverride" : null,
-      "name" : "Doppler",
-      "selectedEventOverlays" : null,
-      "tags" : null
-    }
-  }, {
-    "dashboard" : {
-      "chartDensity" : "DEFAULT",
-      "charts" : [ {
-        "chartId" : "DiVXDihAcAg",
-        "column" : 0,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXDgTAgAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXDgPAYAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      } ],
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : null,
-      "description" : "Metrics on specific Garden containers",
-      "discoveryOptions" : {
-        "query" : "metric_source:cloudfoundry",
-        "selectors" : [ "_exists_:app_name", "sf_key:app_name" ]
-      },
-      "eventOverlays" : null,
-      "filters" : {
-        "sources" : null,
-        "time" : null,
-        "variables" : [ {
-          "alias" : "app_name",
-          "applyIfExists" : false,
-          "description" : "null",
-          "preferredSuggestions" : [ ],
-          "property" : "app_name",
-          "replaceOnly" : false,
-          "required" : false,
-          "restricted" : false,
-          "value" : "pivotal-account"
-        }, {
-          "alias" : "app_instance_index",
-          "applyIfExists" : false,
-          "description" : "null",
-          "preferredSuggestions" : [ ],
-          "property" : "app_instance_index",
-          "replaceOnly" : false,
-          "required" : false,
-          "restricted" : false,
-          "value" : ""
-        } ]
-      },
-      "groupId" : "DiVXCtHAgAA",
-      "id" : "DiVXDOmAcHA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "locked" : false,
-      "maxDelayOverride" : null,
-      "name" : "Garden Container",
-      "selectedEventOverlays" : null,
-      "tags" : null
-    }
-  }, {
-    "dashboard" : {
-      "chartDensity" : "DEFAULT",
-      "charts" : [ {
-        "chartId" : "DiVXMRcAcAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXMJHAgAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXL-yAYAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      } ],
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : null,
-      "description" : "Host specific metrics for Diego Cells",
-      "discoveryOptions" : {
-        "query" : "metric_source:cloudfoundry AND job:diego_cell",
-        "selectors" : [ "_exists_:host", "sf_key:host" ]
-      },
-      "eventOverlays" : null,
-      "filters" : {
-        "sources" : null,
-        "time" : null,
-        "variables" : [ {
-          "alias" : "Host IP",
-          "applyIfExists" : false,
-          "description" : "",
-          "preferredSuggestions" : [ ],
-          "property" : "host",
-          "replaceOnly" : false,
-          "required" : true,
-          "restricted" : false,
-          "value" : ""
-        } ]
-      },
-      "groupId" : "DiVXCtHAgAA",
-      "id" : "DiVXL7QAcHI",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "locked" : false,
-      "maxDelayOverride" : null,
-      "name" : "Diego Cell",
-      "selectedEventOverlays" : null,
-      "tags" : null
-    }
-  }, {
-    "dashboard" : {
-      "chartDensity" : "DEFAULT",
-      "charts" : [ {
-        "chartId" : "DiVXFRQAYAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXEKKAcAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXEKgAYAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXEqkAcAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXEn8AgAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXDmlAgAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      } ],
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : null,
-      "description" : "Overview of the cloud controller component.",
-      "discoveryOptions" : {
-        "query" : "job:(cloud_controller cloud_controller_worker) AND metric_source:cloudfoundry",
-        "selectors" : [ "_exists_:host", "job:(cloud_controller cloud_controller_worker)" ]
-      },
-      "eventOverlays" : null,
-      "filters" : {
-        "sources" : null,
-        "time" : null,
-        "variables" : null
-      },
-      "groupId" : "DiVXCtHAgAA",
-      "id" : "DiVXDktAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "locked" : false,
-      "maxDelayOverride" : null,
-      "name" : "Cloud Controller",
-      "selectedEventOverlays" : null,
-      "tags" : null
-    }
-  }, {
-    "dashboard" : {
-      "chartDensity" : "DEFAULT",
-      "charts" : [ {
-        "chartId" : "DiVXMZjAcAA",
-        "column" : 0,
-        "height" : 2,
-        "row" : 0,
-        "width" : 6
-      }, {
-        "chartId" : "DiVXNFhAgAA",
-        "column" : 6,
-        "height" : 2,
-        "row" : 0,
-        "width" : 6
-      }, {
-        "chartId" : "DiVXNDGAYAA",
-        "column" : 0,
-        "height" : 2,
-        "row" : 2,
-        "width" : 6
-      }, {
-        "chartId" : "DiVXMXXAgAA",
-        "column" : 6,
-        "height" : 2,
-        "row" : 2,
-        "width" : 6
-      } ],
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : null,
-      "description" : "An overview of Garden Containers on the platform",
-      "discoveryOptions" : {
-        "query" : "metric_source:cloudfoundry",
-        "selectors" : [ "sf_key:app_name" ]
-      },
-      "eventOverlays" : null,
-      "filters" : {
-        "sources" : null,
-        "time" : null,
-        "variables" : [ {
-          "alias" : "app_name",
-          "applyIfExists" : false,
-          "description" : "null",
-          "preferredSuggestions" : [ ],
-          "property" : "app_name",
-          "replaceOnly" : false,
-          "required" : false,
-          "restricted" : false,
-          "value" : ""
-        }, {
-          "alias" : "app_org",
-          "applyIfExists" : false,
-          "description" : "null",
-          "preferredSuggestions" : [ ],
-          "property" : "app_org",
-          "replaceOnly" : false,
-          "required" : false,
-          "restricted" : false,
-          "value" : ""
-        }, {
-          "alias" : "app_space",
-          "applyIfExists" : false,
-          "description" : "null",
-          "preferredSuggestions" : [ ],
-          "property" : "app_space",
-          "replaceOnly" : false,
-          "required" : false,
-          "restricted" : false,
-          "value" : ""
-        } ]
-      },
-      "groupId" : "DiVXCtHAgAA",
-      "id" : "DiVXMVEAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "locked" : false,
-      "maxDelayOverride" : null,
-      "name" : "Garden Containers",
-      "selectedEventOverlays" : null,
-      "tags" : null
-    }
-  }, {
-    "dashboard" : {
-      "chartDensity" : "DEFAULT",
-      "charts" : [ {
-        "chartId" : "DiVXNPCAgAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXNM3AYAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXNGOAgD0",
-        "column" : 8,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXNFuAYAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXN6PAYJs",
-        "column" : 4,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXOHfAgAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXNIgAcC0",
-        "column" : 4,
-        "height" : 1,
-        "row" : 2,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXNIxAYC0",
-        "column" : 0,
-        "height" : 1,
-        "row" : 2,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXNIyAgAE",
-        "column" : 8,
-        "height" : 1,
-        "row" : 2,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXNFjAcCs",
-        "column" : 0,
-        "height" : 1,
-        "row" : 3,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXNJlAcAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 3,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXNRZAcAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 3,
-        "width" : 4
-      } ],
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : null,
-      "description" : "Overview of all platform components.",
-      "discoveryOptions" : {
-        "query" : "metric_source:cloudfoundry",
-        "selectors" : [ "sf_key:job" ]
-      },
-      "eventOverlays" : null,
-      "filters" : {
-        "sources" : null,
-        "time" : null,
-        "variables" : [ {
-          "alias" : "Job",
-          "applyIfExists" : false,
-          "description" : "CloudFoundry job type",
-          "preferredSuggestions" : [ ],
-          "property" : "job",
-          "replaceOnly" : false,
-          "required" : false,
-          "restricted" : false,
-          "value" : ""
-        } ]
-      },
-      "groupId" : "DiVXCtHAgAA",
-      "id" : "DiVXNFhAgAE",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "locked" : false,
-      "maxDelayOverride" : null,
-      "name" : "CF Overview",
-      "selectedEventOverlays" : null,
-      "tags" : null
-    }
-  }, {
-    "dashboard" : {
-      "chartDensity" : "DEFAULT",
-      "charts" : [ {
-        "chartId" : "DiVXJVqAYAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 0,
-        "width" : 6
-      }, {
-        "chartId" : "DiVXJgNAcAA",
-        "column" : 10,
-        "height" : 2,
-        "row" : 0,
-        "width" : 2
-      }, {
-        "chartId" : "DiVXFwQAcAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXGYlAYAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXJcuAgAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 1,
-        "width" : 6
-      }, {
-        "chartId" : "DiVXF6eAYAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 2,
-        "width" : 6
-      }, {
-        "chartId" : "DiVXG9IAgAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 2,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXJg_AYAI",
-        "column" : 0,
-        "height" : 1,
-        "row" : 3,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXGUJAcAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 3,
-        "width" : 6
-      }, {
-        "chartId" : "DiVXF-uAgAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 4,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXJRMAcAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 4,
-        "width" : 6
-      } ],
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : null,
-      "description" : "Metrics that help you determine when to scale your CF deployment up or down.",
-      "discoveryOptions" : null,
-      "eventOverlays" : null,
-      "filters" : {
-        "sources" : null,
-        "time" : null,
-        "variables" : null
-      },
-      "groupId" : "DiVXCtHAgAA",
-      "id" : "DiVXFg6AgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "locked" : false,
-      "maxDelayOverride" : null,
-      "name" : "Key Capacity Indicators",
-      "selectedEventOverlays" : null,
-      "tags" : null
-    }
-  }, {
-    "dashboard" : {
-      "chartDensity" : "DEFAULT",
-      "charts" : [ {
-        "chartId" : "DiVXRLCAYAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXQitAcAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXPmjAcAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXQ3lAgAE",
-        "column" : 0,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXRPWAcAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXQ3qAgAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXQ34AgAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 2,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXQAaAYAE",
-        "column" : 0,
-        "height" : 1,
-        "row" : 2,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXPp4AYAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 2,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXQzkAYAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 3,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXQhZAgAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 3,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXQ3nAcAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 3,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXRPQAgAI",
-        "column" : 6,
-        "height" : 1,
-        "row" : 4,
-        "width" : 6
-      }, {
-        "chartId" : "DiVXP9lAcAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 4,
-        "width" : 6
-      }, {
-        "chartId" : "DiVXRB-AcAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 5,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXQGxAcAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 5,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXQ3wAcAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 5,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXQNpAYAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 6,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXP6qAgAM",
-        "column" : 4,
-        "height" : 1,
-        "row" : 6,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXQ3nAYAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 7,
-        "width" : 8
-      }, {
-        "chartId" : "DiVXQErAgAE",
-        "column" : 0,
-        "height" : 1,
-        "row" : 7,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXPiYAgAM",
-        "column" : 0,
-        "height" : 1,
-        "row" : 8,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXQ3yAYAE",
-        "column" : 4,
-        "height" : 1,
-        "row" : 8,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXPiXAYCg",
-        "column" : 8,
-        "height" : 1,
-        "row" : 8,
-        "width" : 4
-      } ],
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : null,
-      "description" : "Key Performance Indicators related to Diego",
-      "discoveryOptions" : {
-        "query" : "metric_source:cloudfoundry AND job:(diego_cell diego_brain diego_database)",
-        "selectors" : [ "job:(diego_cell diego_brain diego_database)" ]
-      },
-      "eventOverlays" : null,
-      "filters" : {
-        "sources" : null,
-        "time" : null,
-        "variables" : null
-      },
-      "groupId" : "DiVXCtHAgAA",
-      "id" : "DiVXPW-AcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "locked" : false,
-      "maxDelayOverride" : null,
-      "name" : "Diego",
-      "selectedEventOverlays" : null,
-      "tags" : null
-    }
-  }, {
-    "dashboard" : {
-      "chartDensity" : "DEFAULT",
-      "charts" : [ {
-        "chartId" : "DiVXO0sAcAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXO7fAYAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXOcWAYAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXO9DAgAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 1,
-        "width" : 6
-      }, {
-        "chartId" : "DiVXOclAgAA",
-        "column" : 6,
-        "height" : 1,
-        "row" : 1,
-        "width" : 6
-      } ],
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : null,
-      "description" : "Host-specific dashboard.",
-      "discoveryOptions" : {
-        "query" : "metric_source:cloudfoundry",
-        "selectors" : [ "_exists_:host", "sf_key:host" ]
-      },
-      "eventOverlays" : null,
-      "filters" : {
-        "sources" : null,
-        "time" : null,
-        "variables" : [ {
-          "alias" : "Host",
-          "applyIfExists" : false,
-          "description" : "Cloud Foundry IP address",
-          "preferredSuggestions" : [ ],
-          "property" : "host",
-          "replaceOnly" : false,
-          "required" : false,
-          "restricted" : false,
-          "value" : ""
-        } ]
-      },
-      "groupId" : "DiVXCtHAgAA",
-      "id" : "DiVXOPHAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "locked" : false,
-      "maxDelayOverride" : null,
-      "name" : "CF Host",
-      "selectedEventOverlays" : null,
-      "tags" : null
-    }
-  }, {
-    "dashboard" : {
-      "chartDensity" : "DEFAULT",
-      "charts" : [ {
-        "chartId" : "DiVXLruAYAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 0,
-        "width" : 3
-      }, {
-        "chartId" : "DiVXK5NAcAA",
-        "column" : 3,
-        "height" : 1,
-        "row" : 0,
-        "width" : 3
-      }, {
-        "chartId" : "DiVXLqpAcAA",
-        "column" : 6,
-        "height" : 1,
-        "row" : 0,
-        "width" : 3
-      }, {
-        "chartId" : "DiVXLy6AgAA",
-        "column" : 9,
-        "height" : 1,
-        "row" : 0,
-        "width" : 3
-      }, {
-        "chartId" : "DiVXJ_rAcAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXLieAgAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXKPaAYAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXKnhAgAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 2,
-        "width" : 4
-      }, {
-        "chartId" : "DiVXLYnAYAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 2,
-        "width" : 4
-      } ],
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : null,
-      "description" : "Key Performance Indicators around the Gorouter system.",
-      "discoveryOptions" : {
-        "query" : "metric_source:cloudfoundry AND job:router",
-        "selectors" : [ "_exists_:host", "sf_key:host" ]
-      },
-      "eventOverlays" : null,
-      "filters" : {
-        "sources" : null,
-        "time" : null,
-        "variables" : null
-      },
-      "groupId" : "DiVXCtHAgAA",
-      "id" : "DiVXJycAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "locked" : false,
-      "maxDelayOverride" : null,
-      "name" : "Router",
-      "selectedEventOverlays" : null,
-      "tags" : null
-    }
-  } ],
-  "groupExport" : {
-    "group" : {
-      "created" : 0,
-      "creator" : null,
-      "dashboards" : [ "DiVXMVEAYAA", "DiVXDktAYAA", "DiVXOPHAcAA", "DiVXNFhAgAE", "DiVXCwFAcAA", "DiVXDOmAcHA", "DiVXL7QAcHI", "DiVXPW-AcAA", "DiVXFg6AgAA", "DiVXJycAgAA" ],
-      "description" : "",
-      "email" : null,
-      "id" : "DiVXCtHAgAA",
-      "importQualifiers" : [ {
-        "filters" : [ {
-          "not" : false,
-          "property" : "metric_source",
-          "values" : [ "cloudfoundry" ]
-        } ],
-        "metric" : "system.cpu.sys"
-      } ],
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Cloud Foundry",
-      "teams" : null
+  "chartExports": [
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Whether CF App requests from the CC are synced to the BBS (< 1 indicates a problem)",
+        "id": "DiVXQhZAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Cloud Controller and Diego in Sync",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 0.99,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 14
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 0.99,
+              "paletteIndex": 16
+            }
+          ],
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Average Status in Last 5 Minutes",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('bbs.Domain.cf-apps', extrapolation='zero').mean(over='5m').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "No data",
+        "id": "DiVXQ3wAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Auctioneer Time to Fetch Cell State",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 10,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 5,
+              "gte": null,
+              "lt": null,
+              "lte": 10,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 5,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "auctioneer.AuctioneerFetchStatesDuration - Maximum(5m) - Scale:1e-9",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('auctioneer.AuctioneerFetchStatesDuration', extrapolation='zero').max(over='5m').scale(1e-9).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Rate of change of server errors (5xx responses)",
+        "id": "DiVXJ_rAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Router Error: Server Error",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Error Rate of Change",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rate of change in server errors per minute",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('gorouter.responses.5xx').mean(over='1m').rateofchange().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXQ3lAgAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top containers per cell",
+        "options": {
+          "colorBy": "Metric",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "job"
+              },
+              {
+                "enabled": true,
+                "property": "bosh_id"
+              },
+              {
+                "enabled": false,
+                "property": "deployment"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": null,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "rep.ContainerCount - Top 10",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('rep.ContainerCount', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'diego_cell'), rollup='latest').top(count=10).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "How many messages were dropped due to either slow consuming nozzle or overburdened Doppler servers",
+        "id": "DiVXC13AgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Firehose Dropped Messages",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "DopplerServer.doppler.shedEnvelopes",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "DopplerServer.TruncatingBuffer.totalDroppedMessages",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Dropped Messages",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('DopplerServer.doppler.shedEnvelopes', extrapolation='zero').publish(label='A', enable=False)\nB = data('DopplerServer.TruncatingBuffer.totalDroppedMessages').publish(label='B', enable=False)\nC = (A+B).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXDihAcAg",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "CPU Utilization",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "% CPU Load",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "app_id"
+              },
+              {
+                "enabled": true,
+                "property": "app_name"
+              },
+              {
+                "enabled": true,
+                "property": "app_instance_index"
+              },
+              {
+                "enabled": false,
+                "property": "app_org"
+              },
+              {
+                "enabled": false,
+                "property": "app_space"
+              },
+              {
+                "enabled": false,
+                "property": "deployment"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "id"
+              },
+              {
+                "enabled": false,
+                "property": "job"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": true,
+                "property": "sf_metric"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": "app_instance_index",
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "container.cpu_percentage",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container.cpu_percentage').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXJRMAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Router VM CPU Utilization - Info",
+        "options": {
+          "markdown": "Metric(s): <code>system.cpu.user</code> of Gorouter VM(s)\n\nHigh CPU utilization of the Gorouter VMs can increase latency and cause throughput, or requests per/second, to level-off. Pivotal recommends keeping the CPU utilization within a maximum range of 60-70% for best Gorouter performance. \n\nIf you want to increase throughput capabilities while also keeping latency low, Pivotal recommends scaling the Gorouter while continuing to ensure that CPU utilization does not exceed the maximum recommended range.\n\nExcessive dropped messages can indicate the Dopplers are not processing messages fast enough. \n\nThe recommended scaling indicator is to look at the total dropped as a percentage of the total throughput and scale if the derived loss rate value grows greater than 0.1.\n\nRecommended thresholds:\t\n<b>Scale indicator: ≥ 60%\n\nIf alerting:\nYellow warning: ≥ 60%\nRed critical: ≥ 70%</b>\n\nHow to scale up:\tResolve high utilization by scaling the Gorouters horizontally or vertically (the Router VM in the Resource Config pane of the Elastic Runtime tile).",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Top system disk usage by host",
+        "id": "DiVXNRZAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "System Disk Used %",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": true,
+                "property": "job"
+              },
+              {
+                "enabled": true,
+                "property": "index"
+              },
+              {
+                "enabled": false,
+                "property": "ip"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "role"
+              },
+              {
+                "enabled": false,
+                "property": "bosh_id"
+              },
+              {
+                "enabled": false,
+                "property": "deployment"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "system.disk.system.percent - Top 10",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('system.disk.system.percent').top(count=10).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXMJHAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Total Memory",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Bytes",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "rep.CapacityRemainingMemory - Sum - Scale:1048576",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Total",
+              "label": "C",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Used",
+              "label": "D",
+              "paletteIndex": 11,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('rep.CapacityRemainingMemory', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry')).sum().scale(1048576).publish(label='A', enable=False)\nC = data('rep.CapacityTotalMemory', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry')).sum().scale(1048576).publish(label='C')\nD = (C - A).publish(label='D')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Gorouter Metrics",
+        "id": "DiVXLruAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": " ",
+        "options": {
+          "markdown": "<h3>Gorouter Metrics</h3>\n\n<a href=\"https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#gorouter\">https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#gorouter</a>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "percentile distribution",
+        "id": "DiVXN6PAYJs",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Memory Used %",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "memory %",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "system.mem.percent",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Minimum",
+              "label": "B",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "P10",
+              "label": "C",
+              "paletteIndex": 15,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "P50",
+              "label": "D",
+              "paletteIndex": 2,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "P90",
+              "label": "E",
+              "paletteIndex": 9,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Maximum",
+              "label": "F",
+              "paletteIndex": 7,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('system.mem.percent', filter=filter('metric_source', 'cloudfoundry')).publish(label='A', enable=False)\nB = (A).min().publish(label='B')\nC = (A).percentile(pct=10).publish(label='C')\nD = (A).percentile(pct=50).publish(label='D')\nE = (A).percentile(pct=90).publish(label='E')\nF = (A).max().publish(label='F')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXDgPAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Disk Util/Quota",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Disk Space (Bytes)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "app_id"
+              },
+              {
+                "enabled": true,
+                "property": "app_name"
+              },
+              {
+                "enabled": true,
+                "property": "app_instance_index"
+              },
+              {
+                "enabled": false,
+                "property": "app_org"
+              },
+              {
+                "enabled": false,
+                "property": "app_space"
+              },
+              {
+                "enabled": false,
+                "property": "deployment"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "id"
+              },
+              {
+                "enabled": false,
+                "property": "job"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": true,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "bosh_id"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": "app_instance_index",
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "container.disk_bytes",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": "AreaChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "container.disk_bytes_quota",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": "AreaChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container.disk_bytes', filter=filter('app_name', 'pivotal-account')).publish(label='A')\nB = data('container.disk_bytes_quota', filter=filter('app_name', 'pivotal-account')).publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Top ephemeral disk usage by host",
+        "id": "DiVXNIyAgAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Ephemeral Disk Used %",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": true,
+                "property": "job"
+              },
+              {
+                "enabled": true,
+                "property": "index"
+              },
+              {
+                "enabled": false,
+                "property": "ip"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "role"
+              },
+              {
+                "enabled": false,
+                "property": "bosh_id"
+              },
+              {
+                "enabled": false,
+                "property": "deployment"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "system.disk.ephemeral.percent - Top 10",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('system.disk.ephemeral.percent').top(count=10).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "The lifetime number of requests completed by the Gorouter VM",
+        "id": "DiVXLy6AgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Router Throughput",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": "sf_originatingMetric",
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "gorouter.total_requests - Delta",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Sum over all indexes",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Divided by 5",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Average over the last 5 minutes",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('gorouter.total_requests').delta().publish(label='A', enable=False)\nB = (A).sum().publish(label='B', enable=False)\nC = (B/5).publish(label='C', enable=False)\nD = (C).mean(over='5m').publish(label='D')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Total # of containers in the Garden",
+        "id": "DiVXNDGAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Total Containers",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Total Containers",
+              "label": "A",
+              "paletteIndex": 13,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container.cpu_percentage').count().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXDgTAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Memory Util/Quota",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "RAM",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "app_id"
+              },
+              {
+                "enabled": true,
+                "property": "app_name"
+              },
+              {
+                "enabled": true,
+                "property": "app_instance_index"
+              },
+              {
+                "enabled": false,
+                "property": "app_org"
+              },
+              {
+                "enabled": false,
+                "property": "app_space"
+              },
+              {
+                "enabled": false,
+                "property": "deployment"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "id"
+              },
+              {
+                "enabled": false,
+                "property": "job"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": true,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "bosh_id"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": "app_instance_index",
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "container.memory_bytes",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": "AreaChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "container.memory_bytes_quota",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": "AreaChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container.memory_bytes').publish(label='A')\nB = data('container.memory_bytes_quota').publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "percentile distribution",
+        "id": "DiVXNFuAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Total CPU load",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "# cores used",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Metric",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "system.cpu.sys",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "system.cpu.user",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "A+B - Mean by host",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Minimum",
+              "label": "E",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Maximum",
+              "label": "F",
+              "paletteIndex": 7,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "P10",
+              "label": "G",
+              "paletteIndex": 2,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "P50",
+              "label": "H",
+              "paletteIndex": 6,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "P90",
+              "label": "I",
+              "paletteIndex": 5,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('system.cpu.sys', filter=filter('metric_source', 'cloudfoundry')).publish(label='A', enable=False)\nB = data('system.cpu.user', filter=filter('metric_source', 'cloudfoundry')).publish(label='B', enable=False)\nC = (A+B).mean(by=['host']).publish(label='C', enable=False)\nE = (C).min().publish(label='E')\nF = (C).max().publish(label='F')\nG = (C).percentile(pct=10).publish(label='G')\nH = (C).percentile(pct=50).publish(label='H')\nI = (C).percentile(pct=90).publish(label='I')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Top CPU usage by host",
+        "id": "DiVXNIxAYC0",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top CPU load",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": true,
+                "property": "job"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "role"
+              },
+              {
+                "enabled": false,
+                "property": "bosh_id"
+              },
+              {
+                "enabled": true,
+                "property": "index"
+              },
+              {
+                "enabled": false,
+                "property": "deployment"
+              }
+            ]
+          },
+          "maximumPrecision": 2,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "system.cpu.user",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "system.cpu.sys",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "A + B - Top 10",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('system.cpu.user').publish(label='A', enable=False)\nB = data('system.cpu.sys').publish(label='B', enable=False)\nC = (A + B).top(count=10).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Top 10 CPU users among Garden Containers",
+        "id": "DiVXMZjAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "CPU Utilization (%)",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "app_name"
+              },
+              {
+                "enabled": false,
+                "property": "app_id"
+              },
+              {
+                "enabled": true,
+                "property": "app_instance_index"
+              },
+              {
+                "enabled": false,
+                "property": "bosh_id"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "job"
+              },
+              {
+                "enabled": false,
+                "property": "deployment"
+              },
+              {
+                "enabled": false,
+                "property": "app_org"
+              },
+              {
+                "enabled": false,
+                "property": "app_space"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "CPU Utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container.cpu_percentage', filter=filter('metric_source', 'cloudfoundry')).top(count=10).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Doppler Server Metrics",
+        "id": "DiVXDNmAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": " ",
+        "options": {
+          "markdown": "<h3>Doppler Server Metrics</h3>\n\n<a href=\"https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#doppler-server\">https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#doppler-server</a>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXLqpAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# Routes",
+        "options": {
+          "colorBy": "Metric",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "gorouter.total_routes - Sum by host",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('gorouter.total_routes', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'router'), rollup='latest').sum(by=['host']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXPiYAgAM",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": " ",
+        "options": {
+          "markdown": "<h3>Diego router-emitter Metrics</h3>\n\n<a href=\"https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#route_emitter\">https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#route_emitter</a>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Time in milliseconds since the last route register was received",
+        "id": "DiVXLYnAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Time Since Last Route Register Received",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 30000,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 30000,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "gorouter.ms_since_last_registry_update - Maximum(5m)",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('gorouter.ms_since_last_registry_update').max(over='5m').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXEKKAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Requests",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Requests/sec",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Requests Outstanding",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Requests Completed",
+              "label": "B",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('cc.requests.outstanding').publish(label='A')\nB = data('cc.requests.completed').publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "percentile distribution",
+        "id": "DiVXOHfAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Ephemeral Disk Used %",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "ephemeral disk %",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "system.disk.ephemeral.percent",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Minimum",
+              "label": "B",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "P10",
+              "label": "C",
+              "paletteIndex": 2,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "P50",
+              "label": "D",
+              "paletteIndex": 6,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "P90",
+              "label": "E",
+              "paletteIndex": 5,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Maximum",
+              "label": "F",
+              "paletteIndex": 7,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 86400000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('system.disk.ephemeral.percent', filter=filter('metric_source', 'cloudfoundry')).publish(label='A', enable=False)\nB = (A).min().publish(label='B')\nC = (A).percentile(pct=10).publish(label='C')\nD = (A).percentile(pct=50).publish(label='D')\nE = (A).percentile(pct=90).publish(label='E')\nF = (A).max().publish(label='F')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Total number of LRP instances that have crashed (5 Min. Average)",
+        "id": "DiVXP9lAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Crashed App Instances",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Crashed LRPs (5 Min. Average)",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('bbs.CrashedActualLRPs').mean(over='5m').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Percentage of Firehose messages lost",
+        "id": "DiVXJg_AYAI",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Firehose Loss Rate",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "% Messages Lost",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": "sf_metric",
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "DopplerServer.listeners.totalReceivedMessageCount - Sum",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "DopplerServer.TruncatingBuffer.totalDroppedMessages - Sum",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "DopplerServer.doppler.shedEnvelopes - Sum",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Percentage Lost",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('DopplerServer.listeners.totalReceivedMessageCount', rollup='sum').sum().publish(label='A', enable=False)\nB = data('DopplerServer.TruncatingBuffer.totalDroppedMessages', extrapolation='zero').sum().publish(label='B', enable=False)\nC = data('DopplerServer.doppler.shedEnvelopes', extrapolation='zero').sum().publish(label='C', enable=False)\nD = ((B+C)/A).scale(100).publish(label='D')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXDKWAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Memory Allocated",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Bytes Allocated",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Metric",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Bytes Allocated Heap",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Bytes Allocated Stack",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('DopplerServer.memoryStats.numBytesAllocatedHeap').publish(label='A')\nB = data('DopplerServer.memoryStats.numBytesAllocatedStack').publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "RAM and swap usage",
+        "id": "DiVXO0sAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Memory Usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Percent",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "system.swap.percent",
+              "label": "A",
+              "paletteIndex": 2,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "system.mem.percent",
+              "label": "B",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('system.swap.percent').publish(label='A')\nB = data('system.mem.percent').publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXQitAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Total Memory",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Bytes",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "rep.CapacityRemainingMemory - Sum - Scale:1048576",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Total",
+              "label": "C",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Used",
+              "label": "D",
+              "paletteIndex": 11,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('rep.CapacityRemainingMemory', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry')).sum().scale(1048576).publish(label='A', enable=False)\nC = data('rep.CapacityTotalMemory', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry')).sum().scale(1048576).publish(label='C')\nD = (C - A).publish(label='D')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXL-yAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Total Disk",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Bytes",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Metric",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": true,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "rep.CapacityRemainingDisk - Sum - Scale:1000000",
+              "label": "A",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Total",
+              "label": "E",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Used",
+              "label": "F",
+              "paletteIndex": 11,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('rep.CapacityRemainingDisk', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry'), rollup='latest').sum().scale(1000000).publish(label='A', enable=False)\nE = data('rep.CapacityTotalDisk', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry')).sum().scale(1000000).publish(label='E')\nF = (E - A).publish(label='F')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXGUJAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Firehose Loss Rate - Info",
+        "options": {
+          "markdown": "Metric(s): <code>(DopplerServer.TruncatingBuffer.totalDroppedMessages + DopplerServer.doppler.shedEnvelopes) / DopplerServer.listeners.totalReceivedMessageCount</code>\n\nThis derived value represents the firehose loss rate, or the total messages dropped as a percentage of the total message throughput.\n\nExcessive dropped messages can indicate the Dopplers are not processing messages fast enough. \n\nThe recommended scaling indicator is to look at the total dropped as a percentage of the total throughput and scale if the derived loss rate value grows greater than 0.1.\n\nRecommended thresholds:\t\n<b>Scale indicator: ≥ 0.1\nIf alerting:\nYellow warning: ≥ 0.05\nRed critical: ≥ 0.1</b>\n\n\n\nHow to scale up:\tScale up the Firehose log receiver and Dopplers.",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Top swap usage by host",
+        "id": "DiVXNFjAcCs",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "System Swap Used %",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": true,
+                "property": "job"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "role"
+              },
+              {
+                "enabled": false,
+                "property": "bosh_id"
+              },
+              {
+                "enabled": true,
+                "property": "index"
+              },
+              {
+                "enabled": false,
+                "property": "deployment"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "system.swap.percent - Top 10",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('system.swap.percent').top(count=10).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "This should stay below 10s",
+        "id": "DiVXPp4AYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "BBS Time to Run LRP Convergence",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 20,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 10,
+              "gte": null,
+              "lt": null,
+              "lte": 20,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 10,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Max Duration (15 Min. Window)",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('bbs.ConvergenceLRPDuration').max(over='15m').scale(1e-9).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Time in seconds that the active route-emitter took to perform its synchronization pass",
+        "id": "DiVXQ3yAYAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Route Emitter Time to Sync",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": "metric_source",
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Last 15min max (in seconds) that the active route-emitter took to perform its synchronization pass",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('route_emitter.RouteEmitterSyncDuration').max(over='15m').scale(1e-9).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXJVqAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Diego Cell Memory Capacity - Info",
+        "options": {
+          "markdown": "Metric(s):\n<code>rep.CapacityRemainingMemory / rep.CapacityTotalMemory</code>\n\nPercentage of remaining memory capacity for a given cell. Monitor this derived metric across all cells in a deployment. \n\nThe metric <code>rep.CapacityRemainingMemory</code> indicates the remaining amount in MiB of memory available for this cell to allocate to containers.\n\nThe metric <code>rep.CapacityTotalMemory</code> indicates the total amount in MiB of memory available for this cell to allocate to containers.\n\nA best practice deployment of Cloud Foundry includes three availability zones (AZs). For these types of deployments, Pivotal recommends that you have enough capacity to suffer failure of an entire AZ. \n\nThe Recommended threshold assumes a three AZ configuration. Adjust the threshold percentage if you have more or less AZs.\n\nRecommended thresholds:<br>\n<b>< avg(30%)</b>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXP6qAgAM",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Auctioneer Task Placement Failures",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 1,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 0.5,
+              "gte": null,
+              "lt": null,
+              "lte": 1,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 0.5,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "auctioneer.AuctioneerTaskAuctionsFailed",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "A - Delta",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "B - Mean(5m)",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('auctioneer.AuctioneerTaskAuctionsFailed', extrapolation='zero').publish(label='A')\nB = (A).delta().publish(label='B')\nC = (B).mean(over='5m').publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Percentage of disk space remaining on all Diego cells",
+        "id": "DiVXG9IAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Diego Cell Disk Capacity",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 30,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 14
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 30,
+              "paletteIndex": 16
+            }
+          ],
+          "maximumPrecision": 4,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Remaining",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Total",
+              "label": "B",
+              "paletteIndex": 14,
+              "plotType": "AreaChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Used",
+              "label": "C",
+              "paletteIndex": 4,
+              "plotType": "AreaChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('rep.CapacityRemainingDisk', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry')).sum().scale(1048576).publish(label='A', enable=False)\nB = data('rep.CapacityTotalDisk', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry')).sum().scale(1048576).publish(label='B', enable=False)\nC = (A/B).scale(100).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "1=healthy, 0=unhealthy",
+        "id": "DiVXO9DAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "System Health",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 0,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 14
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 0,
+              "paletteIndex": 16
+            }
+          ],
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Health",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('system.healthy').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXDJPAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Messages Sent Through Firehose",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "# Messages/sec",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Messages/sec",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('DopplerServer.sentMessagesFirehose').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Rate of change in app instances being started or stopped on the platform",
+        "id": "DiVXRPQAgAI",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Rate of Change of Running App Instances",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "bbs.LRPsRunning - Mean(1h)",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "bbs.LRPsRunning - Timeshift 1h - Mean(1h)",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Change in # of Running Apps (1 Hour Average)",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('bbs.LRPsRunning').mean(over='1h').publish(label='A', enable=False)\nB = data('bbs.LRPsRunning').timeshift('1h').mean(over='1h').publish(label='B', enable=False)\nC = (A-B).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "This should stay below 5s",
+        "id": "DiVXQ34AgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "BBS Time to Handle Requests",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 10,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 5,
+              "gte": null,
+              "lt": null,
+              "lte": 10,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 5,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Max Latency (15 Min. Window)",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('bbs.RequestLatency').scale(1e-9).max(over='15m').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Top 10 consumers of RAM among Garden Containers",
+        "id": "DiVXNFhAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Memory Utilization (%)",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "app_name"
+              },
+              {
+                "enabled": false,
+                "property": "app_id"
+              },
+              {
+                "enabled": true,
+                "property": "app_instance_index"
+              },
+              {
+                "enabled": false,
+                "property": "bosh_id"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "job"
+              },
+              {
+                "enabled": false,
+                "property": "deployment"
+              },
+              {
+                "enabled": false,
+                "property": "app_org"
+              },
+              {
+                "enabled": false,
+                "property": "app_space"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "container.memory_bytes",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "container.memory_bytes_quota",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Percentage Memory Used",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container.memory_bytes').publish(label='A', enable=False)\nB = data('container.memory_bytes_quota').publish(label='B', enable=False)\nC = (A/B).scale(100).top(count=10).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "0=healthy, 1=unhealthy",
+        "id": "DiVXNGOAgD0",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Diego Cell Health",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "job"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "bosh_id"
+              },
+              {
+                "enabled": false,
+                "property": "deployment"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "rep.UnhealthyCell",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('rep.UnhealthyCell').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXJcuAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Diego Cell Container Capacity - Info",
+        "options": {
+          "markdown": "Metric(s): <code>rep.CapacityRemainingContainers / rep.CapacityTotalContainers</code>\n\nPercentage of remaining container capacity for a given cell. Monitor this derived metric across all cells in a deployment. \n\nThe metric <code>rep.CapacityRemainingContainers</code> indicates the remaining number of containers this cell can host.\nThe metric by <code>rep.CapacityTotalContainer</code> indicates the total number of containers this cell can host.\n\nA best practice deployment of Cloud Foundry includes three availability zones (AZs). For these types of deployments, Pivotal recommends that you have enough capacity to suffer failure of an entire AZ. \n\nThe Recommended threshold assumes a three AZ configuration. Adjust the threshold percentage if you have more or less AZs.\n\nRecommended thresholds:<br>\n<b>< avg(30%)</b>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXDmlAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Rate of outstanding requests",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "outstanding %",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "growth %",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Metric",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Requests Outstanding",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Requests Completed",
+              "label": "B",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "outstanding request %",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "C - Timeshift 1d",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "C - Timeshift 1w",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "day-over-day growth %",
+              "label": "F",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            },
+            {
+              "displayName": "week-over-week growth %",
+              "label": "G",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('cc.requests.outstanding').publish(label='A', enable=False)\nB = data('cc.requests.completed').publish(label='B', enable=False)\nC = ((B/A+B) * 100).publish(label='C')\nD = (C).timeshift('1d').publish(label='D', enable=False)\nE = (C).timeshift('1w').publish(label='E', enable=False)\nF = (A/D-1).publish(label='F')\nG = (A/E-1).publish(label='G')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXFRQAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Logging Rates",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Log Messages/sec",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Error",
+              "label": "A",
+              "paletteIndex": 5,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Fatal",
+              "label": "B",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Warning",
+              "label": "C",
+              "paletteIndex": 6,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('cc.log_count.error').publish(label='A')\nB = data('cc.log_count.fatal').publish(label='B')\nC = data('cc.log_count.warn').publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Top memory usage by host",
+        "id": "DiVXNIgAcC0",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "System Memory Used %",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": true,
+                "property": "job"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "role"
+              },
+              {
+                "enabled": false,
+                "property": "bosh_id"
+              },
+              {
+                "enabled": true,
+                "property": "index"
+              },
+              {
+                "enabled": false,
+                "property": "deployment"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "system.mem.percent - Top 10",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('system.mem.percent').top(count=10).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Consul health status. 0  is healthy, and 1 means that Consul is down",
+        "id": "DiVXPiXAYCg",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Consul Up or Down",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 0.99,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 0.99,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Last 5 minute status of Consul health",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('route_emitter.ConsulDownMode').mean(over='5m').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXF6eAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Diego Cell Disk Capacity - Info",
+        "options": {
+          "markdown": "Metric(s): <code>rep.CapacityRemainingDisk / rep.CapacityTotalDisk</code>\n\nPercentage of remaining disk capacity for a given cell. Monitor this derived metric across all cells in a deployment. \n\nThe metric <code>rep.CapacityRemainingDisk</code> indicates the remaining amount in MiB of disk available for this cell to allocate to containers.\n\nThe metric <code>rep.CapacityTotalDisk</code> indicates the total amount in MiB of disk available for this cell to allocate to containers.\n\nA best practice deployment of Cloud Foundry includes three availability zones (AZs). For these types of deployments, Pivotal recommends that you have enough capacity to suffer failure of an entire AZ. \n\nThe Recommended threshold assumes a three AZ configuration. Adjust the threshold percentage if you have more or less AZs.\n\nRecommended thresholds: <br>\n<b>< avg(30%) </b>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Percentage of RAM available for containers",
+        "id": "DiVXGYlAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Diego Cell Memory Capacity",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 30,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 14
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 30,
+              "paletteIndex": 16
+            }
+          ],
+          "maximumPrecision": 4,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Total",
+              "label": "A",
+              "paletteIndex": 14,
+              "plotType": "AreaChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Remaining",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Used",
+              "label": "C",
+              "paletteIndex": 4,
+              "plotType": "AreaChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('rep.CapacityTotalMemory', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'diego_cell')).sum().scale(1048576).publish(label='A', enable=False)\nB = data('rep.CapacityRemainingMemory', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'diego_cell')).sum().scale(1048576).publish(label='B', enable=False)\nC = (B/A).scale(100).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXEqkAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# Running Tasks by controller",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Running Tasks",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('cc.tasks_running.count', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'cloud_controller')).sum(by=['host']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXK5NAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Routing Rates",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Responses/sec",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Requests/sec",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Responses",
+              "label": "A",
+              "paletteIndex": 2,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Requests",
+              "label": "B",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('gorouter.responses').publish(label='A')\nB = data('gorouter.total_requests').publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Ephemeral and system disk usage",
+        "id": "DiVXOcWAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Disk Usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Percent",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "System",
+              "label": "A",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Ephemeral",
+              "label": "B",
+              "paletteIndex": 4,
+              "plotType": "LineChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('system.disk.system.percent').publish(label='A')\nB = data('system.disk.ephemeral.percent').publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Time in seconds that the nsync-bulker took to synchronize CF apps and Diego DesiredLRPs.",
+        "id": "DiVXQ3nAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Nsync-bulker Time to Sync",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 20,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 10,
+              "gte": null,
+              "lt": null,
+              "lte": 20,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 10,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Seconds that the nsync-bulker took to synchronize CF apps and Diego DesiredLRPs",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('nsync_bulker.DesiredLRPSyncDuration').max(over='5m').scale(1e-9).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXQNpAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Auctioneer App Instance Placement Failures",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 1,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 0.5,
+              "gte": null,
+              "lt": null,
+              "lte": 1,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 0.5,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "auctioneer.AuctioneerLRPAuctionsFailed - Mean(1m)",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "A - Delta",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "B - Mean(5m)",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('auctioneer.AuctioneerLRPAuctionsFailed', extrapolation='zero').mean(over='1m').publish(label='A')\nB = (A).delta().publish(label='B')\nC = (B).mean(over='5m').publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "1=healthy, 0=unhealthy",
+        "id": "DiVXOclAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "System Health",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Health",
+              "label": "A",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('system.healthy').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXNJlAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Authentication Failures",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Failures/sec",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "uaa.audit_service.client_authentication_failure_count",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "uaa.audit_service.principal_authentication_failure_count",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "uaa.audit_service.user_authentication_failure_count",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "uaa.audit_service.user_not_found_count",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "uaa.audit_service.user_password_failures",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "uaa.audit_service.principal_not_found_count",
+              "label": "F",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Failures",
+              "label": "G",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('uaa.audit_service.client_authentication_failure_count', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'uaa')).publish(label='A', enable=False)\nB = data('uaa.audit_service.principal_authentication_failure_count', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'uaa')).publish(label='B', enable=False)\nC = data('uaa.audit_service.user_authentication_failure_count', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'uaa')).publish(label='C', enable=False)\nD = data('uaa.audit_service.user_not_found_count', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'uaa')).publish(label='D', enable=False)\nE = data('uaa.audit_service.user_password_failures', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'uaa')).publish(label='E', enable=False)\nF = data('uaa.audit_service.principal_not_found_count', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'uaa')).publish(label='F', enable=False)\nG = (A+B+C+D+E+F).sum().publish(label='G')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXJgNAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": " ",
+        "options": {
+          "markdown": "<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAABjCAYAAADeg0+zAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAsTAAALEwEAmpwYAAABWWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgpMwidZAAAwR0lEQVR4Ae1dB3xUVdY/EBJaAgkklNASEnqXqoIggmABxC6CIMWCiLufrLtr110L/Na2omJ3sQC6K4ggKlKkSJEiSCdAIBA6JISS0Ob7/8/MmbxMJoSQUEzmQN6bd8u57Zx7yr33vWIugAQg0AOBHvDbA8X9hgYCAz0Q6AHtgQCDBAgh0ANn6IESZ4gLRF3AHsim6RYTKYZ/Abi4PRBgkIvQ/2QG/uN/QrFibkawO8MsjZdxkKa4Jx3jA3BheqAYBiBgpF+YvpbT7Gr8FS9+bpqtMg3yk5GczHSBql8kiwkwyAUYdjIGZYSTqI9kZMjBtFTZm3JQDqSmCp/Tj2fIqVMnJTg4REqFlJSw0qUlKjxCIsuHS3hYmIQEZQr806dPBxjlAoxdZo9fgMKKWhFkDMoKU42OZKTLxqRtsmTDWlm4ZaP8vHO7JBzcK3LsiAgIXlz8g5ShKkUpUxzDE1pe2kdWlnbVaknb+HrSAn8xVatKkEcKmQLgZL6i1s/ns70BCXIeetdUIVOldkNKLFi9UiYuXShjN6wSOXJIJLikSMnSUgKSIhqSIRhMEaSqE3gFPHIKjJIOhkk+eUIEjCUZxxBxSqRiFXm88WVyfcu20rxOPSlbspS2gBLFyjsPTSqyKAMMUsBDb1KDUiD1yBH5/tcF8vKs7+W3bRtFSpURKRMmsSWCVT3KAAMcATccwf0k6uE2BnmFQY5rCO6hxYtJmWLFlYGOgwmSoIbJkVStdf8mbWRw525yecMmKlECapd2S4FeAgxSgN3pnMVXbk6Qf0wcL//9bb5IRCWJKR0KJnDJMTBEChiCEoKgBjfv+uS+u2PcDAOly6N2gb/ANuXAMKXBMCcoXVIPiJzIkH907S1DrusplWGvBFQuT0cW0C3AIAXUkcYclCCT5v8st0z4SOT4cWlQIUoOnjole6EekfD5d24+LHde5icz0XisBknkAqMk7t4u7eMbyZt33SvN4+oihmoa7B/aMgHIVw8EGCRf3efObMxxFOrPmCkT5dFvPlNboU5IKdl44jjFhBK0SYYCKFKZ5CSYoCSkSVxwsKxJ2Q+uKSHf939IurVqq0UEmCT/PR1gkHz2oTEHPVQvffmZvPDj1xIbHQMDW2QnXLYlwBwFyRjO6lI+UAUjI8TDNZyQDkM+7YB8PfBP0vvKjpqUKlfAw+Xstbz9Pldpn7dSCmnq01Bv6Dk6ARXq1a8nyAs//FfqV68t+2FMn2/mYJeS8VTdAhMmQFLVhEerTHiU3PzBKzJt8QLtdTKH2SUaELjkqQcCDJKn7spMTKIrDvWGMG7mj/L0d+PBHPGy7eRJOQQGOZ+SI7MW7l9kFJa3DS7hirBL6BS4/pPRsmzjek0QYBDfHjv75wCDnH1fZUmpe6kQsmDNKun/1UcSVbmW7IEhfvQCM4dVikzCtZQkMEkcbB/CI+M/Ea7BUMpRFQxA3nsgwCB57zMlNkqPPakp8tjXn+uiX9kSQXIAqhaJlMR6MYAswPI3Qd2qW76CzNu8Rj7+carbcwYmCUiSvI9KgEHOos9IWPbHmdiM3v/OmSnzElZJnbBwSYRqRTXnYs/TLJ/12wNJUqFiVfn7T5Nl4ZrftZWsu7UjwCxnMfBIEmCQHPqJBEQjnHcSnP1RXeHvDduT5KGZU6HvV5YUqFY0li+W5PBtQhACUsAMEXD7Et6f8b3QBR0UFORtB9vgbqOb+TVh4JKtBwIM4tMlSjQeKUE1ioREyMCMnHr0iOw/lKp6/f/mzxY5nCq1sJeKXqtLqSPJqFwkpCetSvmK8vHvi2Xh6t+VgU9yP5cH2Dam452uYk4IAcjaA4F1EE9/kDH4Zxv+SGS7Dx6QxJ3JsnrrFlmRtEW2w+bYj/WOxKOHZRt24JbBJkMsA6pa5WajrJ17MZ9YH+7vCgfxp4C5W5aLkPY1YqQcNkiWK11GqlWoKHWq15AaUZUlEltUuFGSYCqkTQwaWIQvAQYhUZAxPATCPVKrt2yS75cuks9XLZOVyYnYMoINgiGlYQGHYGqGAgNVpQx+kwD5d6kxB6qk4GYSF5ikuKRwRR8ST7fUw5mgO4OxP6xl1ZrSo05DubpJc7msbn0JLYV2AgKMot0gRZpBKCVcVI9gVxDWJW2V8XNmyHMLZrmJKSxCapQuK2XBEMfBOMehgpxEJu6q4loHNqJfssyhDfLUj0xcEW0MB3OTaTgZsMUpcCzsSsdZFG6/R1zfJq1lYMeuckXjplKS6ykAStWiLE2KLINw4AkcfNoW9EgN/n4itmocFCkfKfWwKn0Y+vpuzLbc8+ROrDncROYOydOVWDyYFMeFlDy0LqzNVmnu44oMKo4t9UGqhu1OS4FIPCEPt+kkD3bvIQ1qxmhSShObRCxvUbkXSQYxQiFzbEreIU9M+I9MWI5t6ZHRWGQrKalgjH1UQwB6iMlDDUbcnscz3owZyASci0uirBDPzM04SqQM/FEKOdP6Mk1eygSqLOCLy/eZTEP1khAKCRNJSQlmSD64TwR2yle3DdA9XTy9WFSZpMgxiBKjZ0ZcnbhZmr37qpzau1MaREXLHnh96JEiuB2kmTO+Bp7FhfiJIQzMUA6ExUNPx6Ca7YI6I8CPaZxiS+2YykHBUprEh/RM41TbiIcEXRVES8ZSOjYKZ6QBw/w8k/mPoS27wOy5ediIgtMBdwfwcBZPOCYcxynGPdvllZvvlWE9b5EQuIyLIpMUOQaxQU5IxhmKt0bJ7gP7pFFEpKwGQcCpq0RptJeXO4mMuj7XIKqDwKie7aduz/PmJWDclw2TmmVCJQJb049COm2EWqdGMw486fFbxFeF4U8GpWcMOYAPrtdUqHwkVjBSnoCMDvspNDRcjinpn729REdFFbQhDIezNm5PkNdvHSTDet2m0tTp0MhTff6giYsUgxhzcH9Sv3delemJG6R+hUqyDl6q/GwuVOYAUamaAn0+kSf9IC3ubNhCujVqik2MtaRi+fJShmfQIRG43nA0PV0OYE1l865kWZSwXl5bj7PqfIEDtoiUB45UMFFJzNr/bNNBKuOtJschgczT5hYZJjp4J5gYca9pMO+mPbvk2SXzUWYJZVwy8NkAWfEE2lMeTBmFuiTs3CKf9n9E+l7TTbMXJcO9yDCIzXwktKc//0hGzpoijXBuYzXWNQqCOSJASNjtJPsP7JbbG7WSBzt3l5b1GuDVPTiHngscBzPt2LtHZv62FKvz30kwZv/DqCdf+7P+sWelKiTcucCqxE3SZNTTOAofqmraEdXTzg6TMQntkmI4Jrw3ZY/MeeRp6QB3cFFiEFO1z67X/qCpTJ9n9b9bNF9GzpgkdaNry1pIDs7KNvfmtXlutQrrDGCOk5AKafACvXfrALmjUxcsxpVVdKehalG3D0KarEoO1CeqQYAQzNSxVaKle+tgyZg1TTIY7qnXiRPueZ94ikPlIY2bk0Ez+7lQQpWAfaN5z7F9rBk3PtJZUQtqoZQKlYFf/kdmR1eTahWjiow9kkfF1s9o/AGCuNZBozVp7265Z8pXun+KBrFKlXzUn0RUElYLDfK0A3vkszsG4uUJvZQ5+AK4U6ehFoExgvB+K+r1aceOysHDh3A/IidRPuP4Z7AIW+cFDgN60sgJqjyZBoVEZI5iMKItX053MgehZAgsGQ8eBxqNO5sL20fpuvXECakbWk4StkPVmvGDTih0++bGqGdTxqWeptBLEM7e5sOfsnC+pO1KkrjKNWQz/P35Ua04sNjKKDVggCfs2SGjrr9V7up8rY73STAHbQ1KjIOH02T+qhWyYP0a2bR/j6TiRQ5hWISLrRgpjWvESAu8ZKFxbG0wzCmZtnIZKDLYs+3DLdeMsPmkW+xTDshvmzZKsOLX4rJdTkMlKgXmWIOFT67+00NFt/K5AHNxctmP+klElPx97o9yfat20rR2vDII4wozFH4GAbEUg2qSvH+fvLl4HvyvEer+5KCeG8m4yYESoSaIOQFqVRe8UWTAtTeoF4ySw5hj2cZ18rf/fi7T1y2HHoVDTHxZHL1RVKHWw1dFDxbCX+rSQ+KrVpfvsd9LYC/QPZsJHgL0EDj3hnV7/iGRqFpuPH5bgTwuEHQpeLHKllcvFko6Zw8d1Qx61+Ih2RIO7tFtOE3AICZFCjOTFHoGscFbvnG9rE3eItF4MyHfS5WfeY+MVQaETruDbtxH8PK2qHLhoHtse9cZtZis2LxRWv77RX0rYsPoWLwgDltTQOTMy7Ipvbi+kYQ9Un//ASv4mOnL4DWjJcB0TJsJzJEJwfBISXRdaQBv1zHFlzXeUrIMxu8BLhJ4ftqrOIGLazWcYN797Vfp06mrVI+qVOilSKFmEK/nCrP6nLU4NAT9vQx0/mQQpe1eNYLKy53kyw2AyWCOxnhJw2V1G2h2M45TjqTJM//7QpmjGRYgV6QfVcZxEinJmuwSBkarjjTpYK5dIGZjoJzqoywG9XAv2rQPREsbIxuA8TiwjCkoI5P9tRMGe204HzZjolmFRVYyCCeEwuzVKtQMosSDAeQb1Kdu2aALZ+n+CCobhZ05gERHD49go1/vOliniKigGewlDovWrpZvVi+RulVqyQq8U9e2qzhJmczCZUm6XnlElhKFYZrGyUmKOfOiEgr7xKpDXYvkjO4AYwguUiaBmI1JHEnO+SerRLWSHjfCEqzddMX7t9i2wmysF24GIREDdu7bK6v3JEsEVBjuszK1SyPP4UIfkc71mMWb1IwBkXCvEt2wQSCi07IIb2/n7lhd2ANR6SzrpxwSNGuYF2fBCW5Z2bpKfouKATeBQYDfC2wv1TPYMeXQ1sOeOHcveFPl6wdfSiHYJr9w22Y5hHcPR4SG5ir18lXgRc5caBmEs5qpF9vBIJztK4ZHSgLUk0zH6rn1Pgk6nYQCe6EKDh4RbBZNO3pUlu3Ypi+qzmps51yWg8RzTuSJ4Yr8M3cNl1AYzFnzQflCQLBnBf2ttSulFH7Tg4Wa5htYFhk9je3GjoCpmHD4fRMySGGGQssgOmgeCcK3j5B6SNi85zSjn+1Ak/F0VRou3rKeA0ZGrMewMr8BhMP9V9ytSxFhcWeL3186t9RzSVx0dXmmzwB/SZRJqeYtWrdK3lr2i4TiFCHetajGekFIEXe7T0sVTAy7Du2XFLiwCzsUbgbB6JE4uUBHA72ggMSmZ0TAcPYhG8NNSaIr4QgoCMYwvM479gc5HzN/exhSRUlmaIH90nYDWym4zQV20+FjZD+3mqg/CuGl4KjmEu0cen24/wpio8AIluRZitIIdofaBI62h2BbRjVKFcSVIEXlQMuOLGf9Uz1YFElkdj9/xTyr8sHcGgL7hMUXcBW0Odz1TCbMYL8Wcij0EoS+oRIkHAwoiaUg4BSInmc9DmEWPcRt6wDDHYoNhs2iqsjcrQmwZct743Ljk9wImfmxyUT2HUqRdVsTdTEyE6f7FwVISTDHcqzB8Aw9VbyTqJnVTStTABctjdKTk0QhhyLAIDgtVwqr2D4u0fyM6wnMoyGcwSEltu3Zrajc21mwxQPu15ax8SLzp7tdwYg9E/EzjkY0Xaj0emUnOU8IqR+wBScgO/zzTzhkHo2MfsxvpoMBH4qvWR1GPSk3s+NUVHm+sAZUOVS9xKRTBu7mwg6FnkE4gJHl3DM5Fw4LQtVyKxYgOzDDUmwpvwuSpCT3PMHtG4SV7nYNGmElMVLWw2Cvihl9J1SRnFy5JLaykEaVYPjuQ/40j2qUSXhuxrBntXnKR0l1bCHhjgA/LKKeKx6SKijGsLJZkzJgYtaTn5MrX7asRjG8oMuyMi/2vdDaIOqp8sy63J7NPU+HsHhWGgOcleTyPgTMz+8L8sTe6I1rdJcwsRje+jVi5L3uveV08mapgJmWe7a4dsI/upg5K9GGKQ8pVAebCoNRzy3YDZwGF3QYwqjCnRGAMwiGMhfteNbd/rh1hS9i4CJmbijOiD+HSK79hAL/MUwIjfHlrIiwcjmkLDzBhZZBOES2NhEdFSWlK1aWXTi6GoEBVkmSjzEkkXPzXizWA2T/Lvl55W+KjZsUT0HtIvTB6bunbuwjqxPXyDZsPQkF0UaCsCsjDU/p8RjVARDaxp3bJOVomvypbUfpBKJLwxkVdQAolhwuKCMDmzC5ZT8FzGV/qfobpxVxL+gZXfGB63hqUo4dlquia+m323OoYaEJLtQMYlTCrSD9a8EuwBsR+ZIEQn4JiKrRUUoRvCJo8E/f4p1aiV6sp7GTlp9nfvyOvjJx2NNyNXbq7sWu3+37dkLaJOOeLHtxLDcKpw0f79xDlv35aXmh32C5vGasvqMq9Axb2Vl3AuvPlvj7y2/biD8n0LUkTDRt4urA3grRZOezvJzqcaHCC7UNQpOXUqQ0jNaO9RvLmMWzdQcuVRHaEfkZWBIK35kVCwfAFnwf8Pn/jZPRgx+SCjhYpIelip1Sg/0mfAqtY7MWsmnHdt1yn47zIHQFVwoPl5qVq0hVqH/cqkKoDe8Xz7KfHwVJizjnC/uLx4o3QsJxRy/PsRDsnL8+FMJL4WYQEDEHkPZI63oNYa1Xla0wnCuDYXYjPD9bTqjjk0m24LRdPAzycXhBdJUJ5eSpO+7B9oswJRUenKJnKgJM04rl+wWs00DVCsFs3DimNgyVEDl2CpIJ+QimDvLO+rrVRnfc+bAztFCfi5aG8ivgGygHsYI+EG9gjKtW3Z3KU0+fLIXm0T11FZrmZG+Ie4sGZmecpX6+RTssq6fAa+RmjfxIEJZEAuVawCYY17F46dxri2bL0PfflKU4KOXe+l5CNzAyJTcz2p8Lv/nnxgBj26Oq8Bgu9znp6T8P9dM7RgiGoU8I4Z2qHSqf3/orwrO4oDTYRfgWI+sHCdK71eWqQpJZdUPmWeD4oyYp1BKEg0IGMTXgFqg7Ty+cJZtxki8C58RTQWgFQWTEkQhpEYtvA47f8LuMf32NPNXuarmxdTt9g3q5sqGelzZkJRPu/E3BGXWqX/PwkZuxyxer6/i0p1IkQJ6EpEp2LCND1x124cit4Mw5100uhARhVVhWZWx83IrXsvZo0ELa480mBNbPJiANKISXIvHaH+dAjpk6SR6c8J40rBYnazAb5rQ+kdexJrFypq2FdRB+TNOVyu+Wh8g1NWrLFTC+q0ZUlHCsG5SCBDiEPUypcBjswXuxFsC4n7ktAatveAlp2XJqL/F4LIHEWQfrDaVgtFPF4mx9GOn4ueeCqrcWdIYL20XXOD+jsAOvNJo9/Cnp2LSFd9I5Q9ZCEVUkGIQjZVIk5chhGTTmNfl6/e9SH67f/L40zpcK+JKfCsWC9KRgCqRKKk4T6tsVyQCc80Hoal/QMOfxWZytqABvVhjUPnrF6D4mY/CPxHkK9ol7F4AnBOmoZrmdyUhwHoEl0lvXCGtIq3dsklE9+8qIW+9y160ISA92bZFhEDbWmGR90jap/8Y/sdqXIbXxys/NIEIurlECFAQQD4mLq85cWOP5dVo9DCOQ8Akkch5A4uo5Tzoyn69RyMVEbnpkHuanfXKIxInf5wuIW5kT5TSEu3oN3tpyR6OWMua+4ZCCod5+PF/lX0p4ixSDUNUiUG/+BZ8ku/Ktl3SFPR5qTAKYxN/R2PwOFolerQWjcEPororWxZcpLAnvnmTOoPPOHOo+MObACn/zKjVk0tARUqtS5SLFHOz0M41NlkEpDA9Og/KKRk1k+uA/YwpPkwS8ZJozJYmRL4wuSGAHlwBJ02bQO3/bM8JyGwDO5r5/BVk/X1xUqbjq34SSA4uaUXh38bhBw4okc7BvipQEMWJwGu1z8VK3q8aOEdm3Cwt10fq9jt2wHaD5K5hqVLBsYzW5eHdT0SjhTCWkMc63uh9G+/fs2iY9m7aVf/UZJHWw5uGUvhev1he+5CLJIOxmJ5NswRvWR8O79eq872E04zMFOMdBaXMEtsFB2Ah0cyqAqmxDuhGYO+KPcWUr3C3B1dMk7iqIgI1UGrbOUazN7KH3Dc9vdL8Vb3PvLhXCwnRNh+12SuA/RovzX8siyyDsOuesyFOHc1culzd+mirfrsPmQ25EhIcpFgt1VI9oRNNA5h/VsAvhRcr/8GZiIENTGrIt/KiPffGKu5K3cfsIv2UCGNqyvQwGY7SIr6fP5tjQhyJ4KdIMwvHWWRVSwt7fm4JX2ZBRxi2cK+M2rXF/5Iar1zDk+RYTvs5HvxwFQvujAZmc78zClmMYW2AKuqDRdp5dGd6gudx2xVXSun5D7wc8izpzcHyLPIMYkTulCcPSsBi3aXuSfiN9WWKC/LJ9qyzEqrd+7YkzLjYqqvVsCP4Id667YB8aj+N2wbfRL8ciZovYOGlQK1Ziq1bTD/awGWQMqlNFUaXyHcYAg/j0iG4OhFjhtzgMMrDIl3L4sBzFCjh342bAJcyNiG6wdB6l3ss1l9Iz102K6TuzuO+rdEm8rgiLk+HYVFnCs/2fbQkwhmdIHbcAgzg6w/mTmw2pf5nq5YwrTL8pOVV6QmIU9o2H5zJuAQbJpdcoB5SAQEgKHtvD5EYu2S+ZaJNnyvXepgTUqNwGKMAgufVQIL5I90BuC7lFunMCjQ/0QIBBAjQQ6IEz9ECAQc7QOYGoQA8EGCRAA4EeOEMPBBjkDJ0TiAr0QIBBAjQQ6IEz9AD2Hpw7+G7POHdM5ydnQa8MexfVUN2LuYB4qdTj/IxadqzO9l7oLTDZ1kGclXFW9UJXzFl2fn+zTWfaV+RsszOdbz5nHOvkG5/fep5N/ryU6WxXTrgvJqPnVCdnuL/2+gtz5jmX38Rp4BznLAySW8GGxInAkJ6Pe37L+/333/G29SBp2LBhjsScW5ud7Tp48KBs2rwZXz04Jc2aNZOSJfGdwFyYz5m/oH4fQD22oB4nUY8WzZtLCF6AnZ965CdvQbXJHx6r13Hsf0tMTJRdu3ZJfHy8REdH56u9/srKKcyrYlllSAQ7duzQCjCMnR+GQzOVK1fGR+5LaDiRncLgvP/+BxIZFSm33nKL4jccORWWl/BzxeXM9/HHn0iTJo2VQfyV7UzLzt+6davs378fbTuNNodKZGSU1KxZQ9vPSWHhwoVy/fXXy919+8o7b799QRnEWdeFCxbIDTfcIH379pMxY97RMfLXvh07kiUFn8DmJFEMmy/5z8Dw1axZU0rh9an2bPGXwt3qxDEZNHiIzJs7RxYsWHheGOTQoUOSnp4upfEBJNK7gZdBLGD16jXSoUN76XN3XwS5JP1Yuuzdt08aNWooDz7wgDRt2lSTUr9PTNyi76G1vDnd2VCCU/JYmHWCM87ScubgX1m8T4rxllaR4cJnxeyZxX1xhILIS6HB/oD1p3rBjpn87bcyduynMv3HH7IlvePOO+Xpp55SJmMeQmTFyCxtsUxaH0dbfevDdExD8I2z8JziDDfrbGkjI7PXg3GGe8qUKfLAA/dLdI1akpy0Vcv1vWzfvl2qVavm7Vsrx9L5U8GsfCvH0lo4ny3O8PGZf/ZsaSyd4bA709kY8V7GM47BwZkka7gMB58Nr+GxOHvm3dLxN+NTUlIwOW7TcGoF0dFVpTy+Jsx0maUxNYAvXr6p983y+muvSig+8XvkyFE5is+MTZkyVdWKFStWKJNQmvzjH//IYqz6qwxx+oZbw51xVmmmtfjly5fLzFmz5LG//MU9CyKO4EyrIT7hmsgunk6zR94N/xEcjho5apS8+MILGv3ww8OlWXOoTpCa7LTvf/hBJowfLy+9+KIzu7d8C8xSH09dGOcMt7S+fZFbuNXVmY99TzD8hsP3HhKCA16AZpCiPW64TvvQhc8mFA8qjjeIHtfZUr9niDTExT+W4yyL+S2cvwm+8e5Q/+FOfP7a4oubz1aGtZN1DMaYEJzD6cRteTRRLhdn/akJcRIuiSMA69atl8sua6GShFKEk0M2BmEFya0RERGqUlHk4HtfMnTog5rx3/9+U95++y0V6xTdbLSzUTnVzdIw3malo/imeAbeTUUJQVWOQHzWgNTUVNm2LUkHViM9F4tn2sM4p0HcYfiYC89wOMthZ7q7OzM34638b775RpmjZes28vSTT0iXLl2kTBmcHPTArbfeKsnJyVKjRg0NsXxZy8jER4ZjfdAAFdM26zE968w760wgLmuHhfPOcP7xt6XjbzLs8eMnpFy5MPSZ+5USuiVfUzkvmWpUcYwPgWomJxm27cQJvFDbc9aF5XN8iZ9jSTgGjSEt7ZCGcVw4SVrd7e6vDcxLYnO2gWFMy35hXuJimgMHDuizSUDmMdy8E0gbhw7huyqhZTW/i8cPFDJH9CSOSR8+fAT0U0bIRPug6TA/iZvtoX5RgofEfIDlsR4EY0KG1atXV4551Cwb6+y5oafyy63kKma2RvP31Vd3kk8/+1xIuFH4KM2HH30klXDv1auXjBs3TsNIZARrNH//gJmYh41633QTH2XX7t3y1VdfybJly5SCWZkbbrherrvuOh0wlj1r9mz5csKXcgiD9corr2h9ypcPlwED+msnzIJkoXTZs2cvBvWo1KpVS4YMHoxGus9Ssxx2dSa5MCSzXklJSfLBhx9p2AP3DZGePXvqb+elSpUqwj8jCBs8J1IOBAfzxx9/lG8mT5Y5c+dhgikjV155udzU6ybp3PlqL/OzzPfee18ZYPCQwVLTw3jM/+mnn8rvq1bJPf36Sdu2bb2ERuP064kTZeaMmbLi91VyWYvmSjSs50kQuy946EuDre18ty9VBo6hzneOTCQi2ibs859//lkmTpoks2fPURq48orLpceNN0r37t10EmM2Evf7H3yAft8j9993vxIVw0msX375pcyZM1dugU3atWsXpZ3x4yfI62+8IY899hdpBGfJRx9/LEuWLFUivu667tIP9hwJmnTGvjwGOvlx+nSZ8u0UmffLLxKOeteBYU7GJRhh01YeM+ZdWbJ0qQx/eJjs3btXnnn2OalTp47cddedYPI0Wblypdxy882g26t1DEln6ZiQx30xThb/uliu695dx71ChQo6+bDvSLcUDgT+9sMg7DD/4GaWzPPb69atUwJn6pIw9F548SW54oordKYiUbHBnD1efOlleeLxvytSOgD63dMfs/U1MuLRRzUtZ2k2jvbPE088rgTEjomCA4BE2ahxYxDDCWUeznhz5syRd8aMkWHDhimRMc24cePl3kGDZfKkiTCuI7VxLDBzvtHiFR9/rV27VmbNnCFXtu+gkoNhHGTW2cDJ5BZmd8YROKCjR4+Wv/71r1IqNFweHDJQpci7qB//PvroY7mnfz99eTWlywsv/FPz9elzl955Ybk/o03jMcl079ZdwzmYGzduRN4BsnDBL9K+w1VyNwaeTLZk6TIJr1gJ6Xxb5x5ULyMrppwvHCOWQ7Xrs88+k0GDBmniYcMe1vvo0W/Kfz75WEaOHCXDhz+sxjwN2ffe/1C2bNoIQsxsA/tjJbyG7747Rtq0aa35iZ8EvATE+Nmnn8nkyd9IfJ16yuBzflkEJpgMiVhO+t59t/Y7tYm34fwYMWKE5h869CGdXGajb4wm7XMQnOk/hBOG9TiF/vsWuAjr1q6BtBwhmzZtkrcwLoS2bduBzty2aDIcFwMH3qvhZE4CJ47q1avpOPA3wcbeD4NA/INITOVxEswkzC7k+ooVKyoSU8P40KljR6H6tWr1amnTurWXQFfjmZ3Qvn17zfP666+Dc7vJXyDyDWJjY8HVn8vV13SRdu3a6ezDWZSzAl213bt1s6R6p4uVxEQVwOBxMODixYuFdkvXrl1RvjvGOpZP1mj+3rVrN2/SAjMyGYpAYnESl/02ZtBEuOgzpxvAzz/PUea4sUcPef7556Vxo8aY5U5Kr5t6yeAh9+tgNG3aRFq2bKn469ZroPqus19ZThQ8ZoQSJdwMSqny3nvvKXM8+eRTamxTmpFAJ0yYoMRcApLBF6zODDfJRzWV6iQN0NNghpM4QmxjQg/WkqVLFF+Ly1rKG2+8Lm3btFG0t99+m/zt74+jfY9Jq1YtIQ07axsaNqivhMlPzhmw3HKebxYSJ4FhEeHh+psOkzlz56J/GqkG8u6778rLL78scxHWC9KbUmQ2tAYyByetl196UVqDjkiwlAQPeZjWTj3y3rxZUymFNv26bLl8CY2E9aZkadCggXpdw/AyisnfTpWhDz7o9WSuBQMRHn74YaieTfS3TRS+zMHIbFtN2Kh0zIp0rdHDQ0KipHjuuefl60nfyAP3369IeSGhmD5LMUVxNh3ikWCFzZg5Ex3QQyXFhg0bZOq076VPnz6a5gSkAitHyUSV7flnn5H/ff0/6Ml80bNo+cX4kmcAy2Ja3sPR6U7mYDhn4bj4OFV3mB7NUMg+x7rD7Uw5iYaMcSZwMhnTnYYbOBgDx3pOnTpVs3IW5JoEvSwkkG7XXiv3D3HPyPPmzdM0/ALuhvVrJU3tJg3yXlh/AttCoIT717/+JbXj68qdkBz0NJGp2O4aNWpqGiczaIDPxXBRdaM91QNM3KtXT1WBBt13n66jMMsMqG+EgffeKx0wkXFy5F+HDh3k7rvdY8U07HuOK7UCAh69wDj7PiOZkMAwqyPVGeLmpBoTEyOdOnXSNHQWsP/ZfuvL/vf00wmVY8M20wY0tcc7sMhNybF2zSp5ZdTLchvaR5c1J0/WvXr16jL0gcGStHWL/PYbXuMEoISaP3++/qbaRaYkWB1ZX+czf2eTIEQ+CWpKaYgkGoUkggzMWu3bXynTpk5RXV+xeC6GnI+cYQbBDhjQv78OaHLyTswQ89QjxvgkuBTbYlYwCcTOZn4byLi4eEn+5D+qorBDqBeHwLtAcJbDZzLVmjVrZClE+N69+/QlCj9hEHuCCJzgS9wWx5mHsBc2THo6vr3hMM4tDe/sNHabEw+NYw4qVab169dr8vj4Ono3HZlta9zYPUPZulIQvEduIDYHdXlCeTNm3blzl4Ze1eFKqQ7mIJCIiJf9ouAfhTsOV5tc6tevhxlzmHrn2B7mL49Jhn1ASbUNL/MmNIBkIFgbSJy0Gwhbt23VtKyfEVKWNtiMxMTOzuIzwRNP3MRbgq9QAnCiYpto165es1bD6tdvoHfSHo1vErbRiLfbgM8mlQYN3HVkeuImUBXvDCYYCSk1c+YsnSCokbz00kvStFlzaY7JjEC81ue+NMb4bAzCQjtd3VntA3JYcbwHKjy8vJeonQiJwAl169aRZlgnWbRosdx8c2+oO8tUpNauHafJ2G+sjFWEHW2/mUClkaOjyaD29SXGMz3zs8NooJE5br/jdrn88st1NtiyZUsm8TCDD7Asqz9nG8LYcV/JQw8Nhd7cBvjx3XH3BO7NaZ3nDXD8YH2MWKzaWdtjDGGZ3JSjvnzLgCjffmBqfo2KUNwjQfnbiZvP/sCJyxgyrnZtNYZJiL5AGyqzje76Ocvx/nYwo1Xd4rQf0HHehUhHWivP5elYI2CvB86TljiMMQ2/5eXdH89ZMaYNEDfbYsxEadKt+3Xy4YcfQKUfoQvgxNUHtpN5Jq0NDPcHviOoYje6alXo5i3UIxAXVzsLc2RBiBqiXQqsFLmdYnwGjF/qyvPhhbj22q6YIdxcTTVqKWwEzhYE5tHO9SChhKlUKUrdgYxnw+mfJljn8fd3332HWWEmbJ435EasKNNzxe0HVL1OnnQTFtNx7rf68dkJjaAL9+t3j8iJo/IFvBr0zlAFYgc7/8iMVrbhYh+w7lR3YmJjFG1CQoLeLS/btX6DW7pQPWIe6v5lylWQ7Tt3ZxlwqhJMTzAjlG0hLFi4SHbu3Km/jbisTzTQ5+IcH6uv2+7IqsJZeVQHq8K2IajTBXdrA8OsXbVq1VQpy77gpEkwQmSZ1Dy8hO2gZrf8RWJvpGb1tp95iYcSvEaN6hq5fv0GvZOeCKyjMYM3o8a4Qx3Faaj1AXd/9IYtSPgBXsbp03/S39SGOFmwXEurEX4u2RiEnVMMfxS9BEoUImKHMs4JQSB8Ljo5oXXrVsoc42FIUr8koxnUrVtXmsAjNcWjt7OSrCAHnurK6NFvqR1jHXMcxGmGqM0OxEXPCBnPiIhhVBtoL9EnTmB9id+3znxmHFW4IXC1EmiYjhw5ErrqCrW9aOhx68mMGTPUxcw1CIINNgma/cK7eZ0+/+IL4SIqCYhxs2FwvvXOGM3X4aqr9M5LTE2oSxhX6sIHD6aoUcly1sM+U/BQNd2V199wo+rY7Et6+qhCsF5L6R4HmITQBz8XGxuboHyTsB/Y1x3gISN8Ck8W68X6sx1LliyRsfA+Ebp06apjZXkYNmfOXHWkcMKji3jZcreu75UkSGPrEL7jYOqfe20GEwcYxBw5NLh/weTKyYnLA1wO4JhU4FeAPf1DpiDjEHyJnM/GvPSqEuiC/uDjT7BD5G5p4FEbNSK3CxqsgA7R+/SffnJ17NTZBQbJEu5OBSUE05HB3/72Nxc8LdnSwddN1naNHz/enRR5DP+qVas0Dls7XNDNXdALXZi5XPfdd7/riSefdKFTDL0LnhfXjT16ukAcLmx3ccHm0PJ/+mmG4vj1119dcCS4EhMTXf8ZO1bD4KP3lvWnP/3Zhf1Yis9Zb/vN+4QJX2o+1pd/13Tp6rqpd29Xs+YtvOHwxCmOiRMnatg9/fu7QBQaBuZxPTpihIZXrlrd9eijI1wPPTTMm3fsp596+wzGrQur9RpXvWaMq/M1XVwxteP1ud3lV+idZRh8881kLx6ova4hQ+5zxdWp6w278667XJhYNLmzTZafY8M2DX/kERdUKQ22ceCD5WGfjxo1yov34eHDXX/+v//zPr/22mvecQGTul4eOVLjasbUBq1c7WrcpJk+YyLQO9Z6tCxMWq6/gkZYhw8++FDD7PLdtGkafsstt7ogvTUY2z20/5m+QmRl1733DnT16NlT0+HjjXqHTatpsUXG1bBREw3DHjkN89c20jHHJ6pKtKYl3RHYdmu/BuRwCXoWgAopkPP2Q9WgLn4lOI8zMPL55VBmSEpKUncaJQPB0oZC9eAqaN++d+ssT7WBuPlXqVIlue322+ETnyxcRJqNmWcaPFvXXNNZ7oeHjMYVGqozP92am7dslrffeUcXyjjL0hNSr15dqQ29+tXXXpdfl/yK2WaBrqsMGTJEXobP/jJIrapQE8E46t+Ox0ITgeXb3epKVetmeN/YhvDwCOzW3SLb4SunuO99U2+4HR+Fsd1Y68WV2iOQrG2w8k5JydmXs1irVq2Qvx4k51EZ+8WXUImShS5SblHhQhulHwZD1RDWhWpgBj5HTefCoIED1JCkLcB0vbC4aKpGXFycujrRfbIVfU3f/jNPPSkDBtyLckuq65iuUJO41sfaSFyomnHRly5zetg4ntZ+u7MfGE59nX/BePPiJLhGl69YKbdhwe9ZeBbvuOMObSfHhWlrx8ZqWzir09NJN/ybWDOhvUj66d37Jt11S9zbse4VBJXsqo5XSV1IRYP96EuuZbDvWD+qaFzMbNeuLbSAUPTRCZk08WtdXH7uuefQv3XgIKL3q6PSHBf8Dh9Ok3g4djpiiYF0ZWNqZfDOvuHugQ/ee1cua9lKHnlkuJoMTOsr1Zz57HeW7e4MpHg19cEIyhL73ikCWYgNkFWQd8ZRBXHisHgrhwSnHhV0DDuHYGnsngHVKRmdzHLo/aLebzjpiqZqRhezuewYxnK5rcG3flqA42JlWLm0Q7j3DLUAjlK6rYMMa/EkEKo5rItb5840+pnGnf+IxrM9rIPlZZ2tPKqv9KgQB/Vk4uMz6832kVEsLfO7CTFNtwBFwUYjEAfTWT000OfCunIsnfX1SaKPzrKoTrJPCVwr4R/B0tidfbsbOyJYB9qWrAf7ns9st02uHF9ODnw2OiE+1su3L524SRt8Jm72C21aPrMclkGcxM0w4iV+JxguhnERtB92KDz9zDNYsH5ccTjjnfl8f2dhkLPN5IvE+ZwbDsbzj4PmC2y0MzwnXP7CmZdEaMzjL41veXxmOv45y3WmYxzB8Drj7LdvvS3cX16G+eLyF0YcOYUb/oK859wG1iP3cSmouvqrhy9u32d3P3CcfM11Uc/Vgw8O1ZX2H374UW1X//n992YWtuPAMTP/ciIYJxqmIzgH3ImDxr5vlRnvTGP4GOZbpr90TJNTOHE5GcVf/aw8uxOXP3wW76yT9Y3lcaaxOAvj3ZnXwpmXdTQwXBZmz4znb1+8DCNY2/yVoQk8aZjOidPifO/E41sW0zCvbxm+9TL8/tpgOC2NlZtTOMuCeYBkmbTFvNlwI9pcxYabaZifqv+0adMkJiYGe65+Vea4HWpiy5aXafHWJ1aXM92zSJAzJQzEBXrgUu4BEj2BzDIJ22psYyzDqlavKVMnT1KPqjMd43KDAIPk1kOB+D9cD/AQGLylwqPJ3MncDA4K7ggm5EV6MH2AQdgLASgSPZBX5mCnZLeUi0RXBRpZmHuAjGCqFNtJ2+RcmIN5AxKEvRCAQtcDTgahXXKukMWLda5IAvkCPXCp9UB+mMLZloCK5eyNwO9AD/j0wP8DtYt/fOhzihIAAAAASUVORK5CYII=' />\n\nThese metrics help you determine when you need to scale up your deployment.  \n\nSee [Key Capacity Scaling Indicators](https://docs.pivotal.io/pivotalcf/1-10/monitoring/key-cap-scaling.html).",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXO7fAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "CPU Load",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "# cores",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "User",
+              "label": "A",
+              "paletteIndex": 6,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "System",
+              "label": "B",
+              "paletteIndex": 5,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Wait",
+              "label": "C",
+              "paletteIndex": 7,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('system.cpu.user').publish(label='A')\nB = data('system.cpu.sys').publish(label='B')\nC = data('system.cpu.wait').publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Total number of LRP instances that are no longer desired but still have a BBS record.",
+        "id": "DiVXQzkAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "More App Instances Than Expected",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 10,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 5,
+              "gte": null,
+              "lt": null,
+              "lte": 10,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 5,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Extra LRPs (5 Min. Average)",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('bbs.LRPsExtra').mean(over='5m').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Percentage of remaining container capacity across all Diego cells",
+        "id": "DiVXFwQAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Diego Cell Container Capacity",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 30,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 14
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 30,
+              "paletteIndex": 16
+            }
+          ],
+          "maximumPrecision": 4,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "rep.CapacityRemainingContainers - Sum",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Total Capacity",
+              "label": "B",
+              "paletteIndex": 14,
+              "plotType": "AreaChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Used Capacity",
+              "label": "C",
+              "paletteIndex": 4,
+              "plotType": "AreaChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('rep.CapacityRemainingContainers', filter=filter('job', 'diego_cell')).sum().publish(label='A', enable=False)\nB = data('rep.CapacityTotalContainers', filter=filter('job', 'diego_cell')).sum().publish(label='B', enable=False)\nC = (A/B).scale(100).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXQErAgAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": " ",
+        "options": {
+          "markdown": "<h3>Diego nsync_bulker Metrics</h3>\n\n<a href=\"https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#nsync_bulker\">https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#nsync_bulker</a>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXRLCAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Total Disk",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Bytes",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Metric",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": true,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "rep.CapacityRemainingDisk - Sum - Scale:1000000",
+              "label": "A",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Total",
+              "label": "E",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Used",
+              "label": "F",
+              "paletteIndex": 11,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('rep.CapacityRemainingDisk', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry'), rollup='latest').sum().scale(1000000).publish(label='A', enable=False)\nE = data('rep.CapacityTotalDisk', filter=filter('job', 'diego_cell') and filter('metric_source', 'cloudfoundry')).sum().scale(1000000).publish(label='E')\nF = (E - A).publish(label='F')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXEKgAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Number of workers",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "system.healthy - Count",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('system.healthy', filter=filter('job', 'cloud_controller_worker')).count().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "The time in milliseconds that the Gorouter takes to handle requests to its app endpoints",
+        "id": "DiVXKPaAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Router Handling Latency",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 200,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 100,
+              "gte": null,
+              "lt": null,
+              "lte": 200,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 100,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": 5,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "gorouter.latency - Mean(30m)",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('gorouter.latency').mean(over='30m').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXNM3AYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# Active Hosts",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "system.cpu.sys - Count",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('system.cpu.sys', filter=filter('metric_source', 'cloudfoundry'), rollup='latest').count().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXEn8AgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# Running Tasks + growth",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "# Tasks",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "growth %",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Metric",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": true,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": true,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "metric_source"
+              },
+              {
+                "enabled": true,
+                "property": "job"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Running Tasks",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "A - Timeshift 1d",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "A - Timeshift 1w",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Day-over-day growth %",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            },
+            {
+              "displayName": "Week-over-week growth %",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 86400000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('cc.tasks_running.count', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'cloud_controller')).sum().publish(label='A')\nB = (A).timeshift('1d').publish(label='B', enable=False)\nC = (A).timeshift('1w').publish(label='C', enable=False)\nD = (A/B-1).publish(label='D')\nE = (A/C-1).publish(label='E')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXQAaAYAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": " ",
+        "options": {
+          "markdown": "<h3>Diego BBS Metrics</h3>\n\n<a href=\"https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#bbs\">https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#bbs</a>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Total number of LRP instances that are desired but have no record in the BBS (5 Min. Average)",
+        "id": "DiVXQ3nAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Fewer App Instances Than Expected",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 10,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 5,
+              "gte": null,
+              "lt": null,
+              "lte": 10,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 5,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Missing LRPs (5 Min. Average)",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('bbs.LRPsMissing').mean(over='5m').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Maximum delta over a 5-minute window of the total number of messages received across all Doppler listeners",
+        "id": "DiVXCx0AYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Firehose Throughput",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": "metric_source",
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Maximum delta per minute over a 5-minute window",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('DopplerServer.listeners.totalReceivedMessageCount').delta().max(over='1m').max(over='5m').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "No data",
+        "id": "DiVXQGxAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Auctioneer App Instance Starts",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "auctioneer.AuctioneerLRPAuctionsStarted - Mean(1m)",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "A - Delta",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "B - Mean(5m)",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('auctioneer.AuctioneerLRPAuctionsStarted', extrapolation='zero').mean(over='1m').publish(label='A')\nB = (A).delta().publish(label='B')\nC = (B).mean(over='5m').publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXMRcAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Container Count",
+        "options": {
+          "colorBy": "Metric",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": null,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "rep.ContainerCount - Sum",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('rep.ContainerCount', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'diego_cell'), rollup='latest').sum().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Max. # of Unhealthy Cells averaged over 5 minutes",
+        "id": "DiVXRPWAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Unhealthy Cells",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 0.99,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 0.99,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "# Unhealth Cells (5 Min. Window)",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('rep.UnhealthyCell').sum(over='5m').max().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Top 10 consumers of disk capacity among Garden Containers",
+        "id": "DiVXMXXAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Disk Usage (%)",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "app_name"
+              },
+              {
+                "enabled": false,
+                "property": "app_id"
+              },
+              {
+                "enabled": true,
+                "property": "app_instance_index"
+              },
+              {
+                "enabled": false,
+                "property": "bosh_id"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "job"
+              },
+              {
+                "enabled": false,
+                "property": "deployment"
+              },
+              {
+                "enabled": false,
+                "property": "app_org"
+              },
+              {
+                "enabled": false,
+                "property": "app_space"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "container.disk_bytes",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "container.disk_bytes_quota",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "% Disk Used",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container.disk_bytes').publish(label='A', enable=False)\nB = data('container.disk_bytes_quota').publish(label='B', enable=False)\nC = (A/B).scale(100).top(count=10).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXPmjAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": " ",
+        "options": {
+          "markdown": "<h3>Diego Cell Metrics</h3>\n\n<a href=\"https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#cell\">https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#cell</a>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "The current total number of routes registered with the Gorouter",
+        "id": "DiVXKnhAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Number of Gorouter Routes Registered",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": "metric_source",
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "5 minute average of the deltas",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('gorouter.total_routes').delta().mean(over='5m').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "This should stay below 60-70% for all routers for best performance",
+        "id": "DiVXF-uAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Router VM CPU Load",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 70,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 60,
+              "gte": null,
+              "lt": null,
+              "lte": 70,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 60,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": 4,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Maximum CPU Load",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": "LineChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('system.cpu.user', filter=filter('job', 'router')).max().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXRB-AcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": " ",
+        "options": {
+          "markdown": "<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGIAAAAwCAYAAADq46/yAAAABGdBTUEAALGPC/xhBQAAACBjSFJN\nAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAsTAAALEwEAmpwY\nAAABWWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpu\nczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9\nImh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRm\nOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8v\nbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3Rp\nZmY6T3JpZW50YXRpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+Cjwv\neDp4bXBtZXRhPgpMwidZAAAS00lEQVR4Ae1bCXSWVXp+QvaF7CsJAQIhrBq0oyKiQC2MWlkUHZmj\nWGhPW/S4zdgep60zHoWZHo8cPe2MDnawgoJKReCAgoCCOOwwhFQIIWTfyb5Bdvo898+Nn+EXl2P+\nhLb3JPm//977ve+9z/Mu997vi9clFlylpe/Qvby8rtKZAD5X28gFvn4Fel/gTRsnJDr6tg32eV41\nRFjrdxLQ3tmBzs4uYnwJQ4Z4w8/XF0N6vMLZf7CToPFdFURYD9CAGy+0ILeoEFlFBSiuKENTSxO6\nuy8hMCAA8dGxGDt8BNJGjEJ8VLS6G++Ri9B/zPfB+mfQE9Hd3U1rH4KW1lZ8fuIYNh/8DKvOfgG0\nttCM/PjbMwX2Q2c7cfbC3KTRmPtnU3HnzbciITrGkMGANqjDlRetbdAma0tCadV5/G7jO/jN/h3A\n0EgMDR6KKIYiBaVO/moC3vz1ZVhqJyFlbReBuvO4I3ks/vn+xZh2zRS2urxjsOaOQUtE9yV6gtcQ\n5BQX4eerVmJreTFSYhPRRqBru7vQ5sZ+RIj8I5weFOrtg1yGLTTXY+vSJ3HXtNuMRzjDnMgZLGVQ\nEmE9oby6Co//+7/i/coSjI6MQ157K3HzMtb/dW6sTKC2LhKV5OOLC11dqK0uwZ7HfokZ19/AfOIK\ndYOFADuOIfZioD9lqQJJn8oJbR0d+P2W/8L7RbkYSxJy21pJgBc04K8jQXOwbQpTJVxVBXkzaIXH\n4ul3VqOQyV2yu6hHHtdNXbb/QM9/wImwKUqxWyB1EqQugnQgMwPPH/wEiQxHhe1t8GG7QDN7hJ7P\nK4HH1G3uERkpgcE4XluJjZ/uRBu/e1OPwp6WupInQga6DOiqycZrwZBfWoIzBbk4V1KE+uYmfFaQ\nw8Qcjhbmgw62W8CckBFHeohaXEXgf+kTrkv1Kexoh29ELF770wG0dnYiITzSrKZGD0/GqGFJ8JHX\n9HjHQCXzAckRTi8oOV+JbX/cg9UH9uBYbQURJyhcESEkFCGM8c1K2gR7KBENYQL27sFdhHRy/yCi\nmgmiLCrStNNzZOFf8mMu21lXx3zR2VADkBjpmBgWhcXXT8W86TO590ihBPExMMvcASNClnfoi5N4\n+q3Xsb+iiCjGIdnP3wCoZWlTVzeaLnUZEhIIcInAa6oniG2Ci/0YVf2DgKAQ+BHUdhIGrZJ4j/zE\n9OFfI1BtfgEIDgwiWd5GppK5kdlQDQQEYcv9S3HXrbNItItIT3uGx4lQPFZsPvRFJqb+23IDQiqt\nv4pAy7Jd4cUgaCw5miBX1ldjEvssGJ+OkbHx8CNhzS3NOF1WjF2FOTjDvJJCoOcmjUQQjzk6aPmm\n0Ctk4b5DSCRJfKuilKQxWbvoQTDHEUmvq6buppJz2LD057hv9p3mVk97hkeJsCQUlpdh0SvLcZDH\nFSncnOURCFmioonNAbqOImiVddVYMX027p85G6MSh5tEa5Din3bG+5M52bj/P17BZMb91x/7R0SH\nhnFVdMn0kywB6sfd97GsU/jRK88jNjQSDfQQbQRV5BkxxkuASi6T9zz+rFnmepoIjyVrTUyeIPDe\n2fkhDlaXY0xsEs5xRaSlpjzBkqDPWIJTXleFl//8biy79wH4+/qhsrYW2UzoF3lPGEPS5NQ0BPn7\no6ChFtdGxbCPLxOvDyprKtBy8SLJ8DbLVB0GVtRUcfvtQwK+umTVaqyKHpSooxLmjBc+WIdxI1PM\nWZUnyfAoEYq7Wh394ug+REfEoUxLyR4SZJ0qIkHhqJzesiApBYtm32VIyMw5g1+sXYWPygp6Gfub\nCTy6ILhc9xpv6mJeUdmwazt+tmcbfhSTgGbqoFugiuFL+aSR15Zw9dW1yCilgYyhd35anIMjpzIx\nl/nCk8VjRNjk90XuWSbdOgSHhKGah3TapNmiK4WvAAKrPvN+vABxkVGoa2rEi++/jY9K8jE6PhkX\nuVJqYXj5Q142D5h48Md9gsC2OppbedZUdhZHRZLOndROkDVZJwlWr+qku9mQFYp9mSdw+43TjLd5\nyis8QoSdTAet7lxxAcEL4N6A07cI9CCir7JOswIiiCMThpmW/LISrCvOQwI3d5XMJ6280ZctsSTT\nnyGsuKnBIQGYPHoMfnnP3yGEqyT5SkFtNVbnZ6OTnmbI7unt/BCJRi9XUHtKC1FTX4eguHhnl369\n9ggRdgbKD+UNdUTb11j+l75ge7gWnnq+oD5BAYGmofnCBbP21467nSToPm3yznd1ItKwyfsIpC3z\nZ8yGfm3JyD6NtS8fw6WhERhC0ZIh0p1Fd3fSq+Dti5KWBjRyU4n/rUTIM7SiYQxxYvCVawHkNYTt\n3Z1obdOegRvsIO4XGIK8uHfwY1pXrXYKsfSaQHpELa+dwJ4tzEd9UxO8vdmfhJ4uzEOnr3/PguBy\nEni7KeLBsEzCdR7lyeJRj/D18UYEwwVoye6emImeDqLhp80aQ1BpVaXBYkRCEn6amIL1uaeQGj+c\nm70uA+r5lkYXqSROJLtQBM+UPsY/bV0DJI5hjuCJrV8ghjDkcK3+tdiqxezamfD9uCcJ9A/42r79\n0SDD6vdik6gvl5EpPNsBj7PtIZ5TuYGJ3tJJi0RQGLZnHENdcyMiQ0PxDwt/ijmxw5BTXoSKqjKc\nryzC4qRReEorJ3qOCVg9QPsLxKhEjOZZVWhYtMkVpMqpyu21ltHg0nhqVByiIsLd9umvSo95hH0O\nMCEllabHpEnQRIaKEyJZhtb18dxJr835b8zYuxsP/+U9SE+bgDeefg6nzp3FhYsXEBEWZurKuT94\n+djnlOE6Ppc8AzpDizZrbSL1G4pGob5BTOagl81IHY8w6vdk8RgR1ivSuFn623FT8Hr+GSSFRvC8\np+My7xAxdQQwPDwaS7e+i9b2dszlwVxiTByG8Rm0LVrq1ubnwjdoqHmBQEfogl2git4ufvCEyuQT\ne4+7T/UOoFG0c1ksI5mWfr1rf0N5Opr3RPHsEUfPxA7yWcPNrzyH5Ohh3A9cQg0B6BuqBI7qgmnf\nddxhz4pLxB0T0pHIHbQvwWqiV5zhWdOOc1nIpAeNYVy/d3QagrnT3pefg93cbev09qIhxT2U8gTp\nEXFp/oHILs3Dyjn34rGfPEgdPibvWANyL+GHq/UoEZq0Ji9LXvvRFix5+7cYPSKNZAAV3AGrzbkM\nVX/tF6IISpk2adzkKdGborDGJKyNWgCPJ1pJsjmd5WoLIeFmN67EL5nuimRrHMG0+CSuqLKZc5ak\nXoMXlz2F6LBwj5Kg8XmUCCm0m7s2hpv/3LYJyzav4aPMGIwMDjUrpjZ6h9bzAspZBFiAYrijqM8F\nEiOr11YtlJ6iI5Mm1unlAnckqE6bPJ3Cagdfz9BYX1WCh9LS8fySR8wm0uYzh6p+v/Q4EZqRJUPH\n1Z8dP4LffbQJm/NPu54vcJnpOj9yA6OQV7WTpb7dbB8pclfUrlygFxEucK9B7/ntzLuw8PYfG08Y\nCBI0zAEhQootGbquqqvDET4kOpiVieOlRajjs4b2LnMIouYfsOjZhDf8mU/GR8fjxjHjcEv6dUhN\nHmlCokKVMzT+gIq/UdSAEaGRuTZhtAbFe5ZWbuLqGhtxkUfYnTYXmJYf7o9eGvDz90P40FCEBvEw\nsKcMlCdY/QNKhB1EX0JsfX9/KkpdYpL3Yq7oG+H6W3df+YOCCDsoS4j93t+f1hP7W8+3ke+xDZ0G\n48wL7gbXCwxj9ZUOBt3d27dO1j7QVt53TFf63usRfa1RoHwTcFcS/G3b3On9tvd+l37S49Sl+fUS\n/10E/YB97XjMWPhFxnNZUfV3HeiV7lFbJ59H+HDzJblX6qt+6uPNfcH3KUq8XVwaW13fR8b3uUfj\nVpHe71q8n2MRKIWFhcjJyUFtLZ9MBQXCn0cFmZmZRl5ISIh5L9UCaJVYonS/irt2C3hDQwOOHTuG\nxMREA7C9V3qPHz+OgoICHj/rmYMX1q1bh5iYGJ41hV+m16nDXttPqysrKws7d+3C+HHjekGprDyP\nc+dyUFFRgZKSErS0tCAiIuKycVtZ+lT5urmpzfbVtcoHH3yA5uYWDB+eZMatOmcf57XkNjQ0Gvk6\nlTYnWmJy7969ZnANDfXYuHEjampqDBiBga6nZHZg+rS/sjo7eVnhqdOnOZDm3nbV2Ym0cyctMOx3\nDXLPnj144sknCVAujh49iu07dpj79+3bZ5aw6qNDN63vrU7V9b22dfaAro77kowTGV/RdfjwYSy8\n7z58/PHHBGxTr5FJlsbpTqaVqzbnte1r527bT57MxHm+uaiisdh6d/1b+Y83Z8+eRXl5uRmn8SEB\nKuu78cYbEMgHNwoJpwlqamoqqqqqUMb3kNLGppkBnzlzxlh1ZWWlESQlN9xwA8Tqhvc2YMLECZh2\n8824SEVnaJkC8aabboIv3dXPz7cXHHnAvzz7LH7/2muYPHmyCVsah4gMGcoH/ZSnsn37dvzpxAla\nWTLuWTDfjG3Hjo9x2223Qp66c+dOXHfddUhISMAnn3yCrKwzKOS/doWHh5n75azCsYv7kp899RQe\neeQRE7bUKAJkDEeOHEF8fDzmzZuH4OBg7Nq9G9dTpuq2b9+B9PRr+cijDUdoLPoXsdOns7Bg/nyk\njUsz+Gzdtg0X6GEZGScwZ85sknGecveavZCMPCY6GiNHjsSECROQm5uLbBIwa+ZMJCcP740CxiME\nZidBaGhoMkCUlpYabxDoCilSXMN3igRSdnY21J6RkYFp06YZsnbv/sQAOWnSRBMO5PJ6l2j69OlI\nGTUK+//4OSevA2qXZQkEWcPMGTMwfvx4fTXWo3CoIu8RcQJWRNyzYAHKqPOdd99FIx+BLl+xHPX1\n9abfmjVr0chN4MGDB/Hmm29i5kzKZEhqb+chIufFH1MUtwX4tm0fYsuWLcbjDh86jLfeegt33323\nmdsbb7xhosLmTZsMwDKMNWveNNcKaStW/BqRkZE0Oh+8vX6duWfVqlV8CNiKWbNmIZQvt6nUEqsH\nHviJkXUjjbSJY16/fr1p28WQmUcyAvQ/fyRa8lSMR8gDmjgZWYdCUVJSEsaOHYtixlLFam9OoiA/\nn7kjCCPJrBSlp6ebGCvQi4tLeFRdh9hYPi8YNsxYVTeBz8k9Z/q6CHA9uLHHedIpYm2ocibmABIi\nEPbvP4BFixYZskJChmL58hcMecbDSLRyyigSLcs+cOAAHnzwQUyaNMkQpNzjLCJFBLfyFFdWKgvf\nRwN5+OGHzT2xsbGUv5zzqEVKSoqRLfKSR4ww3q453HffQtxyyy0YSo/dtHkzQ20lTjAErl79BxNR\nJtIQXf/lCjz66KNY/NBDBvBwYnTo0CF6a5YxYulU0bhtODUeoUkH0SWnT78Fd955hwkl6tDBk0l1\nTh0zBmeZyCVI4Uptcj8V9Wnke0cKTU1888Fa9abNmxDB8DBp4kQmTFeY6eZhG23U3Cc3VdwW+R0d\nnSZxSab0SaaAi4qKZP44Z/oX81+4QvnIVOCXlZWRxBZDfjnDpkgM4xM7LTZUJEcynEXAT506FQsX\nLqS1PkDZUQjhnOWZKkVFRcYoFJqrq6uNFSsalJWWmXaNvZVHLyo6gukgqRqLXjJQhHDlwErz4oPw\n1KtDIlyGFkeSFT5/9avnjBckJycbOZqjLcYjtOaRq4RyMhIuMNRJ4cWQRE/QoFWvuDyR4CpkyGKV\n3GPpNcOHDzdhay+T/pQpUxDNuuKSUhNiamprcIGvxLhIcilXTH/11Vfx0ksr8SnJUKhRXHbF6RCO\nyAvzGYcVDgoLizjZEvz9smXG45SDVvx6hekvT5TlzpkzB48/8QSNoRmNXI0oR1hv02RlKDrK0BxU\nZEwLGPJefPFFvEBPKC4uxl/RUuXRCpfPP/8Cbv+L282iRfJFtiKCijAS0NGM/UuXLsEzzzxj9FeU\nV5gcordNQnmWJQwt2DKCxYsXmzxlMbbeIJlmQ6eE2sw4JkVSaotChyYgAGUFKoGBervBywCrhKt7\nRtB9pVBgy4ITE5NooaHG2mR5kmEno9DnHICsTstJtQsEyVPok/VLr4CWtcbFxRlr0hgUc+UVki2r\nkzdIrjyhjsvvmFjX41QtQKwu5RH1VSjVWO2KR/oVxgSq9KtoaStiIim/m9YtOTJILUCiWScs1Ef3\nqD4vL8+MVYleBi3SmpqajUdbMk6dOkWjewkrV640ecHqNwr5p3dnbSvcffa9qe933eOuzp0sZ903\n3dO3Xd9VrJV9F1nOvva6r3zVu6uz/b/Ppwzgww8/xHsb3sPSJX+NuXPvdqujlwh3A3BO3HltB+wc\nmLUyZ527674gSq5TtlOOvVa7ru299h77XXr69rV1dgxOHbZOn1aWrq332DqnfLWrWD3Oa/Xv21d1\nkqf9QsbJk8bjr73mGhMd3PXvJcJo+f8//Y6AOxKk9MuE0O9D+L+rQOBbAvp6jkXlfwCQnGFDn0fk\n9QAAAABJRU5ErkJggg==' /><br><h3>Diego Auctioneer Metrics</h3>\n\n<a href=\"https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#auctioneer\">https://docs.pivotal.io/pivotalcf/1-10/monitoring/kpi.html#auctioneer</a>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Time that the Diego Cell Rep took to sync the ActualLRPs that it claimed with its actual garden containers.",
+        "id": "DiVXQ3qAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Cell Rep Time to Sync",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Seconds",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": "metric_source",
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Cell Sync Time (15 Min. Max)",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('rep.RepBulkSyncDuration').max(over='15m').scale(1e-9).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVXNPCAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Container Count",
+        "options": {
+          "colorBy": "Metric",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": null,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "rep.ContainerCount - Sum",
+              "label": "A",
+              "paletteIndex": 2,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('rep.ContainerCount', filter=filter('metric_source', 'cloudfoundry') and filter('job', 'diego_cell'), rollup='latest').sum().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "The lifetime number of bad gateways, or 502 responses, from Gorouter itself",
+        "id": "DiVXLieAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Router Error: 502 Bad Gateway",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "gorouter.bad_gateways - Delta",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Maximum Bad Gateway delta over a 5 minute window",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('gorouter.bad_gateways').delta().publish(label='A')\nB = (A).max(over='5m').publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    }
+  ],
+  "crossLinkExports": [],
+  "dashboardExports": [
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DiVXMZjAcAA",
+            "column": 0,
+            "height": 2,
+            "row": 0,
+            "width": 6
+          },
+          {
+            "chartId": "DiVXNFhAgAA",
+            "column": 6,
+            "height": 2,
+            "row": 0,
+            "width": 6
+          },
+          {
+            "chartId": "DiVXNDGAYAA",
+            "column": 0,
+            "height": 2,
+            "row": 2,
+            "width": 6
+          },
+          {
+            "chartId": "DiVXMXXAgAA",
+            "column": 6,
+            "height": 2,
+            "row": 2,
+            "width": 6
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "An overview of Garden Containers on the platform",
+        "discoveryOptions": {
+          "query": "metric_source:cloudfoundry",
+          "selectors": [
+            "sf_key:app_name"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": [
+            {
+              "alias": "app_name",
+              "applyIfExists": false,
+              "description": "null",
+              "preferredSuggestions": [],
+              "property": "app_name",
+              "replaceOnly": false,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            },
+            {
+              "alias": "app_org",
+              "applyIfExists": false,
+              "description": "null",
+              "preferredSuggestions": [],
+              "property": "app_org",
+              "replaceOnly": false,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            },
+            {
+              "alias": "app_space",
+              "applyIfExists": false,
+              "description": "null",
+              "preferredSuggestions": [],
+              "property": "app_space",
+              "replaceOnly": false,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            }
+          ]
+        },
+        "groupId": "DiVXCtHAgAA",
+        "id": "DiVXMVEAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "Garden Containers",
+        "selectedEventOverlays": null,
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DiVXNPCAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXNM3AYAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXNGOAgD0",
+            "column": 8,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXNFuAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXN6PAYJs",
+            "column": 4,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXOHfAgAA",
+            "column": 8,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXNIgAcC0",
+            "column": 4,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXNIxAYC0",
+            "column": 0,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXNIyAgAE",
+            "column": 8,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXNFjAcCs",
+            "column": 0,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXNJlAcAA",
+            "column": 8,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXNRZAcAA",
+            "column": 4,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "Overview of all platform components.",
+        "discoveryOptions": {
+          "query": "metric_source:cloudfoundry",
+          "selectors": [
+            "sf_key:job"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": [
+            {
+              "alias": "Job",
+              "applyIfExists": false,
+              "description": "CloudFoundry job type",
+              "preferredSuggestions": [],
+              "property": "job",
+              "replaceOnly": false,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            }
+          ]
+        },
+        "groupId": "DiVXCtHAgAA",
+        "id": "DiVXNFhAgAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "CF Overview",
+        "selectedEventOverlays": null,
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DiVXJVqAYAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 6
+          },
+          {
+            "chartId": "DiVXJgNAcAA",
+            "column": 10,
+            "height": 2,
+            "row": 0,
+            "width": 2
+          },
+          {
+            "chartId": "DiVXFwQAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXGYlAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXJcuAgAA",
+            "column": 4,
+            "height": 1,
+            "row": 1,
+            "width": 6
+          },
+          {
+            "chartId": "DiVXF6eAYAA",
+            "column": 4,
+            "height": 1,
+            "row": 2,
+            "width": 6
+          },
+          {
+            "chartId": "DiVXG9IAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXJg_AYAI",
+            "column": 0,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXGUJAcAA",
+            "column": 4,
+            "height": 1,
+            "row": 3,
+            "width": 6
+          },
+          {
+            "chartId": "DiVXF-uAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 4,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXJRMAcAA",
+            "column": 4,
+            "height": 1,
+            "row": 4,
+            "width": 6
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "Metrics that help you determine when to scale your CF deployment up or down.",
+        "discoveryOptions": null,
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": null
+        },
+        "groupId": "DiVXCtHAgAA",
+        "id": "DiVXFg6AgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "Key Capacity Indicators",
+        "selectedEventOverlays": null,
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DiVXO0sAcAA",
+            "column": 8,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXO7fAYAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXOcWAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXO9DAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 6
+          },
+          {
+            "chartId": "DiVXOclAgAA",
+            "column": 6,
+            "height": 1,
+            "row": 1,
+            "width": 6
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "Host-specific dashboard.",
+        "discoveryOptions": {
+          "query": "metric_source:cloudfoundry",
+          "selectors": [
+            "_exists_:host",
+            "sf_key:host"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": [
+            {
+              "alias": "Host",
+              "applyIfExists": false,
+              "description": "Cloud Foundry IP address",
+              "preferredSuggestions": [],
+              "property": "host",
+              "replaceOnly": false,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            }
+          ]
+        },
+        "groupId": "DiVXCtHAgAA",
+        "id": "DiVXOPHAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "CF Host",
+        "selectedEventOverlays": null,
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DiVXDKWAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 6
+          },
+          {
+            "chartId": "DiVXDJPAcAA",
+            "column": 6,
+            "height": 1,
+            "row": 0,
+            "width": 6
+          },
+          {
+            "chartId": "DiVXDNmAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXCx0AYAA",
+            "column": 4,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXC13AgAA",
+            "column": 8,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "Key metrics related to the Doppler logging/metric component of CF.",
+        "discoveryOptions": {
+          "query": "metric_source:cloudfoundry AND job:(loggregator_trafficcontroller OR doppler)",
+          "selectors": [
+            "job: loggregator_trafficcontroller",
+            "_exists_:host",
+            "job:doppler",
+            "sf_key:host"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": null
+        },
+        "groupId": "DiVXCtHAgAA",
+        "id": "DiVXCwFAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "Doppler",
+        "selectedEventOverlays": null,
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DiVXLruAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 3
+          },
+          {
+            "chartId": "DiVXK5NAcAA",
+            "column": 3,
+            "height": 1,
+            "row": 0,
+            "width": 3
+          },
+          {
+            "chartId": "DiVXLqpAcAA",
+            "column": 6,
+            "height": 1,
+            "row": 0,
+            "width": 3
+          },
+          {
+            "chartId": "DiVXLy6AgAA",
+            "column": 9,
+            "height": 1,
+            "row": 0,
+            "width": 3
+          },
+          {
+            "chartId": "DiVXJ_rAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXLieAgAA",
+            "column": 4,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXKPaAYAA",
+            "column": 8,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXKnhAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXLYnAYAA",
+            "column": 4,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "Key Performance Indicators around the Gorouter system.",
+        "discoveryOptions": {
+          "query": "metric_source:cloudfoundry AND job:router",
+          "selectors": [
+            "_exists_:host",
+            "sf_key:host"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": null
+        },
+        "groupId": "DiVXCtHAgAA",
+        "id": "DiVXJycAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "Router",
+        "selectedEventOverlays": null,
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DiVXFRQAYAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXEKKAcAA",
+            "column": 8,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXEKgAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXEqkAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXEn8AgAA",
+            "column": 4,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXDmlAgAA",
+            "column": 8,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "Overview of the cloud controller component.",
+        "discoveryOptions": {
+          "query": "job:(cloud_controller OR cloud_controller_worker) AND metric_source:cloudfoundry",
+          "selectors": [
+            "_exists_:host",
+            "job:cloud_controller_worker",
+            "job:cloud_controller"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": null
+        },
+        "groupId": "DiVXCtHAgAA",
+        "id": "DiVXDktAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "Cloud Controller",
+        "selectedEventOverlays": null,
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DiVXMRcAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXMJHAgAA",
+            "column": 8,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXL-yAYAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "Host specific metrics for Diego Cells",
+        "discoveryOptions": {
+          "query": "metric_source:cloudfoundry AND job:diego_cell",
+          "selectors": [
+            "_exists_:host",
+            "sf_key:host"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": [
+            {
+              "alias": "Host IP",
+              "applyIfExists": false,
+              "description": "",
+              "preferredSuggestions": [],
+              "property": "host",
+              "replaceOnly": false,
+              "required": true,
+              "restricted": false,
+              "value": ""
+            }
+          ]
+        },
+        "groupId": "DiVXCtHAgAA",
+        "id": "DiVXL7QAcHI",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "Diego Cell",
+        "selectedEventOverlays": null,
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DiVXDihAcAg",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXDgTAgAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXDgPAYAA",
+            "column": 8,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "Metrics on specific Garden containers",
+        "discoveryOptions": {
+          "query": "metric_source:cloudfoundry",
+          "selectors": [
+            "_exists_:app_name",
+            "sf_key:app_name"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": [
+            {
+              "alias": "app_name",
+              "applyIfExists": false,
+              "description": "null",
+              "preferredSuggestions": [],
+              "property": "app_name",
+              "replaceOnly": false,
+              "required": false,
+              "restricted": false,
+              "value": "pivotal-account"
+            },
+            {
+              "alias": "app_instance_index",
+              "applyIfExists": false,
+              "description": "null",
+              "preferredSuggestions": [],
+              "property": "app_instance_index",
+              "replaceOnly": false,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            }
+          ]
+        },
+        "groupId": "DiVXCtHAgAA",
+        "id": "DiVXDOmAcHA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "Garden Container",
+        "selectedEventOverlays": null,
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DiVXRLCAYAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXQitAcAA",
+            "column": 8,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXPmjAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXQ3lAgAE",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXRPWAcAA",
+            "column": 4,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXQ3qAgAA",
+            "column": 8,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXQ34AgAA",
+            "column": 8,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXQAaAYAE",
+            "column": 0,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXPp4AYAA",
+            "column": 4,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXQzkAYAA",
+            "column": 4,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXQhZAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXQ3nAcAA",
+            "column": 8,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXRPQAgAI",
+            "column": 6,
+            "height": 1,
+            "row": 4,
+            "width": 6
+          },
+          {
+            "chartId": "DiVXP9lAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 4,
+            "width": 6
+          },
+          {
+            "chartId": "DiVXRB-AcAA",
+            "column": 0,
+            "height": 1,
+            "row": 5,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXQGxAcAA",
+            "column": 4,
+            "height": 1,
+            "row": 5,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXQ3wAcAA",
+            "column": 8,
+            "height": 1,
+            "row": 5,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXQNpAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 6,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXP6qAgAM",
+            "column": 4,
+            "height": 1,
+            "row": 6,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXQ3nAYAA",
+            "column": 4,
+            "height": 1,
+            "row": 7,
+            "width": 8
+          },
+          {
+            "chartId": "DiVXQErAgAE",
+            "column": 0,
+            "height": 1,
+            "row": 7,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXPiYAgAM",
+            "column": 0,
+            "height": 1,
+            "row": 8,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXQ3yAYAE",
+            "column": 4,
+            "height": 1,
+            "row": 8,
+            "width": 4
+          },
+          {
+            "chartId": "DiVXPiXAYCg",
+            "column": 8,
+            "height": 1,
+            "row": 8,
+            "width": 4
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "Key Performance Indicators related to Diego",
+        "discoveryOptions": {
+          "query": "metric_source:cloudfoundry AND job:(diego_cell OR diego_brain OR diego_database)",
+          "selectors": [
+            "job: diego_brain",
+            "job: diego_database",
+            "job: diego_cell"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": null
+        },
+        "groupId": "DiVXCtHAgAA",
+        "id": "DiVXPW-AcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "Diego",
+        "selectedEventOverlays": null,
+        "tags": null
+      }
+    }
+  ],
+  "groupExport": {
+    "group": {
+      "created": 0,
+      "creator": null,
+      "dashboards": [
+        "DiVXOPHAcAA",
+        "DiVXNFhAgAE",
+        "DiVXDktAYAA",
+        "DiVXPW-AcAA",
+        "DiVXL7QAcHI",
+        "DiVXCwFAcAA",
+        "DiVXDOmAcHA",
+        "DiVXMVEAYAA",
+        "DiVXFg6AgAA",
+        "DiVXJycAgAA"
+      ],
+      "description": "",
+      "email": null,
+      "id": "DiVXCtHAgAA",
+      "importQualifiers": [
+        {
+          "filters": [
+            {
+              "not": false,
+              "property": "metric_source",
+              "values": [
+                "cloudfoundry"
+              ]
+            }
+          ],
+          "metric": "system.cpu.sys"
+        }
+      ],
+      "lastUpdated": 0,
+      "lastUpdatedBy": null,
+      "name": "Cloud Foundry",
+      "teams": null
     }
   },
-  "hashCode" : -1499034680,
-  "id" : "DiVXCtHAgAA",
-  "modelVersion" : 1,
-  "packageType" : "GROUP"
+  "hashCode": 2099350983,
+  "id": "DiVXCtHAgAA",
+  "modelVersion": 1,
+  "packageType": "GROUP"
 }

--- a/navigators/Cloud Foundry/cf cloud controller.json
+++ b/navigators/Cloud Foundry/cf cloud controller.json
@@ -1,160 +1,187 @@
 {
-  "hashCode" : -1974189938,
-  "id" : "DiVVQC0AgAA",
-  "importQualifiers" : [ {
-    "filters" : [ {
-      "not" : false,
-      "property" : "metric_source",
-      "values" : [ "cloudfoundry" ]
-    }, {
-      "not" : false,
-      "property" : "job",
-      "values" : [ "cloud_controller", "cloud_controller_worker" ]
-    } ],
-    "metric" : "system.healthy"
-  } ],
-  "modelVersion" : 1,
-  "navigatorExport" : {
-    "navigator" : {
-      "created" : 0,
-      "creator" : null,
-      "description" : "",
-      "id" : "DiVVQC0AgAA",
-      "importQualifiers" : [ {
-        "filters" : [ {
-          "not" : false,
-          "property" : "metric_source",
-          "values" : [ "cloudfoundry" ]
-        }, {
-          "not" : false,
-          "property" : "job",
-          "values" : [ "cloud_controller", "cloud_controller_worker" ]
-        } ],
-        "metric" : "system.healthy"
-      } ],
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Cloud Controller",
-      "navigatorCategory" : "Cloud Foundry",
-      "navigatorType" : "architectural",
-      "uiModel" : {
-        "alertQuery" : "metric_source:cloudfoundry AND job:(cloud_controller cloud_controller_worker)",
-        "category" : "Cloud Foundry",
-        "categoryPriority" : 20,
-        "discoveryQuery" : [ "job:(cloud_controller cloud_controller_worker)" ],
-        "displayName" : "Cloud Controller",
-        "filterProperties" : null,
-        "id" : "cf cloud controller",
-        "listColumns" : [ {
-          "aggregate" : null,
-          "displayName" : "Instance",
-          "format" : "id",
-          "metric" : null,
-          "property" : "id",
-          "sortable" : null
-        }, {
-          "aggregate" : null,
-          "displayName" : "Value",
-          "format" : "Number",
-          "metric" : null,
-          "property" : "value",
-          "sortable" : null
-        }, {
-          "aggregate" : null,
-          "displayName" : "Job",
-          "format" : null,
-          "metric" : null,
-          "property" : "job",
-          "sortable" : null
-        } ],
-        "map" : {
-          "groupingStructure" : {
-            "children" : null,
-            "drawBoundary" : true,
-            "key" : "sf_streamLabel",
-            "memberSettings" : null
-          },
-          "job" : {
-            "filters" : [ ],
-            "resolution" : 300000,
-            "template" : "CLOUD_CONTROLLER = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"cloud_controller\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nCLOUD_CONTROLLER_WORKER = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"cloud_controller_worker\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
-            "varName" : null
-          },
-          "metrics" : [ {
-            "coloring" : {
-              "limits" : [ {
-                "color" : "#05ce00",
-                "lowerLimit" : 1.0
-              }, {
-                "color" : "#ea1849",
-                "lowerLimit" : 0.0
-              } ],
-              "maxValue" : 1,
-              "method" : "threshold",
-              "minValue" : 0,
-              "range" : null
-            },
-            "idTemplate" : "{{host}}",
-            "name" : "Controllers",
-            "valueFormat" : null,
-            "valueLabel" : "System Health",
-            "varName" : "CLOUD_CONTROLLER"
-          }, {
-            "coloring" : {
-              "limits" : [ {
-                "color" : "#05ce00",
-                "lowerLimit" : 1.0
-              }, {
-                "color" : "#ea1849",
-                "lowerLimit" : 0.0
-              } ],
-              "maxValue" : 1,
-              "method" : "threshold",
-              "minValue" : 0,
-              "range" : null
-            },
-            "idTemplate" : "{{host}}",
-            "name" : "Workers",
-            "valueFormat" : null,
-            "valueLabel" : "System Health",
-            "varName" : "CLOUD_CONTROLLER_WORKER"
-          } ]
-        },
-        "mtsQuery" : "metric_source:cloudfoundry",
-        "propertyColumns" : [ [ {
-          "header" : "Tags",
-          "properties" : [ "sf_tags" ]
-        }, {
-          "header" : "Other",
-          "properties" : [ ]
-        }, {
-          "header" : "AWS",
-          "properties" : [ ]
-        } ] ],
-        "requiredProperties" : [ "host" ],
-        "singleHostSystemDashboardName" : "CF Host",
-        "systemDashboardName" : null,
-        "systemDashboardPrefix" : null,
-        "tooltipKeyList" : [ {
-          "displayName" : "Instance",
-          "format" : null,
-          "isSummaryProperty" : true,
-          "property" : "id"
-        }, {
-          "displayName" : "Value",
-          "format" : "Number",
-          "isSummaryProperty" : true,
-          "property" : "value"
-        }, {
-          "displayName" : "Job",
-          "format" : null,
-          "isSummaryProperty" : true,
-          "property" : "job"
-        } ],
-        "type" : "architectural",
-        "unreleased" : false
-      }
-    }
-  },
-  "packageType" : "NAVIGATOR"
+    "hashCode": 854864785,
+    "id": "DiVVQC0AgAA",
+    "modelVersion": 1,
+    "navigatorExport": {
+        "navigator": {
+            "created": 0,
+            "creator": null,
+            "description": "",
+            "id": "DiVVQC0AgAA",
+            "importQualifiers": [
+                {
+                    "filters": [
+                        {
+                            "not": false,
+                            "property": "metric_source",
+                            "values": [
+                                "cloudfoundry"
+                            ]
+                        },
+                        {
+                            "not": false,
+                            "property": "job",
+                            "values": [
+                                "cloud_controller",
+                                "cloud_controller_worker"
+                            ]
+                        }
+                    ],
+                    "metric": "system.healthy"
+                }
+            ],
+            "lastUpdated": 0,
+            "lastUpdatedBy": null,
+            "name": "Cloud Controller",
+            "navigatorCategory": "Cloud Foundry",
+            "navigatorType": "architectural",
+            "uiModel": {
+                "alertQuery": "metric_source:cloudfoundry AND job:(cloud_controller OR cloud_controller_worker)",
+                "category": "Cloud Foundry",
+                "categoryPriority": 20,
+                "discoveryQuery": [
+                    "job:(cloud_controller OR cloud_controller_worker)"
+                ],
+                "displayName": "Cloud Controller",
+                "filterProperties": null,
+                "id": "cf cloud controller",
+                "listColumns": [
+                    {
+                        "aggregate": null,
+                        "displayName": "Instance",
+                        "format": "id",
+                        "metric": null,
+                        "property": "id",
+                        "sortable": null
+                    },
+                    {
+                        "aggregate": null,
+                        "displayName": "Value",
+                        "format": "Number",
+                        "metric": null,
+                        "property": "value",
+                        "sortable": null
+                    },
+                    {
+                        "aggregate": null,
+                        "displayName": "Job",
+                        "format": null,
+                        "metric": null,
+                        "property": "job",
+                        "sortable": null
+                    }
+                ],
+                "map": {
+                    "groupingStructure": {
+                        "children": null,
+                        "drawBoundary": true,
+                        "key": "sf_streamLabel",
+                        "memberSettings": null
+                    },
+                    "job": {
+                        "filters": [],
+                        "resolution": 300000,
+                        "template": "CLOUD_CONTROLLER = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"cloud_controller\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nCLOUD_CONTROLLER_WORKER = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"cloud_controller_worker\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
+                        "varName": null
+                    },
+                    "metrics": [
+                        {
+                            "coloring": {
+                                "limits": [
+                                    {
+                                        "color": "#05ce00",
+                                        "lowerLimit": 1
+                                    },
+                                    {
+                                        "color": "#ea1849",
+                                        "lowerLimit": 0
+                                    }
+                                ],
+                                "maxValue": 1,
+                                "method": "threshold",
+                                "minValue": 0,
+                                "range": null
+                            },
+                            "idTemplate": "{{host}}",
+                            "name": "Controllers",
+                            "valueFormat": null,
+                            "valueLabel": "System Health",
+                            "varName": "CLOUD_CONTROLLER"
+                        },
+                        {
+                            "coloring": {
+                                "limits": [
+                                    {
+                                        "color": "#05ce00",
+                                        "lowerLimit": 1
+                                    },
+                                    {
+                                        "color": "#ea1849",
+                                        "lowerLimit": 0
+                                    }
+                                ],
+                                "maxValue": 1,
+                                "method": "threshold",
+                                "minValue": 0,
+                                "range": null
+                            },
+                            "idTemplate": "{{host}}",
+                            "name": "Workers",
+                            "valueFormat": null,
+                            "valueLabel": "System Health",
+                            "varName": "CLOUD_CONTROLLER_WORKER"
+                        }
+                    ]
+                },
+                "mtsQuery": "metric_source:cloudfoundry",
+                "propertyColumns": [
+                    [
+                        {
+                            "header": "Tags",
+                            "properties": [
+                                "sf_tags"
+                            ]
+                        },
+                        {
+                            "header": "Other",
+                            "properties": []
+                        },
+                        {
+                            "header": "AWS",
+                            "properties": []
+                        }
+                    ]
+                ],
+                "requiredProperties": [
+                    "host"
+                ],
+                "singleHostSystemDashboardName": "CF Host",
+                "systemDashboardName": null,
+                "systemDashboardPrefix": null,
+                "tooltipKeyList": [
+                    {
+                        "displayName": "Instance",
+                        "format": null,
+                        "isSummaryProperty": true,
+                        "property": "id"
+                    },
+                    {
+                        "displayName": "Value",
+                        "format": "Number",
+                        "isSummaryProperty": true,
+                        "property": "value"
+                    },
+                    {
+                        "displayName": "Job",
+                        "format": null,
+                        "isSummaryProperty": true,
+                        "property": "job"
+                    }
+                ],
+                "type": "architectural",
+                "unreleased": false
+            }
+        }
+    },
+    "packageType": "NAVIGATOR"
 }

--- a/navigators/Cloud Foundry/cf diego.json
+++ b/navigators/Cloud Foundry/cf diego.json
@@ -1,179 +1,209 @@
 {
-  "hashCode" : -1712595415,
-  "id" : "DiVVEVhAYEM",
-  "importQualifiers" : [ {
-    "filters" : [ {
-      "not" : false,
-      "property" : "metric_source",
-      "values" : [ "cloudfoundry" ]
-    }, {
-      "not" : false,
-      "property" : "job",
-      "values" : [ "diego_cell" ]
-    } ],
-    "metric" : "rep.UnhealthyCell"
-  } ],
-  "modelVersion" : 1,
-  "navigatorExport" : {
-    "navigator" : {
-      "created" : 0,
-      "creator" : null,
-      "description" : "",
-      "id" : "DiVVEVhAYEM",
-      "importQualifiers" : [ {
-        "filters" : [ {
-          "not" : false,
-          "property" : "metric_source",
-          "values" : [ "cloudfoundry" ]
-        }, {
-          "not" : false,
-          "property" : "job",
-          "values" : [ "diego_cell" ]
-        } ],
-        "metric" : "rep.UnhealthyCell"
-      } ],
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Diego",
-      "navigatorCategory" : "Cloud Foundry",
-      "navigatorType" : "architectural",
-      "uiModel" : {
-        "alertQuery" : "metric_source:cloudfoundry AND job:(diego_cell diego_brain diego_database)",
-        "category" : "Cloud Foundry",
-        "categoryPriority" : 30,
-        "discoveryQuery" : [ "job:(diego_cell diego_brain diego_database)" ],
-        "displayName" : "Diego",
-        "filterProperties" : null,
-        "id" : "cf diego",
-        "listColumns" : [ {
-          "aggregate" : null,
-          "displayName" : "Instance",
-          "format" : "id",
-          "metric" : null,
-          "property" : "id",
-          "sortable" : null
-        }, {
-          "aggregate" : null,
-          "displayName" : "Value",
-          "format" : "Number",
-          "metric" : null,
-          "property" : "value",
-          "sortable" : null
-        }, {
-          "aggregate" : null,
-          "displayName" : "Job",
-          "format" : null,
-          "metric" : null,
-          "property" : "job",
-          "sortable" : null
-        } ],
-        "map" : {
-          "groupingStructure" : {
-            "children" : null,
-            "drawBoundary" : true,
-            "key" : "sf_streamLabel",
-            "memberSettings" : null
-          },
-          "job" : {
-            "filters" : [ ],
-            "resolution" : 300000,
-            "template" : "DIEGO_CELL = data(\"rep.UnhealthyCell\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"diego_cell\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nDIEGO_BRAIN = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"diego_brain\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nDIEGO_DATABASE = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"diego_database\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
-            "varName" : null
-          },
-          "metrics" : [ {
-            "coloring" : {
-              "limits" : [ {
-                "color" : "#ea1849",
-                "lowerLimit" : 1.0
-              }, {
-                "color" : "#05ce00",
-                "lowerLimit" : 0.0
-              } ],
-              "maxValue" : 1,
-              "method" : "threshold",
-              "minValue" : 0,
-              "range" : null
-            },
-            "idTemplate" : "{{host}}",
-            "name" : "Cells",
-            "valueFormat" : null,
-            "valueLabel" : "Cell Unhealthy",
-            "varName" : "DIEGO_CELL"
-          }, {
-            "coloring" : {
-              "limits" : [ {
-                "color" : "#05ce00",
-                "lowerLimit" : 1.0
-              }, {
-                "color" : "#ea1849",
-                "lowerLimit" : 0.0
-              } ],
-              "maxValue" : 1,
-              "method" : "threshold",
-              "minValue" : 0,
-              "range" : null
-            },
-            "idTemplate" : "{{host}}",
-            "name" : "Brains",
-            "valueFormat" : null,
-            "valueLabel" : "System Health",
-            "varName" : "DIEGO_BRAIN"
-          }, {
-            "coloring" : {
-              "limits" : [ {
-                "color" : "#05ce00",
-                "lowerLimit" : 1.0
-              }, {
-                "color" : "#ea1849",
-                "lowerLimit" : 0.0
-              } ],
-              "maxValue" : 1,
-              "method" : "threshold",
-              "minValue" : 0,
-              "range" : null
-            },
-            "idTemplate" : "{{host}}",
-            "name" : "Databases",
-            "valueFormat" : null,
-            "valueLabel" : "System Health",
-            "varName" : "DIEGO_DATABASE"
-          } ]
-        },
-        "mtsQuery" : "metric_source:cloudfoundry AND job:(diego_cell diego_brain diego_database)",
-        "propertyColumns" : [ [ {
-          "header" : "Tags",
-          "properties" : [ "sf_tags" ]
-        }, {
-          "header" : "Other",
-          "properties" : [ ]
-        }, {
-          "header" : "AWS",
-          "properties" : [ ]
-        } ] ],
-        "requiredProperties" : [ "host" ],
-        "singleHostSystemDashboardName" : "CF Host",
-        "systemDashboardName" : null,
-        "systemDashboardPrefix" : null,
-        "tooltipKeyList" : [ {
-          "displayName" : "Instance",
-          "format" : null,
-          "isSummaryProperty" : true,
-          "property" : "id"
-        }, {
-          "displayName" : "Value",
-          "format" : "Number",
-          "isSummaryProperty" : true,
-          "property" : "value"
-        }, {
-          "displayName" : "Job",
-          "format" : null,
-          "isSummaryProperty" : true,
-          "property" : "job"
-        } ],
-        "type" : "architectural",
-        "unreleased" : false
-      }
-    }
-  },
-  "packageType" : "NAVIGATOR"
+    "hashCode": -1263326903,
+    "id": "DiVVEVhAYEM",
+    "modelVersion": 1,
+    "navigatorExport": {
+        "navigator": {
+            "created": 0,
+            "creator": null,
+            "description": "",
+            "id": "DiVVEVhAYEM",
+            "importQualifiers": [
+                {
+                    "filters": [
+                        {
+                            "not": false,
+                            "property": "metric_source",
+                            "values": [
+                                "cloudfoundry"
+                            ]
+                        },
+                        {
+                            "not": false,
+                            "property": "job",
+                            "values": [
+                                "diego_cell"
+                            ]
+                        }
+                    ],
+                    "metric": "rep.UnhealthyCell"
+                }
+            ],
+            "lastUpdated": 0,
+            "lastUpdatedBy": null,
+            "name": "Diego",
+            "navigatorCategory": "Cloud Foundry",
+            "navigatorType": "architectural",
+            "uiModel": {
+                "alertQuery": "metric_source:cloudfoundry AND job:(diego_cell OR diego_brain OR diego_database)",
+                "category": "Cloud Foundry",
+                "categoryPriority": 30,
+                "discoveryQuery": [
+                    "job:(diego_cell OR diego_brain OR diego_database)"
+                ],
+                "displayName": "Diego",
+                "filterProperties": null,
+                "id": "cf diego",
+                "listColumns": [
+                    {
+                        "aggregate": null,
+                        "displayName": "Instance",
+                        "format": "id",
+                        "metric": null,
+                        "property": "id",
+                        "sortable": null
+                    },
+                    {
+                        "aggregate": null,
+                        "displayName": "Value",
+                        "format": "Number",
+                        "metric": null,
+                        "property": "value",
+                        "sortable": null
+                    },
+                    {
+                        "aggregate": null,
+                        "displayName": "Job",
+                        "format": null,
+                        "metric": null,
+                        "property": "job",
+                        "sortable": null
+                    }
+                ],
+                "map": {
+                    "groupingStructure": {
+                        "children": null,
+                        "drawBoundary": true,
+                        "key": "sf_streamLabel",
+                        "memberSettings": null
+                    },
+                    "job": {
+                        "filters": [],
+                        "resolution": 300000,
+                        "template": "DIEGO_CELL = data(\"rep.UnhealthyCell\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"diego_cell\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nDIEGO_BRAIN = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"diego_brain\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nDIEGO_DATABASE = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"diego_database\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
+                        "varName": null
+                    },
+                    "metrics": [
+                        {
+                            "coloring": {
+                                "limits": [
+                                    {
+                                        "color": "#ea1849",
+                                        "lowerLimit": 1
+                                    },
+                                    {
+                                        "color": "#05ce00",
+                                        "lowerLimit": 0
+                                    }
+                                ],
+                                "maxValue": 1,
+                                "method": "threshold",
+                                "minValue": 0,
+                                "range": null
+                            },
+                            "idTemplate": "{{host}}",
+                            "name": "Cells",
+                            "valueFormat": null,
+                            "valueLabel": "Cell Unhealthy",
+                            "varName": "DIEGO_CELL"
+                        },
+                        {
+                            "coloring": {
+                                "limits": [
+                                    {
+                                        "color": "#05ce00",
+                                        "lowerLimit": 1
+                                    },
+                                    {
+                                        "color": "#ea1849",
+                                        "lowerLimit": 0
+                                    }
+                                ],
+                                "maxValue": 1,
+                                "method": "threshold",
+                                "minValue": 0,
+                                "range": null
+                            },
+                            "idTemplate": "{{host}}",
+                            "name": "Brains",
+                            "valueFormat": null,
+                            "valueLabel": "System Health",
+                            "varName": "DIEGO_BRAIN"
+                        },
+                        {
+                            "coloring": {
+                                "limits": [
+                                    {
+                                        "color": "#05ce00",
+                                        "lowerLimit": 1
+                                    },
+                                    {
+                                        "color": "#ea1849",
+                                        "lowerLimit": 0
+                                    }
+                                ],
+                                "maxValue": 1,
+                                "method": "threshold",
+                                "minValue": 0,
+                                "range": null
+                            },
+                            "idTemplate": "{{host}}",
+                            "name": "Databases",
+                            "valueFormat": null,
+                            "valueLabel": "System Health",
+                            "varName": "DIEGO_DATABASE"
+                        }
+                    ]
+                },
+                "mtsQuery": "metric_source:cloudfoundry AND job:(diego_cell OR diego_brain OR diego_database)",
+                "propertyColumns": [
+                    [
+                        {
+                            "header": "Tags",
+                            "properties": [
+                                "sf_tags"
+                            ]
+                        },
+                        {
+                            "header": "Other",
+                            "properties": []
+                        },
+                        {
+                            "header": "AWS",
+                            "properties": []
+                        }
+                    ]
+                ],
+                "requiredProperties": [
+                    "host"
+                ],
+                "singleHostSystemDashboardName": "CF Host",
+                "systemDashboardName": null,
+                "systemDashboardPrefix": null,
+                "tooltipKeyList": [
+                    {
+                        "displayName": "Instance",
+                        "format": null,
+                        "isSummaryProperty": true,
+                        "property": "id"
+                    },
+                    {
+                        "displayName": "Value",
+                        "format": "Number",
+                        "isSummaryProperty": true,
+                        "property": "value"
+                    },
+                    {
+                        "displayName": "Job",
+                        "format": null,
+                        "isSummaryProperty": true,
+                        "property": "job"
+                    }
+                ],
+                "type": "architectural",
+                "unreleased": false
+            }
+        }
+    },
+    "packageType": "NAVIGATOR"
 }

--- a/navigators/Cloud Foundry/cf logging.json
+++ b/navigators/Cloud Foundry/cf logging.json
@@ -1,160 +1,187 @@
 {
-  "hashCode" : -2004065539,
-  "id" : "DiVVGjvAgAA",
-  "importQualifiers" : [ {
-    "filters" : [ {
-      "not" : false,
-      "property" : "metric_source",
-      "values" : [ "cloudfoundry" ]
-    }, {
-      "not" : false,
-      "property" : "job",
-      "values" : [ "loggregator_trafficcontroller", "doppler" ]
-    } ],
-    "metric" : "system.healthy"
-  } ],
-  "modelVersion" : 1,
-  "navigatorExport" : {
-    "navigator" : {
-      "created" : 0,
-      "creator" : null,
-      "description" : "",
-      "id" : "DiVVGjvAgAA",
-      "importQualifiers" : [ {
-        "filters" : [ {
-          "not" : false,
-          "property" : "metric_source",
-          "values" : [ "cloudfoundry" ]
-        }, {
-          "not" : false,
-          "property" : "job",
-          "values" : [ "loggregator_trafficcontroller", "doppler" ]
-        } ],
-        "metric" : "system.healthy"
-      } ],
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Logging",
-      "navigatorCategory" : "Cloud Foundry",
-      "navigatorType" : "architectural",
-      "uiModel" : {
-        "alertQuery" : "metric_source:cloudfoundry AND job:(loggregator_trafficcontroller doppler)",
-        "category" : "Cloud Foundry",
-        "categoryPriority" : 40,
-        "discoveryQuery" : [ "job:(loggregator_trafficcontroller doppler)" ],
-        "displayName" : "Logging",
-        "filterProperties" : null,
-        "id" : "cf logging",
-        "listColumns" : [ {
-          "aggregate" : null,
-          "displayName" : "Instance",
-          "format" : "id",
-          "metric" : null,
-          "property" : "id",
-          "sortable" : null
-        }, {
-          "aggregate" : null,
-          "displayName" : "Value",
-          "format" : "Number",
-          "metric" : null,
-          "property" : "value",
-          "sortable" : null
-        }, {
-          "aggregate" : null,
-          "displayName" : "Job",
-          "format" : null,
-          "metric" : null,
-          "property" : "job",
-          "sortable" : null
-        } ],
-        "map" : {
-          "groupingStructure" : {
-            "children" : null,
-            "drawBoundary" : true,
-            "key" : "sf_streamLabel",
-            "memberSettings" : null
-          },
-          "job" : {
-            "filters" : [ ],
-            "resolution" : 300000,
-            "template" : "DOPPLER = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"doppler\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nLOGGREGATOR_TRAFFICCONTROLLER = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"loggregator_trafficcontroller\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
-            "varName" : null
-          },
-          "metrics" : [ {
-            "coloring" : {
-              "limits" : [ {
-                "color" : "#05ce00",
-                "lowerLimit" : 1.0
-              }, {
-                "color" : "#ea1849",
-                "lowerLimit" : 0.0
-              } ],
-              "maxValue" : 1,
-              "method" : "threshold",
-              "minValue" : 0,
-              "range" : null
-            },
-            "idTemplate" : "{{host}}",
-            "name" : "Dopplers",
-            "valueFormat" : null,
-            "valueLabel" : "System Health",
-            "varName" : "DOPPLER"
-          }, {
-            "coloring" : {
-              "limits" : [ {
-                "color" : "#05ce00",
-                "lowerLimit" : 1.0
-              }, {
-                "color" : "#ea1849",
-                "lowerLimit" : 0.0
-              } ],
-              "maxValue" : 1,
-              "method" : "threshold",
-              "minValue" : 0,
-              "range" : null
-            },
-            "idTemplate" : "{{host}}",
-            "name" : "Traffic Controllers",
-            "valueFormat" : null,
-            "valueLabel" : "System Health",
-            "varName" : "LOGGREGATOR_TRAFFICCONTROLLER"
-          } ]
-        },
-        "mtsQuery" : "metric_source:cloudfoundry AND job:(loggregator_trafficcontroller doppler)",
-        "propertyColumns" : [ [ {
-          "header" : "Tags",
-          "properties" : [ "sf_tags" ]
-        }, {
-          "header" : "Other",
-          "properties" : [ ]
-        }, {
-          "header" : "AWS",
-          "properties" : [ ]
-        } ] ],
-        "requiredProperties" : [ "host" ],
-        "singleHostSystemDashboardName" : "CF Host",
-        "systemDashboardName" : null,
-        "systemDashboardPrefix" : null,
-        "tooltipKeyList" : [ {
-          "displayName" : "Instance",
-          "format" : null,
-          "isSummaryProperty" : true,
-          "property" : "id"
-        }, {
-          "displayName" : "Value",
-          "format" : "Number",
-          "isSummaryProperty" : true,
-          "property" : "value"
-        }, {
-          "displayName" : "Job",
-          "format" : null,
-          "isSummaryProperty" : true,
-          "property" : "job"
-        } ],
-        "type" : "architectural",
-        "unreleased" : false
-      }
-    }
-  },
-  "packageType" : "NAVIGATOR"
+    "hashCode": -1323779172,
+    "id": "DiVVGjvAgAA",
+    "modelVersion": 1,
+    "navigatorExport": {
+        "navigator": {
+            "created": 0,
+            "creator": null,
+            "description": "",
+            "id": "DiVVGjvAgAA",
+            "importQualifiers": [
+                {
+                    "filters": [
+                        {
+                            "not": false,
+                            "property": "metric_source",
+                            "values": [
+                                "cloudfoundry"
+                            ]
+                        },
+                        {
+                            "not": false,
+                            "property": "job",
+                            "values": [
+                                "loggregator_trafficcontroller",
+                                "doppler"
+                            ]
+                        }
+                    ],
+                    "metric": "system.healthy"
+                }
+            ],
+            "lastUpdated": 0,
+            "lastUpdatedBy": null,
+            "name": "Logging",
+            "navigatorCategory": "Cloud Foundry",
+            "navigatorType": "architectural",
+            "uiModel": {
+                "alertQuery": "metric_source:cloudfoundry AND job:(loggregator_trafficcontroller OR doppler)",
+                "category": "Cloud Foundry",
+                "categoryPriority": 40,
+                "discoveryQuery": [
+                    "job:(loggregator_trafficcontroller OR doppler)"
+                ],
+                "displayName": "Logging",
+                "filterProperties": null,
+                "id": "cf logging",
+                "listColumns": [
+                    {
+                        "aggregate": null,
+                        "displayName": "Instance",
+                        "format": "id",
+                        "metric": null,
+                        "property": "id",
+                        "sortable": null
+                    },
+                    {
+                        "aggregate": null,
+                        "displayName": "Value",
+                        "format": "Number",
+                        "metric": null,
+                        "property": "value",
+                        "sortable": null
+                    },
+                    {
+                        "aggregate": null,
+                        "displayName": "Job",
+                        "format": null,
+                        "metric": null,
+                        "property": "job",
+                        "sortable": null
+                    }
+                ],
+                "map": {
+                    "groupingStructure": {
+                        "children": null,
+                        "drawBoundary": true,
+                        "key": "sf_streamLabel",
+                        "memberSettings": null
+                    },
+                    "job": {
+                        "filters": [],
+                        "resolution": 300000,
+                        "template": "DOPPLER = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"doppler\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nLOGGREGATOR_TRAFFICCONTROLLER = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"loggregator_trafficcontroller\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
+                        "varName": null
+                    },
+                    "metrics": [
+                        {
+                            "coloring": {
+                                "limits": [
+                                    {
+                                        "color": "#05ce00",
+                                        "lowerLimit": 1
+                                    },
+                                    {
+                                        "color": "#ea1849",
+                                        "lowerLimit": 0
+                                    }
+                                ],
+                                "maxValue": 1,
+                                "method": "threshold",
+                                "minValue": 0,
+                                "range": null
+                            },
+                            "idTemplate": "{{host}}",
+                            "name": "Dopplers",
+                            "valueFormat": null,
+                            "valueLabel": "System Health",
+                            "varName": "DOPPLER"
+                        },
+                        {
+                            "coloring": {
+                                "limits": [
+                                    {
+                                        "color": "#05ce00",
+                                        "lowerLimit": 1
+                                    },
+                                    {
+                                        "color": "#ea1849",
+                                        "lowerLimit": 0
+                                    }
+                                ],
+                                "maxValue": 1,
+                                "method": "threshold",
+                                "minValue": 0,
+                                "range": null
+                            },
+                            "idTemplate": "{{host}}",
+                            "name": "Traffic Controllers",
+                            "valueFormat": null,
+                            "valueLabel": "System Health",
+                            "varName": "LOGGREGATOR_TRAFFICCONTROLLER"
+                        }
+                    ]
+                },
+                "mtsQuery": "metric_source:cloudfoundry AND job:(loggregator_trafficcontroller OR doppler)",
+                "propertyColumns": [
+                    [
+                        {
+                            "header": "Tags",
+                            "properties": [
+                                "sf_tags"
+                            ]
+                        },
+                        {
+                            "header": "Other",
+                            "properties": []
+                        },
+                        {
+                            "header": "AWS",
+                            "properties": []
+                        }
+                    ]
+                ],
+                "requiredProperties": [
+                    "host"
+                ],
+                "singleHostSystemDashboardName": "CF Host",
+                "systemDashboardName": null,
+                "systemDashboardPrefix": null,
+                "tooltipKeyList": [
+                    {
+                        "displayName": "Instance",
+                        "format": null,
+                        "isSummaryProperty": true,
+                        "property": "id"
+                    },
+                    {
+                        "displayName": "Value",
+                        "format": "Number",
+                        "isSummaryProperty": true,
+                        "property": "value"
+                    },
+                    {
+                        "displayName": "Job",
+                        "format": null,
+                        "isSummaryProperty": true,
+                        "property": "job"
+                    }
+                ],
+                "type": "architectural",
+                "unreleased": false
+            }
+        }
+    },
+    "packageType": "NAVIGATOR"
 }

--- a/navigators/Cloud Foundry/cf other services.json
+++ b/navigators/Cloud Foundry/cf other services.json
@@ -1,179 +1,211 @@
 {
-  "hashCode" : 1998771543,
-  "id" : "DiVVAuiAcJE",
-  "importQualifiers" : [ {
-    "filters" : [ {
-      "not" : false,
-      "property" : "metric_source",
-      "values" : [ "cloudfoundry" ]
-    }, {
-      "not" : false,
-      "property" : "job",
-      "values" : [ "clock_global", "router", "uaa" ]
-    } ],
-    "metric" : "system.healthy"
-  } ],
-  "modelVersion" : 1,
-  "navigatorExport" : {
-    "navigator" : {
-      "created" : 0,
-      "creator" : null,
-      "description" : "",
-      "id" : "DiVVAuiAcJE",
-      "importQualifiers" : [ {
-        "filters" : [ {
-          "not" : false,
-          "property" : "metric_source",
-          "values" : [ "cloudfoundry" ]
-        }, {
-          "not" : false,
-          "property" : "job",
-          "values" : [ "clock_global", "router", "uaa" ]
-        } ],
-        "metric" : "system.healthy"
-      } ],
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Other Services",
-      "navigatorCategory" : "Cloud Foundry",
-      "navigatorType" : "architectural",
-      "uiModel" : {
-        "alertQuery" : "metric_source:cloudfoundry AND job:(uaa clock_global router)",
-        "category" : "Cloud Foundry",
-        "categoryPriority" : 70,
-        "discoveryQuery" : [ "sf_key:job" ],
-        "displayName" : "Other Services",
-        "filterProperties" : null,
-        "id" : "cf other services",
-        "listColumns" : [ {
-          "aggregate" : null,
-          "displayName" : "Instance",
-          "format" : "id",
-          "metric" : null,
-          "property" : "id",
-          "sortable" : null
-        }, {
-          "aggregate" : null,
-          "displayName" : "Value",
-          "format" : "Number",
-          "metric" : null,
-          "property" : "value",
-          "sortable" : null
-        }, {
-          "aggregate" : null,
-          "displayName" : "Job",
-          "format" : null,
-          "metric" : null,
-          "property" : "job",
-          "sortable" : null
-        } ],
-        "map" : {
-          "groupingStructure" : {
-            "children" : null,
-            "drawBoundary" : true,
-            "key" : "sf_streamLabel",
-            "memberSettings" : null
-          },
-          "job" : {
-            "filters" : [ ],
-            "resolution" : 300000,
-            "template" : "UAA = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"uaa\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nCLOCK_GLOBAL = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"clock_global\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nROUTER = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"router\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
-            "varName" : null
-          },
-          "metrics" : [ {
-            "coloring" : {
-              "limits" : [ {
-                "color" : "#05ce00",
-                "lowerLimit" : 1.0
-              }, {
-                "color" : "#ea1849",
-                "lowerLimit" : 0.0
-              } ],
-              "maxValue" : 1,
-              "method" : "threshold",
-              "minValue" : 0,
-              "range" : null
-            },
-            "idTemplate" : "{{host}}",
-            "name" : "UAAs",
-            "valueFormat" : null,
-            "valueLabel" : "System Health",
-            "varName" : "UAA"
-          }, {
-            "coloring" : {
-              "limits" : [ {
-                "color" : "#05ce00",
-                "lowerLimit" : 1.0
-              }, {
-                "color" : "#ea1849",
-                "lowerLimit" : 0.0
-              } ],
-              "maxValue" : 1,
-              "method" : "threshold",
-              "minValue" : 0,
-              "range" : null
-            },
-            "idTemplate" : "{{host}}",
-            "name" : "Clock Globals",
-            "valueFormat" : null,
-            "valueLabel" : "System Health",
-            "varName" : "CLOCK_GLOBAL"
-          }, {
-            "coloring" : {
-              "limits" : [ {
-                "color" : "#05ce00",
-                "lowerLimit" : 1.0
-              }, {
-                "color" : "#ea1849",
-                "lowerLimit" : 0.0
-              } ],
-              "maxValue" : 1,
-              "method" : "threshold",
-              "minValue" : 0,
-              "range" : null
-            },
-            "idTemplate" : "{{host}}",
-            "name" : "Routers",
-            "valueFormat" : null,
-            "valueLabel" : "System Health",
-            "varName" : "ROUTER"
-          } ]
-        },
-        "mtsQuery" : "metric_source:cloudfoundry AND job:(uaa clock_global router)",
-        "propertyColumns" : [ [ {
-          "header" : "Tags",
-          "properties" : [ "sf_tags" ]
-        }, {
-          "header" : "Other",
-          "properties" : [ ]
-        }, {
-          "header" : "AWS",
-          "properties" : [ ]
-        } ] ],
-        "requiredProperties" : [ "host" ],
-        "singleHostSystemDashboardName" : "CF Host",
-        "systemDashboardName" : null,
-        "systemDashboardPrefix" : null,
-        "tooltipKeyList" : [ {
-          "displayName" : "Name",
-          "format" : null,
-          "isSummaryProperty" : true,
-          "property" : "id"
-        }, {
-          "displayName" : "Value",
-          "format" : "Number",
-          "isSummaryProperty" : true,
-          "property" : "value"
-        }, {
-          "displayName" : "Job",
-          "format" : null,
-          "isSummaryProperty" : true,
-          "property" : "job"
-        } ],
-        "type" : "architectural",
-        "unreleased" : false
-      }
-    }
-  },
-  "packageType" : "NAVIGATOR"
+    "hashCode": -711617912,
+    "id": "DiVVAuiAcJE",
+    "modelVersion": 1,
+    "navigatorExport": {
+        "navigator": {
+            "created": 0,
+            "creator": null,
+            "description": "",
+            "id": "DiVVAuiAcJE",
+            "importQualifiers": [
+                {
+                    "filters": [
+                        {
+                            "not": false,
+                            "property": "metric_source",
+                            "values": [
+                                "cloudfoundry"
+                            ]
+                        },
+                        {
+                            "not": false,
+                            "property": "job",
+                            "values": [
+                                "clock_global",
+                                "router",
+                                "uaa"
+                            ]
+                        }
+                    ],
+                    "metric": "system.healthy"
+                }
+            ],
+            "lastUpdated": 0,
+            "lastUpdatedBy": null,
+            "name": "Other Services",
+            "navigatorCategory": "Cloud Foundry",
+            "navigatorType": "architectural",
+            "uiModel": {
+                "alertQuery": "metric_source:cloudfoundry AND job:(uaa OR clock_global OR router)",
+                "category": "Cloud Foundry",
+                "categoryPriority": 70,
+                "discoveryQuery": [
+                    "sf_key:job"
+                ],
+                "displayName": "Other Services",
+                "filterProperties": null,
+                "id": "cf other services",
+                "listColumns": [
+                    {
+                        "aggregate": null,
+                        "displayName": "Instance",
+                        "format": "id",
+                        "metric": null,
+                        "property": "id",
+                        "sortable": null
+                    },
+                    {
+                        "aggregate": null,
+                        "displayName": "Value",
+                        "format": "Number",
+                        "metric": null,
+                        "property": "value",
+                        "sortable": null
+                    },
+                    {
+                        "aggregate": null,
+                        "displayName": "Job",
+                        "format": null,
+                        "metric": null,
+                        "property": "job",
+                        "sortable": null
+                    }
+                ],
+                "map": {
+                    "groupingStructure": {
+                        "children": null,
+                        "drawBoundary": true,
+                        "key": "sf_streamLabel",
+                        "memberSettings": null
+                    },
+                    "job": {
+                        "filters": [],
+                        "resolution": 300000,
+                        "template": "UAA = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"uaa\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nCLOCK_GLOBAL = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"clock_global\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nROUTER = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"router\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
+                        "varName": null
+                    },
+                    "metrics": [
+                        {
+                            "coloring": {
+                                "limits": [
+                                    {
+                                        "color": "#05ce00",
+                                        "lowerLimit": 1
+                                    },
+                                    {
+                                        "color": "#ea1849",
+                                        "lowerLimit": 0
+                                    }
+                                ],
+                                "maxValue": 1,
+                                "method": "threshold",
+                                "minValue": 0,
+                                "range": null
+                            },
+                            "idTemplate": "{{host}}",
+                            "name": "UAAs",
+                            "valueFormat": null,
+                            "valueLabel": "System Health",
+                            "varName": "UAA"
+                        },
+                        {
+                            "coloring": {
+                                "limits": [
+                                    {
+                                        "color": "#05ce00",
+                                        "lowerLimit": 1
+                                    },
+                                    {
+                                        "color": "#ea1849",
+                                        "lowerLimit": 0
+                                    }
+                                ],
+                                "maxValue": 1,
+                                "method": "threshold",
+                                "minValue": 0,
+                                "range": null
+                            },
+                            "idTemplate": "{{host}}",
+                            "name": "Clock Globals",
+                            "valueFormat": null,
+                            "valueLabel": "System Health",
+                            "varName": "CLOCK_GLOBAL"
+                        },
+                        {
+                            "coloring": {
+                                "limits": [
+                                    {
+                                        "color": "#05ce00",
+                                        "lowerLimit": 1
+                                    },
+                                    {
+                                        "color": "#ea1849",
+                                        "lowerLimit": 0
+                                    }
+                                ],
+                                "maxValue": 1,
+                                "method": "threshold",
+                                "minValue": 0,
+                                "range": null
+                            },
+                            "idTemplate": "{{host}}",
+                            "name": "Routers",
+                            "valueFormat": null,
+                            "valueLabel": "System Health",
+                            "varName": "ROUTER"
+                        }
+                    ]
+                },
+                "mtsQuery": "metric_source:cloudfoundry AND job:(uaa OR clock_global OR router)",
+                "propertyColumns": [
+                    [
+                        {
+                            "header": "Tags",
+                            "properties": [
+                                "sf_tags"
+                            ]
+                        },
+                        {
+                            "header": "Other",
+                            "properties": []
+                        },
+                        {
+                            "header": "AWS",
+                            "properties": []
+                        }
+                    ]
+                ],
+                "requiredProperties": [
+                    "host"
+                ],
+                "singleHostSystemDashboardName": "CF Host",
+                "systemDashboardName": null,
+                "systemDashboardPrefix": null,
+                "tooltipKeyList": [
+                    {
+                        "displayName": "Name",
+                        "format": null,
+                        "isSummaryProperty": true,
+                        "property": "id"
+                    },
+                    {
+                        "displayName": "Value",
+                        "format": "Number",
+                        "isSummaryProperty": true,
+                        "property": "value"
+                    },
+                    {
+                        "displayName": "Job",
+                        "format": null,
+                        "isSummaryProperty": true,
+                        "property": "job"
+                    }
+                ],
+                "type": "architectural",
+                "unreleased": false
+            }
+        }
+    },
+    "packageType": "NAVIGATOR"
 }

--- a/navigators/Cloud Foundry/cf service brokers.json
+++ b/navigators/Cloud Foundry/cf service brokers.json
@@ -1,198 +1,235 @@
 {
-  "hashCode" : -356581196,
-  "id" : "DiVVOc8AYAA",
-  "importQualifiers" : [ {
-    "filters" : [ {
-      "not" : false,
-      "property" : "metric_source",
-      "values" : [ "cloudfoundry" ]
-    }, {
-      "not" : false,
-      "property" : "job",
-      "values" : [ "nats", "etcd_server", "consul_server", "etcd_tls_server" ]
-    } ],
-    "metric" : "system.healthy"
-  } ],
-  "modelVersion" : 1,
-  "navigatorExport" : {
-    "navigator" : {
-      "created" : 0,
-      "creator" : null,
-      "description" : "",
-      "id" : "DiVVOc8AYAA",
-      "importQualifiers" : [ {
-        "filters" : [ {
-          "not" : false,
-          "property" : "metric_source",
-          "values" : [ "cloudfoundry" ]
-        }, {
-          "not" : false,
-          "property" : "job",
-          "values" : [ "nats", "etcd_server", "consul_server", "etcd_tls_server" ]
-        } ],
-        "metric" : "system.healthy"
-      } ],
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Service Brokers",
-      "navigatorCategory" : "Cloud Foundry",
-      "navigatorType" : "architectural",
-      "uiModel" : {
-        "alertQuery" : "metric_source:cloudfoundry AND job:(consul_server etcd_server etcd_tls_server nats)",
-        "category" : "Cloud Foundry",
-        "categoryPriority" : 60,
-        "discoveryQuery" : [ "sf_key:job" ],
-        "displayName" : "Service Brokers",
-        "filterProperties" : null,
-        "id" : "cf service brokers",
-        "listColumns" : [ {
-          "aggregate" : null,
-          "displayName" : "Instance",
-          "format" : "id",
-          "metric" : null,
-          "property" : "id",
-          "sortable" : null
-        }, {
-          "aggregate" : null,
-          "displayName" : "Value",
-          "format" : "Number",
-          "metric" : null,
-          "property" : "value",
-          "sortable" : null
-        }, {
-          "aggregate" : null,
-          "displayName" : "Job",
-          "format" : null,
-          "metric" : null,
-          "property" : "job",
-          "sortable" : null
-        } ],
-        "map" : {
-          "groupingStructure" : {
-            "children" : null,
-            "drawBoundary" : true,
-            "key" : "sf_streamLabel",
-            "memberSettings" : null
-          },
-          "job" : {
-            "filters" : [ ],
-            "resolution" : 300000,
-            "template" : "CONSUL_SERVER = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"consul_server\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nETCD_SERVER = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"etcd_server\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nETCD_TLS_SERVER = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"etcd_tls_server\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nNATS = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"nats\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
-            "varName" : null
-          },
-          "metrics" : [ {
-            "coloring" : {
-              "limits" : [ {
-                "color" : "#05ce00",
-                "lowerLimit" : 1.0
-              }, {
-                "color" : "#ea1849",
-                "lowerLimit" : 0.0
-              } ],
-              "maxValue" : 1,
-              "method" : "threshold",
-              "minValue" : 0,
-              "range" : null
-            },
-            "idTemplate" : "{{host}}",
-            "name" : "NATS",
-            "valueFormat" : null,
-            "valueLabel" : "System Health",
-            "varName" : "NATS"
-          }, {
-            "coloring" : {
-              "limits" : [ {
-                "color" : "#05ce00",
-                "lowerLimit" : 1.0
-              }, {
-                "color" : "#ea1849",
-                "lowerLimit" : 0.0
-              } ],
-              "maxValue" : 1,
-              "method" : "threshold",
-              "minValue" : 0,
-              "range" : null
-            },
-            "idTemplate" : "{{host}}",
-            "name" : "etcds",
-            "valueFormat" : null,
-            "valueLabel" : "System Health",
-            "varName" : "ETCD_SERVER"
-          }, {
-            "coloring" : {
-              "limits" : [ {
-                "color" : "#05ce00",
-                "lowerLimit" : 1.0
-              }, {
-                "color" : "#ea1849",
-                "lowerLimit" : 0.0
-              } ],
-              "maxValue" : 1,
-              "method" : "threshold",
-              "minValue" : 0,
-              "range" : null
-            },
-            "idTemplate" : "{{host}}",
-            "name" : "etcds (TLS)",
-            "valueFormat" : null,
-            "valueLabel" : "System Health",
-            "varName" : "ETCD_TLS_SERVER"
-          }, {
-            "coloring" : {
-              "limits" : [ {
-                "color" : "#05ce00",
-                "lowerLimit" : 1.0
-              }, {
-                "color" : "#ea1849",
-                "lowerLimit" : 0.0
-              } ],
-              "maxValue" : 1,
-              "method" : "threshold",
-              "minValue" : 0,
-              "range" : null
-            },
-            "idTemplate" : "{{host}}",
-            "name" : "Consul",
-            "valueFormat" : null,
-            "valueLabel" : "System Health",
-            "varName" : "CONSUL_SERVER"
-          } ]
-        },
-        "mtsQuery" : "metric_source:cloudfoundry AND job:(consul_server etcd_server etcd_tls_server nats)",
-        "propertyColumns" : [ [ {
-          "header" : "Tags",
-          "properties" : [ "sf_tags" ]
-        }, {
-          "header" : "Other",
-          "properties" : [ ]
-        }, {
-          "header" : "AWS",
-          "properties" : [ ]
-        } ] ],
-        "requiredProperties" : [ "host" ],
-        "singleHostSystemDashboardName" : "CF Host",
-        "systemDashboardName" : null,
-        "systemDashboardPrefix" : null,
-        "tooltipKeyList" : [ {
-          "displayName" : "Instance",
-          "format" : null,
-          "isSummaryProperty" : true,
-          "property" : "id"
-        }, {
-          "displayName" : "Value",
-          "format" : "Number",
-          "isSummaryProperty" : true,
-          "property" : "value"
-        }, {
-          "displayName" : "Job",
-          "format" : null,
-          "isSummaryProperty" : true,
-          "property" : "job"
-        } ],
-        "type" : "architectural",
-        "unreleased" : false
-      }
-    }
-  },
-  "packageType" : "NAVIGATOR"
+    "hashCode": 945023184,
+    "id": "DiVVOc8AYAA",
+    "modelVersion": 1,
+    "navigatorExport": {
+        "navigator": {
+            "created": 0,
+            "creator": null,
+            "description": "",
+            "id": "DiVVOc8AYAA",
+            "importQualifiers": [
+                {
+                    "filters": [
+                        {
+                            "not": false,
+                            "property": "metric_source",
+                            "values": [
+                                "cloudfoundry"
+                            ]
+                        },
+                        {
+                            "not": false,
+                            "property": "job",
+                            "values": [
+                                "nats",
+                                "etcd_server",
+                                "consul_server",
+                                "etcd_tls_server"
+                            ]
+                        }
+                    ],
+                    "metric": "system.healthy"
+                }
+            ],
+            "lastUpdated": 0,
+            "lastUpdatedBy": null,
+            "name": "Service Brokers",
+            "navigatorCategory": "Cloud Foundry",
+            "navigatorType": "architectural",
+            "uiModel": {
+                "alertQuery": "metric_source:cloudfoundry AND job:(consul_server OR etcd_server OR etcd_tls_server OR nats)",
+                "category": "Cloud Foundry",
+                "categoryPriority": 60,
+                "discoveryQuery": [
+                    "sf_key:job"
+                ],
+                "displayName": "Service Brokers",
+                "filterProperties": null,
+                "id": "cf service brokers",
+                "listColumns": [
+                    {
+                        "aggregate": null,
+                        "displayName": "Instance",
+                        "format": "id",
+                        "metric": null,
+                        "property": "id",
+                        "sortable": null
+                    },
+                    {
+                        "aggregate": null,
+                        "displayName": "Value",
+                        "format": "Number",
+                        "metric": null,
+                        "property": "value",
+                        "sortable": null
+                    },
+                    {
+                        "aggregate": null,
+                        "displayName": "Job",
+                        "format": null,
+                        "metric": null,
+                        "property": "job",
+                        "sortable": null
+                    }
+                ],
+                "map": {
+                    "groupingStructure": {
+                        "children": null,
+                        "drawBoundary": true,
+                        "key": "sf_streamLabel",
+                        "memberSettings": null
+                    },
+                    "job": {
+                        "filters": [],
+                        "resolution": 300000,
+                        "template": "CONSUL_SERVER = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"consul_server\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nETCD_SERVER = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"etcd_server\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nETCD_TLS_SERVER = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"etcd_tls_server\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])\nNATS = data(\"system.healthy\", filter=filter(\"metric_source\", \"cloudfoundry\") and filter(\"job\", \"nats\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
+                        "varName": null
+                    },
+                    "metrics": [
+                        {
+                            "coloring": {
+                                "limits": [
+                                    {
+                                        "color": "#05ce00",
+                                        "lowerLimit": 1
+                                    },
+                                    {
+                                        "color": "#ea1849",
+                                        "lowerLimit": 0
+                                    }
+                                ],
+                                "maxValue": 1,
+                                "method": "threshold",
+                                "minValue": 0,
+                                "range": null
+                            },
+                            "idTemplate": "{{host}}",
+                            "name": "NATS",
+                            "valueFormat": null,
+                            "valueLabel": "System Health",
+                            "varName": "NATS"
+                        },
+                        {
+                            "coloring": {
+                                "limits": [
+                                    {
+                                        "color": "#05ce00",
+                                        "lowerLimit": 1
+                                    },
+                                    {
+                                        "color": "#ea1849",
+                                        "lowerLimit": 0
+                                    }
+                                ],
+                                "maxValue": 1,
+                                "method": "threshold",
+                                "minValue": 0,
+                                "range": null
+                            },
+                            "idTemplate": "{{host}}",
+                            "name": "etcds",
+                            "valueFormat": null,
+                            "valueLabel": "System Health",
+                            "varName": "ETCD_SERVER"
+                        },
+                        {
+                            "coloring": {
+                                "limits": [
+                                    {
+                                        "color": "#05ce00",
+                                        "lowerLimit": 1
+                                    },
+                                    {
+                                        "color": "#ea1849",
+                                        "lowerLimit": 0
+                                    }
+                                ],
+                                "maxValue": 1,
+                                "method": "threshold",
+                                "minValue": 0,
+                                "range": null
+                            },
+                            "idTemplate": "{{host}}",
+                            "name": "etcds (TLS)",
+                            "valueFormat": null,
+                            "valueLabel": "System Health",
+                            "varName": "ETCD_TLS_SERVER"
+                        },
+                        {
+                            "coloring": {
+                                "limits": [
+                                    {
+                                        "color": "#05ce00",
+                                        "lowerLimit": 1
+                                    },
+                                    {
+                                        "color": "#ea1849",
+                                        "lowerLimit": 0
+                                    }
+                                ],
+                                "maxValue": 1,
+                                "method": "threshold",
+                                "minValue": 0,
+                                "range": null
+                            },
+                            "idTemplate": "{{host}}",
+                            "name": "Consul",
+                            "valueFormat": null,
+                            "valueLabel": "System Health",
+                            "varName": "CONSUL_SERVER"
+                        }
+                    ]
+                },
+                "mtsQuery": "metric_source:cloudfoundry AND job:(consul_server OR etcd_server OR etcd_tls_server OR nats)",
+                "propertyColumns": [
+                    [
+                        {
+                            "header": "Tags",
+                            "properties": [
+                                "sf_tags"
+                            ]
+                        },
+                        {
+                            "header": "Other",
+                            "properties": []
+                        },
+                        {
+                            "header": "AWS",
+                            "properties": []
+                        }
+                    ]
+                ],
+                "requiredProperties": [
+                    "host"
+                ],
+                "singleHostSystemDashboardName": "CF Host",
+                "systemDashboardName": null,
+                "systemDashboardPrefix": null,
+                "tooltipKeyList": [
+                    {
+                        "displayName": "Instance",
+                        "format": null,
+                        "isSummaryProperty": true,
+                        "property": "id"
+                    },
+                    {
+                        "displayName": "Value",
+                        "format": "Number",
+                        "isSummaryProperty": true,
+                        "property": "value"
+                    },
+                    {
+                        "displayName": "Job",
+                        "format": null,
+                        "isSummaryProperty": true,
+                        "property": "job"
+                    }
+                ],
+                "type": "architectural",
+                "unreleased": false
+            }
+        }
+    },
+    "packageType": "NAVIGATOR"
 }


### PR DESCRIPTION
ES6 no longer allows querys in the form of prop:(val1 val2 val3)
so we are rewriting these to prop(val1 OR val2 OR val3). This only
seems to have been an issue for cloud foundry. The cloud foundry
dashboard discovery selectors also seem to have been off -- selectors
aren't ES queries, but they were formed as if they were, I split them
into individual selectors that are supported by the current system.