### PR TITLE
Fix invalid data models for chart objects in dynamodb dashboard

### DIFF
--- a/group/AWS DynamoDB.json
+++ b/group/AWS DynamoDB.json
@@ -5,6 +5,82 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
+        "description": "Requests to DynamoDB or Amazon DynamoDB Streams that generate an HTTP 400 status code during the specified time period.",
+        "id": "DiVV4-OAgGA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "User Errors",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": true
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "ColumnChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": true
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "UserErrors",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('UserErrors', filter=filter('namespace', 'AWS/DynamoDB') and filter('sf_metric', 'UserErrors') and filter('stat', 'sum'), rollup='sum').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
         "description": "The percentage of write capacity units consumed over the specified time period, so you can track how much of your provisioned throughput is used.",
         "id": "DiVV41MAYAA",
         "lastUpdated": 0,
@@ -80,7 +156,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -125,6 +202,7 @@
         },
         "packageSpecifications": "",
         "programText": "A = data('ProvisionedWriteCapacityUnits', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean') and filter('TableName', '*')).publish(label='A', enable=False)\nB = data('ConsumedWriteCapacityUnits', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean') and filter('TableName', '*')).publish(label='B', enable=False)\nC = ((B/A)*100).publish(label='C')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -133,16 +211,72 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "Requests to DynamoDB that exceed the provisioned write capacity units for a table or a global secondary index.",
-        "id": "DiVV45aAYCM",
+        "description": "Requests to DynamoDB or DynamoDB Streams that generate an HTTP 400 status code during the specified time period.",
+        "id": "DiVV5GTAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Write Throttle Events",
+        "name": "User Errors",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "UserErrors",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('UserErrors', filter=filter('namespace', 'AWS/DynamoDB') and filter('sf_metric', 'UserErrors') and filter('stat', 'sum'), rollup='sum').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Requests to DynamoDB or Amazon DynamoDB Streams that generate an HTTP 500 status code during the specified time period.",
+        "id": "DiVV5MdAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "System Errors",
         "options": {
           "areaChartOptions": {
-            "showDataMarkers": true
+            "showDataMarkers": false
           },
           "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
@@ -165,22 +299,23 @@
             "fields": null
           },
           "lineChartOptions": {
-            "showDataMarkers": true
+            "showDataMarkers": false
           },
           "onChartLegendOptions": {
             "dimensionInLegend": null,
-            "showLegend": true
+            "showLegend": false
           },
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "WriteThrottleEvents",
+              "displayName": "SystemErrors",
               "label": "A",
-              "paletteIndex": 5,
+              "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -198,7 +333,113 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('WriteThrottleEvents', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*'), rollup='sum').publish(label='A')",
+        "programText": "A = data('SystemErrors', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*') and filter('Operation', '*'), rollup='sum').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "The number of items returned by Query or Scan operations during the specified time period.",
+        "id": "DiVV45WAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Returned Item Count",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": true
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "AWSUniqueId"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "namespace"
+              },
+              {
+                "enabled": true,
+                "property": "Operation"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "stat"
+              },
+              {
+                "enabled": true,
+                "property": "TableName"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": true
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": "Operation",
+            "showLegend": true
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "ReturnedItemCount",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('ReturnedItemCount', filter=filter('namespace', 'AWS/DynamoDB') and filter('TableName', '*') and filter('Operation', '*') and filter('stat', 'count'), rollup='sum').publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -220,7 +461,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -244,199 +486,7 @@
         },
         "packageSpecifications": "",
         "programText": "A = data('ThrottledRequests', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum'), rollup='sum').sum().publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Requests to DynamoDB or DynamoDB Streams that generate an HTTP 400 status code during the specified time period.",
-        "id": "DiVV5GTAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "User Errors",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "UserErrors",
-              "label": "A",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": null,
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('UserErrors', filter=filter('namespace', 'AWS/DynamoDB') and filter('sf_metric', 'UserErrors') and filter('stat', 'sum'), rollup='sum').publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Requests to DynamoDB that exceed the provisioned read capacity units for a table or a global secondary index.",
-        "id": "DiVV4t3AYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Read Throttle Events",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": true
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": true
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": "TableName",
-            "showLegend": true
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "ReadThrottleEvents",
-              "label": "A",
-              "paletteIndex": 11,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 3600000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('ReadThrottleEvents', filter=filter('stat', 'sum') and filter('TableName', '*'), rollup='sum').publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Requests to DynamoDB or Amazon DynamoDB Streams that generate an HTTP 400 status code during the specified time period.",
-        "id": "DiVV4-OAgGA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "User Errors",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": true
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "ColumnChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": true
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "UserErrors",
-              "label": "A",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 3600000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('UserErrors', filter=filter('namespace', 'AWS/DynamoDB') and filter('sf_metric', 'UserErrors') and filter('stat', 'sum'), rollup='sum').publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -515,7 +565,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -540,6 +591,168 @@
         },
         "packageSpecifications": "",
         "programText": "A = data('SuccessfulRequestLatency', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean')).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Requests to DynamoDB that exceed the provisioned read capacity units for a table or a global secondary index.",
+        "id": "DiVV4t3AYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Read Throttle Events",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": true
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": true
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": "TableName",
+            "showLegend": true
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "ReadThrottleEvents",
+              "label": "A",
+              "paletteIndex": 11,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('ReadThrottleEvents', filter=filter('stat', 'sum') and filter('TableName', '*'), rollup='sum').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Requests to DynamoDB that exceed the provisioned write capacity units for a table or a global secondary index.",
+        "id": "DiVV45aAYCM",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Write Throttle Events",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": true
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": true
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "WriteThrottleEvents",
+              "label": "A",
+              "paletteIndex": 5,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('WriteThrottleEvents', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*'), rollup='sum').publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -623,7 +836,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -668,51 +882,7 @@
         },
         "packageSpecifications": "",
         "programText": "A = data('ProvisionedReadCapacityUnits', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean') and filter('TableName', '*')).publish(label='A', enable=False)\nB = data('ConsumedReadCapacityUnits', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean') and filter('TableName', '*')).publish(label='B', enable=False)\nC = ((B/A)*100).publish(label='C')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Requests to DynamoDB or Amazon DynamoDB Streams that generate an HTTP 500 status code during the specified time period.",
-        "id": "DiVV42dAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "System Errors",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "SystemErrors",
-              "label": "A",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": null,
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('SystemErrors', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*') and filter('Operation', '*'), rollup='sum').publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -791,7 +961,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -816,6 +987,7 @@
         },
         "packageSpecifications": "",
         "programText": "A = data('ThrottledRequests', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum'), rollup='sum').publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -837,7 +1009,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -861,6 +1034,7 @@
         },
         "packageSpecifications": "",
         "programText": "A = data('SuccessfulRequestLatency', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean')).mean().publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -870,53 +1044,26 @@
         "creator": null,
         "customProperties": {},
         "description": "Requests to DynamoDB or Amazon DynamoDB Streams that generate an HTTP 500 status code during the specified time period.",
-        "id": "DiVV5MdAYAA",
+        "id": "DiVV42dAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "name": "System Errors",
         "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
           "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": true
-          },
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
               "displayName": "SystemErrors",
               "label": "A",
-              "paletteIndex": null,
+              "paletteIndex": 4,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -924,124 +1071,22 @@
               "yAxis": 0
             }
           ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
         "programText": "A = data('SystemErrors', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*') and filter('Operation', '*'), rollup='sum').publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "The number of items returned by Query or Scan operations during the specified time period.",
-        "id": "DiVV45WAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Returned Item Count",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": true
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": false,
-                "property": "AWSUniqueId"
-              },
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": false,
-                "property": "namespace"
-              },
-              {
-                "enabled": true,
-                "property": "Operation"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              },
-              {
-                "enabled": false,
-                "property": "stat"
-              },
-              {
-                "enabled": true,
-                "property": "TableName"
-              }
-            ]
-          },
-          "lineChartOptions": {
-            "showDataMarkers": true
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": "Operation",
-            "showLegend": true
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "ReturnedItemCount",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 3600000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('ReturnedItemCount', filter=filter('namespace', 'AWS/DynamoDB') and filter('TableName', '*') and filter('Operation', '*') and filter('stat', 'count'), rollup='sum').publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     }
   ],
+  "crossLinkExports": [],
   "dashboardExports": [
     {
       "dashboard": {
@@ -1204,7 +1249,7 @@
       "teams": null
     }
   },
-  "hashCode": -275758371,
+  "hashCode": 999252344,
   "id": "DiVV4qwAcAE",
   "modelVersion": 1,
   "packageType": "GROUP"


### PR DESCRIPTION
The System Errors and Write Throttle Events charts had show chart legend
eneabled but a null value the dimension to show in the legend, which caused
validation errors during imports. This change just removes the chart legend
from the two charts. A better fix is likely to configure this properly, but
we'd need data flowing into signalbuddy master org to do that, which we don't
have...