### PR TITLE
Update Kubernetes dashboard group

### DIFF
--- a/group/Kubernetes.json
+++ b/group/Kubernetes.json
@@ -6,6 +6,324 @@
         "creator": null,
         "customProperties": {},
         "description": "",
+        "id": "DkBm2jfAcDo",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "% CPU Used per Container",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum(by=['container_name']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SmSj3AYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Network Throughput (bytes/sec)",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Rx Bytes /sec (RED)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Tx Bytes /sec (BLUE)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "ColumnChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx (bytes/sec)",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx (bytes/sec)",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('kubernetes_cluster', '*', match_missing=True), extrapolation='zero').sum().publish(label='A')\nB = data('pod_network_transmit_bytes_total', filter=filter('kubernetes_cluster', '*', match_missing=True), extrapolation='zero').sum().publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "per cluster",
+        "id": "DkBncDiAgAI",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "CPU Capacity Used",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale2": [
+            {
+              "gt": 80,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 60,
+              "gte": null,
+              "lt": null,
+              "lte": 80,
+              "paletteIndex": 17
+            },
+            {
+              "gt": 40,
+              "gte": null,
+              "lt": null,
+              "lte": 60,
+              "paletteIndex": 18
+            },
+            {
+              "gt": 20,
+              "gte": null,
+              "lt": null,
+              "lte": 40,
+              "paletteIndex": 19
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 20,
+              "paletteIndex": 20
+            }
+          ],
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              }
+            ]
+          },
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "centi-cores per cluster",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "# cores per cluster",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "CPU Capacity Usage %",
+              "label": "F",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "D = data('container_cpu_utilization').sum(by=['kubernetes_cluster']).publish(label='D', enable=False)\nE = data('machine_cpu_cores').sum(by=['kubernetes_cluster']).publish(label='E', enable=False)\nF = (D/E).publish(label='F')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnCYRAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Container Restarts",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 1,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 1,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "kubernetes.container_restart_count - Sum by kubernetes_cluster",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.container_restart_count', rollup='sum').sum(by=['kubernetes_cluster']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
         "id": "DkBnB8XAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
@@ -49,7 +367,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -92,6 +411,7 @@
         },
         "packageSpecifications": "",
         "programText": "A = data('kubernetes.replication_controller.available').publish(label='A', enable=False)\nB = data('kubernetes.replication_controller.desired').publish(label='B', enable=False)\nC = (B-A).publish(label='C')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -101,30 +421,172 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBm2jfAcDo",
+        "id": "DkBnI_OAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "% CPU Used per Container",
+        "name": "CPU Use per Pod (%)",
         "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "%",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
           "colorBy": "Dimension",
-          "colorScale2": null,
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
           "legendOptions": {
             "fields": null
           },
-          "maximumPrecision": 3,
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "",
+              "displayName": "CPU %",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 3600001,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_pod_name']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "per cluster",
+        "id": "DkBnb24AYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Memory Capacity Used",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale2": [
+            {
+              "gt": 80,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 60,
+              "gte": null,
+              "lt": null,
+              "lte": 80,
+              "paletteIndex": 17
+            },
+            {
+              "gt": 40,
+              "gte": null,
+              "lt": null,
+              "lte": 60,
+              "paletteIndex": 18
+            },
+            {
+              "gt": 20,
+              "gte": null,
+              "lt": null,
+              "lte": 40,
+              "paletteIndex": 19
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 20,
+              "paletteIndex": 20
+            }
+          ],
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              }
+            ]
+          },
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "memory usage per cluster",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "memory capacity per cluster",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "% used per cluster",
+              "label": "F",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "%",
               "valueUnit": null,
               "yAxis": 0
             }
@@ -137,7 +599,8 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum(by=['container_name']).publish(label='A')",
+        "programText": "D = data('container_memory_usage_bytes').sum(by=['kubernetes_cluster']).publish(label='D', enable=False)\nE = data('machine_memory_bytes').sum(by=['kubernetes_cluster']).publish(label='E', enable=False)\nF = (D/E).scale(100).publish(label='F')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -146,14 +609,43 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "This may include \"pause\" containers used internally by K8s",
-        "id": "DkBmciwAcAA",
+        "description": "",
+        "id": "D2SlUbdAcDo",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Top 10 Pods by # Containers",
+        "name": "CPU Usage per Pod",
         "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "cpu %",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
           "colorBy": "Dimension",
-          "colorScale2": null,
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
           "legendOptions": {
             "fields": [
               {
@@ -161,6 +653,244 @@
                 "property": "kubernetes_pod_name"
               },
               {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": true,
+                "property": "sf_metric"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "conatiner centi-core usage",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "num cores on host",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "pod cpu usage",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": true,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['kubernetes_pod_name', 'host', 'kubernetes_pod_name', 'kubernetes_namespace', 'kubernetes_cluster', 'kubernetes_node']).publish(label='A', enable=False)\nB = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['kubernetes_node']).publish(label='E', enable=False)\nC = (A/B).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "per cluster",
+        "id": "DkBnb_OAcAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Network Receieve Errors",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx (Bytes)",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_cluster']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "per cluster",
+        "id": "DkBnaCuAgDg",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Memory Usage",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": 4,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_usage_bytes').sum(by=['kubernetes_cluster']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2Sl4rMAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Memory Usage per Pod",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
                 "enabled": false,
                 "property": "sf_originatingMetric"
               },
@@ -170,33 +900,43 @@
               }
             ]
           },
-          "maximumPrecision": null,
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "container_cpu_utilization - Mean(1m) - Count by kubernetes_pod_name - Top 10",
+              "displayName": "",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
-              "valueUnit": null,
+              "valueUnit": "Byte",
               "yAxis": 0
             }
           ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).mean(over='1m').count(by=['kubernetes_pod_name']).top(count=10).publish(label='A')",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_pod_uid', 'kubernetes_pod_name']).publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -206,74 +946,22 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBnJksAcAA",
+        "id": "DkBnHS4AgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Total Memory (bytes)",
+        "name": "Highest Memory Use per Pod (bytes)",
         "options": {
           "colorBy": "Dimension",
-          "colorScale": null,
           "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
           "maximumPrecision": 4,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "machine_memory_bytes - Sum",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "A/1024/1024",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": null,
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('machine_memory_bytes', filter=filter('metric_source', 'kubernetes')).sum().publish(label='A')\nB = (A/1024/1024).publish(label='B', enable=False)",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBkyDZAgAI",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "# Nodes",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -288,15 +976,15 @@
             }
           ],
           "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
           "time": null,
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
+          "type": "List",
+          "unitPrefix": "Binary"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization').sum(by=['host']).mean(over='1m').count().publish(label='A')",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes'), extrapolation='last_value').sum(by=['kubernetes_pod_name']).mean(over='1m').top(count=10).publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -305,55 +993,62 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "",
-        "id": "DkBnAW2AgAI",
+        "description": "Based on Pod spec's resources.limits.cpu value if present, otherwise chart will be blank.",
+        "id": "DkBm1ulAYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Available Pods by Deployment",
+        "name": "% CPU Limit Used per Container",
         "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": false,
-                "property": "kubernetes_cluster"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_name"
-              },
-              {
-                "enabled": false,
-                "property": "kubernetes_namespace"
-              },
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": false,
-                "property": "metric_source"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              },
-              {
-                "enabled": false,
-                "property": "uid"
-              }
-            ]
+          "areaChartOptions": {
+            "showDataMarkers": false
           },
-          "maximumPrecision": null,
+          "axes": [
+            {
+              "highWatermark": 80,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "available pods",
+              "displayName": "Centicores used",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -363,8 +1058,28 @@
               "yAxis": 0
             },
             {
-              "displayName": "desired pods",
+              "displayName": "CFS quota",
               "label": "B",
+              "paletteIndex": 6,
+              "plotType": "LineChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "CFS period",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "% of Limit",
+              "label": "D",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
@@ -373,15 +1088,18 @@
               "yAxis": 0
             }
           ],
-          "refreshInterval": 60000,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "+kubernetes_name",
-          "time": null,
-          "type": "List",
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('kubernetes.deployment.available').publish(label='A')\nB = data('kubernetes.deployment.desired').publish(label='B', enable=False)",
+        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).publish(label='A', enable=False)\nB = data('container_spec_cpu_quota', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).publish(label='B', enable=False)\nC = data('container_spec_cpu_period', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).publish(label='C', enable=False)\nD = (A/(B/C)).sum(by=['container_name']).publish(label='D')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -405,7 +1123,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -428,6 +1147,217 @@
         },
         "packageSpecifications": "",
         "programText": "B = data('pod_network_transmit_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_cluster']).publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Based on Kubernetes resource limits.  If no limits, will be blank.",
+        "id": "DkBm2N8AgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "% Memory Used per Container",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "container",
+              "label": "A",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "limit",
+              "label": "B",
+              "paletteIndex": 6,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            },
+            {
+              "displayName": "",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600001,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).publish(label='A', enable=False)\nB = data('container_spec_memory_limit_bytes', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).above(0, inclusive=True).publish(label='B', enable=False)\nC = (A/B*100).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Based on Kubernetes resource limits.  If no limits, will be blank.",
+        "id": "D2Sl4zpAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "% Memory Used per Pod",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "% memory used",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 110,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "container",
+              "label": "A",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "limit",
+              "label": "B",
+              "paletteIndex": 6,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).publish(label='A', enable=False)\nB = data('container_spec_memory_limit_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).above(0, inclusive=True).publish(label='B', enable=False)\nC = (A/B*100).publish(label='C')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -437,21 +1367,48 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBnCV1AcAA",
+        "id": "DkBnBZnAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "name": "Pods by Phase",
         "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "pods",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
           "colorBy": "Metric",
-          "colorScale2": null,
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
           "legendOptions": {
             "fields": null
           },
-          "maximumPrecision": null,
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": "sf_metric",
+            "showLegend": true
+          },
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 30000,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -505,15 +1462,18 @@
               "yAxis": 0
             }
           ],
-          "refreshInterval": 60000,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "",
-          "time": null,
-          "type": "List",
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
         "programText": "A = data('kubernetes.pod_phase', rollup='latest').below(1, inclusive=True).count().publish(label='A')\nB = data('kubernetes.pod_phase', rollup='latest').between(1.1, 2, low_inclusive=True, high_inclusive=True).count().publish(label='B')\nC = data('kubernetes.pod_phase', rollup='latest').between(2.1, 3, low_inclusive=True, high_inclusive=True).count().publish(label='C')\nD = data('kubernetes.pod_phase', rollup='latest').between(3.1, 4, low_inclusive=True, high_inclusive=True).count().publish(label='D')\nE = data('kubernetes.pod_phase', rollup='latest').above(4).count().publish(label='E')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -522,95 +1482,25 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "Network receive and transmit errors from pods on this node",
-        "id": "DkBkzE4AYAA",
+        "description": "This may include \"pause\" containers used internally by K8s",
+        "id": "DkBm2ftAYCM",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Network Errors by Interface",
+        "name": "# Active Containers",
         "options": {
           "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Rx",
-              "label": "A",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Tx",
-              "label": "B",
-              "paletteIndex": 1,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['interface']).publish(label='A')\nB = data('pod_network_transmit_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['interface']).publish(label='B')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnCYRAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Container Restarts",
-        "options": {
-          "colorBy": "Scale",
           "colorScale": null,
-          "colorScale2": [
-            {
-              "gt": 1,
-              "gte": null,
-              "lt": null,
-              "lte": null,
-              "paletteIndex": 16
-            },
-            {
-              "gt": null,
-              "gte": null,
-              "lt": null,
-              "lte": 1,
-              "paletteIndex": 14
-            }
-          ],
+          "colorScale2": null,
           "maximumPrecision": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "kubernetes.container_restart_count - Sum by kubernetes_cluster",
+              "displayName": "container_cpu_utilization - Mean(1m) - Count",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -629,7 +1519,58 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('kubernetes.container_restart_count', rollup='sum').sum(by=['kubernetes_cluster']).publish(label='A')",
+        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).mean(over='1m').count().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "created by Deployments",
+        "id": "D2SlYGhAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Desired Pods",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.deployment.desired', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace']).sum().publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -744,7 +1685,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -789,6 +1731,7 @@
         },
         "packageSpecifications": "",
         "programText": "A = data('container_cpu_utilization').sum(by=['host']).mean(over='1m').publish(label='A', enable=False)\nG = data('machine_cpu_cores').sum(by=['host']).mean(over='1m').publish(label='G', enable=False)\nL = (A/G).publish(label='L')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -798,10 +1741,468 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBnBFnAcAE",
+        "id": "D2SlUGlAgAc",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Net Pods Desired by Replica Set",
+        "name": "Memory Usage per Pod",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "pod memory usage",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_pod_uid', 'kubernetes_pod_name']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBm2CNAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Network Errors / sec",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "+sf_metric",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_errors_total', filter=filter('metric_source', 'kubernetes')).sum().publish(label='A')\nB = data('pod_network_transmit_errors_total', filter=filter('metric_source', 'kubernetes')).sum().publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnAvVAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Deployments Not at Spec",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 0,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 0,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "available pods",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "desired pods",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "pods desired but not available",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": 60000,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.deployment.available', extrapolation='zero').publish(label='A', enable=False)\nB = data('kubernetes.deployment.desired', extrapolation='zero').publish(label='B', enable=False)\nC = (B-A).above(0).count().publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SlYW-AYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Memory Capacity Used per Node",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "memory %",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 110,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": 4,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "container_image"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "container_name"
+              },
+              {
+                "enabled": false,
+                "property": "container_spec_name"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "container_id"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "memory usage per node",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "memory capacity per node",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "% memory used per node",
+              "label": "F",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "D = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'kubernetes_node']).publish(label='D', enable=False)\nE = data('machine_memory_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['kubernetes_cluster', 'kubernetes_node']).publish(label='E', enable=False)\nF = (D/E).scale(100).publish(label='F')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "of all phases",
+        "id": "D2SlXplAcAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Total of Pods",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='latest').count().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnCXLAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Desired Pods by Deployment",
         "options": {
           "colorBy": "Dimension",
           "colorScale2": null,
@@ -841,7 +2242,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -863,186 +2265,18 @@
               "valueSuffix": null,
               "valueUnit": null,
               "yAxis": 0
-            },
-            {
-              "displayName": "pods desired but not available",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
             }
           ],
-          "refreshInterval": null,
+          "refreshInterval": 60000,
           "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
+          "sortBy": "+kubernetes_name",
           "time": null,
           "type": "List",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('kubernetes.replica_set.available').publish(label='A', enable=False)\nB = data('kubernetes.replica_set.desired').publish(label='B', enable=False)\nC = (B-A).publish(label='C')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Based on Pod spec's resources.limits.cpu value if present, otherwise chart will be blank.",
-        "id": "DkBmcgVAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "% CPU Limit Used per Pod",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": 80,
-              "highWatermarkLabel": null,
-              "label": "CPU %",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Centicores used",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "CFS quota",
-              "label": "B",
-              "paletteIndex": 6,
-              "plotType": "LineChart",
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "CFS period",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "% of Limit",
-              "label": "D",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 3600000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_pod_name']).publish(label='A', enable=False)\nB = data('container_spec_cpu_quota', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_pod_name']).publish(label='B', enable=False)\nC = data('container_spec_cpu_period', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_pod_name']).publish(label='C', enable=False)\nD = (A/(B/C)).sum(by=['kubernetes_pod_name']).publish(label='D')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "per cluster",
-        "id": "DkBnaCuAgDg",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Memory Usage",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 4,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Byte",
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_memory_usage_bytes').sum(by=['kubernetes_cluster']).publish(label='A')",
+        "programText": "A = data('kubernetes.deployment.available').publish(label='A', enable=False)\nB = data('kubernetes.deployment.desired').publish(label='B')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -1052,56 +2286,10 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBmckkAgAA",
+        "id": "DkBnAW2AgAI",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Top 10 Pods by Average Container Memory Usage",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 4,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Byte",
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes')).mean(by=['kubernetes_pod_name']).top(count=10).publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnCMpAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Container Restarts by Pod",
+        "name": "Available Pods by Deployment",
         "options": {
           "colorBy": "Dimension",
           "colorScale2": null,
@@ -1112,16 +2300,28 @@
                 "property": "kubernetes_cluster"
               },
               {
+                "enabled": true,
+                "property": "kubernetes_name"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_namespace"
+              },
+              {
                 "enabled": false,
                 "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
               },
               {
                 "enabled": false,
                 "property": "sf_metric"
               },
               {
-                "enabled": true,
-                "property": "kubernetes_pod_name"
+                "enabled": false,
+                "property": "uid"
               }
             ]
           },
@@ -1129,186 +2329,14 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "container restarts by pod",
+              "displayName": "available pods",
               "label": "A",
               "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('kubernetes.container_restart_count', rollup='sum').sum(by=['kubernetes_pod_name']).publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnHS4AgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Highest Memory Use per Pod (bytes)",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 4,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes'), extrapolation='last_value').sum(by=['kubernetes_pod_name']).mean(over='1m').top(count=10).publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBmbAEAcAE",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Top 10 Pods by Major Page Faults",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_memory_failures_total', filter=filter('metric_source', 'kubernetes') and filter('type', 'pgmajfault')).sum(by=['kubernetes_pod_name']).top(count=10).publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBkzRrAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Network Throughput (bytes/sec)",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "Rx Bytes /sec (RED)",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "Tx Bytes /sec (BLUE)",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "ColumnChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Rx (bytes/sec)",
-              "label": "A",
-              "paletteIndex": 4,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -1316,27 +2344,26 @@
               "yAxis": 0
             },
             {
-              "displayName": "Tx (bytes/sec)",
+              "displayName": "desired pods",
               "label": "B",
-              "paletteIndex": 1,
+              "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
               "valueUnit": null,
-              "yAxis": 1
+              "yAxis": 0
             }
           ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 3600000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Binary"
+          "refreshInterval": 60000,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "+kubernetes_name",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum().publish(label='A')\nB = data('pod_network_transmit_bytes_total', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum().publish(label='B')",
+        "programText": "A = data('kubernetes.deployment.available').publish(label='A')\nB = data('kubernetes.deployment.desired').publish(label='B', enable=False)",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -1360,7 +2387,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -1383,52 +2411,7 @@
         },
         "packageSpecifications": "",
         "programText": "A = data('container_cpu_utilization').sum(by=['host', 'kubernetes_cluster']).mean(over='1m').count(by=['kubernetes_cluster']).publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "per cluster",
-        "id": "DkBnb_OAcAE",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Network Receieve Errors",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Rx (Bytes)",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Byte",
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_cluster']).publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -1438,725 +2421,7 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBmbNpAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Top 10 Pods by % CPU Used",
-        "options": {
-          "colorBy": "Scale",
-          "colorScale2": [
-            {
-              "gt": 80,
-              "gte": null,
-              "lt": null,
-              "lte": null,
-              "paletteIndex": 16
-            },
-            {
-              "gt": 60,
-              "gte": null,
-              "lt": null,
-              "lte": 80,
-              "paletteIndex": 17
-            },
-            {
-              "gt": 40,
-              "gte": null,
-              "lt": null,
-              "lte": 60,
-              "paletteIndex": 18
-            },
-            {
-              "gt": 20,
-              "gte": null,
-              "lt": null,
-              "lte": 40,
-              "paletteIndex": 19
-            },
-            {
-              "gt": null,
-              "gte": null,
-              "lt": null,
-              "lte": 20,
-              "paletteIndex": 20
-            }
-          ],
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": true,
-                "property": "container_name"
-              },
-              {
-                "enabled": true,
-                "property": "host"
-              },
-              {
-                "enabled": true,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_pod_name"
-              }
-            ]
-          },
-          "maximumPrecision": 3,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "conatiner centi-core usage",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "num cores on host",
-              "label": "E",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "% cpu used by container",
-              "label": "F",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "%",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum(by=['host', 'kubernetes_pod_name']).publish(label='A', enable=False)\nE = data('machine_cpu_cores').sum(by=['host']).publish(label='E', enable=False)\nF = (A/E).top(count=10).publish(label='F')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBky-7AgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Top Nodes by Memory",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": true,
-                "property": "host"
-              },
-              {
-                "enabled": false,
-                "property": "kubernetes_cluster"
-              },
-              {
-                "enabled": false,
-                "property": "kubernetes_role"
-              },
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": false,
-                "property": "metric_source"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              },
-              {
-                "enabled": true,
-                "property": "machine_id"
-              },
-              {
-                "enabled": true,
-                "property": "AWSUniqueId"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_node"
-              },
-              {
-                "enabled": true,
-                "property": "gcp_id"
-              }
-            ]
-          },
-          "maximumPrecision": 4,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('machine_memory_bytes', filter=filter('metric_source', 'kubernetes')).mean(over='1m').top(count=10).publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBm16iAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Memory Used per Container (Bytes)",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 3,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes')).mean(by=['container_name']).publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "bytes in + bytes out",
-        "id": "DkBkzjnAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Top Nodes by Network Usage",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": true,
-                "property": "host"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              }
-            ]
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Rx (bytes/sec)",
-              "label": "A",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Tx (bytes/sec)",
-              "label": "B",
-              "paletteIndex": 1,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 1
-            },
-            {
-              "displayName": "A+B",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Byte",
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum(by=['host']).publish(label='A', enable=False)\nB = data('pod_network_transmit_bytes_total', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum(by=['host']).publish(label='B', enable=False)\nC = (A+B).publish(label='C')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Based on Pod spec's resources.limits.cpu value if present, otherwise chart will be blank.",
-        "id": "DkBm1ulAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "% CPU Limit Used per Container",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": 80,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Centicores used",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "CFS quota",
-              "label": "B",
-              "paletteIndex": 6,
-              "plotType": "LineChart",
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "CFS period",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "% of Limit",
-              "label": "D",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 3600000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).publish(label='A', enable=False)\nB = data('container_spec_cpu_quota', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).publish(label='B', enable=False)\nC = data('container_spec_cpu_period', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).publish(label='C', enable=False)\nD = (A/(B/C)).sum(by=['container_name']).publish(label='D')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBkzLZAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Total Memory (bytes)",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": 4,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "machine_memory_bytes - Sum",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "A/1024/1024",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": null,
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('machine_memory_bytes', filter=filter('metric_source', 'kubernetes')).sum().publish(label='A')\nB = (A/1024/1024).publish(label='B', enable=False)",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Based on Kubernetes resource limits.  If no limits, will be blank.",
-        "id": "DkBmclKAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "% Memory Used per Pod",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "% memory used",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": 110,
-              "min": null
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": true,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "container",
-              "label": "A",
-              "paletteIndex": 1,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "limit",
-              "label": "B",
-              "paletteIndex": 6,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 3600000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_pod_name']).publish(label='A', enable=False)\nB = data('container_spec_memory_limit_bytes', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_pod_name']).above(0, inclusive=True).publish(label='B', enable=False)\nC = (A/B*100).publish(label='C')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "This may include \"pause\" containers used internally by K8s",
-        "id": "DkBm2ftAYCM",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "# Active Containers",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "container_cpu_utilization - Mean(1m) - Count",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": null,
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).mean(over='1m').count().publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBkzFUAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Top Nodes by # Pods",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": true,
-                "property": "host"
-              },
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_pod_name"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_node"
-              },
-              {
-                "enabled": true,
-                "property": "machine_id"
-              }
-            ]
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "container_cpu_utilization - Sum by kubernetes_pod_name - Mean(1m) - Count by host",
-              "label": "A",
-              "paletteIndex": 1,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', extrapolation='last_value').sum(by=['kubernetes_pod_name']).mean(over='1m').count(by=['host']).publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBkzShAcAA",
+        "id": "D2SmUQbAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "name": "Top 10 Nodes by CPU Capacity Usage %",
@@ -2271,7 +2536,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -2308,12 +2574,16 @@
           "refreshInterval": null,
           "secondaryVisualization": "None",
           "sortBy": "-value",
-          "time": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
           "type": "List",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization').sum(by=['host', 'kubernetes_cluster']).mean(over='1m').publish(label='A', enable=False)\nG = data('machine_cpu_cores').sum(by=['host', 'kubernetes_cluster']).mean(over='1m').publish(label='G', enable=False)\nL = (A/G).top(count=10).publish(label='L')",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['host', 'kubernetes_cluster']).mean(over='1m').publish(label='A', enable=False)\nG = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['host', 'kubernetes_cluster']).mean(over='1m').publish(label='G', enable=False)\nL = (A/G).top(count=10).publish(label='L')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -2323,85 +2593,25 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBnBhCAYAA",
+        "id": "DkBnHTuAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Daemon Sets by Stage",
+        "name": "Total # CPU Cores",
         "options": {
           "colorBy": "Dimension",
+          "colorScale": null,
           "colorScale2": null,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": false,
-                "property": "kubernetes_cluster"
-              },
-              {
-                "enabled": false,
-                "property": "kubernetes_name"
-              },
-              {
-                "enabled": false,
-                "property": "kubernetes_namespace"
-              },
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": false,
-                "property": "metric_source"
-              },
-              {
-                "enabled": true,
-                "property": "sf_metric"
-              },
-              {
-                "enabled": false,
-                "property": "uid"
-              }
-            ]
-          },
           "maximumPrecision": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "current",
+              "displayName": "cpu cores",
               "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "desired",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "misscheduled",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "ready",
-              "label": "D",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
@@ -2411,14 +2621,16 @@
             }
           ],
           "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "+kubernetes_cluster",
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
           "time": null,
-          "type": "List",
+          "timestampHidden": false,
+          "type": "SingleValue",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('kubernetes.daemon_set.current_scheduled').sum(by=['kubernetes_cluster']).publish(label='A')\nB = data('kubernetes.daemon_set.desired_scheduled').sum(by=['kubernetes_cluster']).publish(label='B')\nC = data('kubernetes.daemon_set.misscheduled').sum(by=['kubernetes_cluster']).publish(label='C')\nD = data('kubernetes.daemon_set.ready').sum(by=['kubernetes_cluster']).publish(label='D')",
+        "programText": "A = data('machine_cpu_cores', filter=filter('metric_source', 'kubernetes')).sum().mean(over='1m').publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -2428,10 +2640,10 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBnHZUAgAA",
+        "id": "D2SlSy6AYB8",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "% Memory Capacity Used",
+        "name": "Bytes Out per Pod",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -2440,10 +2652,315 @@
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "% memory used",
+              "label": "",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
-              "max": 110,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "interface"
+              },
+              {
+                "enabled": false,
+                "property": "container_image"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "container_spec_name"
+              },
+              {
+                "enabled": false,
+                "property": "container_id"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "bytes sent",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_transmit_bytes_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'kubernetes_node', 'kubernetes_pod_name', 'kubernetes_pod_uid']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "bytes in + bytes out per pod, summed per node",
+        "id": "D2SlXcSAgAI",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Network Usage Per Node",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "interface"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "container_image"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "metric_source"
+              },
+              {
+                "enabled": true,
+                "property": "container_spec_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              },
+              {
+                "enabled": true,
+                "property": "sf_originatingMetric"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx (bytes/sec)",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx (bytes/sec)",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            },
+            {
+              "displayName": "total bytes in and out",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'kubernetes_node']).publish(label='A', enable=False)\nB = data('pod_network_transmit_bytes_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'kubernetes_node']).publish(label='B', enable=False)\nC = (A+B).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SlWheAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Available Pods by Deployments",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
               "min": null
             }
           ],
@@ -2456,193 +2973,90 @@
           },
           "includeZero": true,
           "legendOptions": {
-            "fields": null
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": false,
+                "property": "deployment"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_deployment_uid"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_uid"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "kuberentes_deployment_name"
+              },
+              {
+                "enabled": false,
+                "property": "kuberentes_deployment_uid"
+              }
+            ]
           },
           "lineChartOptions": {
             "showDataMarkers": false
           },
           "onChartLegendOptions": {
-            "dimensionInLegend": null,
+            "dimensionInLegend": "kubernetes_name",
             "showLegend": false
           },
           "programOptions": {
             "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "memory usage per node",
-              "label": "D",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "memory capacity per node",
-              "label": "E",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "",
-              "label": "F",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "%",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 3600000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "D = data('container_memory_usage_bytes').sum(by=['host']).mean(over='1m').publish(label='D', enable=False)\nE = data('machine_memory_bytes').sum(by=['host']).mean(over='1m').publish(label='E', enable=False)\nF = (D/E).scale(100).publish(label='F')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBm2CNAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Network Errors / sec",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Rx",
-              "label": "A",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Tx",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "+sf_metric",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_errors_total', filter=filter('metric_source', 'kubernetes')).sum().publish(label='A')\nB = data('pod_network_transmit_errors_total', filter=filter('metric_source', 'kubernetes')).sum().publish(label='B')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnHSwAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Memory Use per Pod (bytes)",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "bytes",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "memory use (bytes)",
+              "displayName": "deployed pods",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
-              "valueSuffix": null,
+              "valueSuffix": "pods",
               "valueUnit": null,
               "yAxis": 0
             }
           ],
-          "showEventLines": false,
+          "showEventLines": true,
           "stacked": true,
           "time": {
-            "range": 3600000,
+            "range": 900000,
             "type": "relative"
           },
           "type": "TimeSeriesChart",
-          "unitPrefix": "Binary"
+          "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_pod_name']).publish(label='A')",
+        "programText": "A = data('kubernetes.deployment.available', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_name']).publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -2652,26 +3066,26 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBnCXLAgAA",
+        "id": "D2SmR8XAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Desired Pods by Deployment",
+        "name": "Top Nodes by Memory",
         "options": {
           "colorBy": "Dimension",
           "colorScale2": null,
           "legendOptions": {
             "fields": [
               {
+                "enabled": true,
+                "property": "host"
+              },
+              {
                 "enabled": false,
                 "property": "kubernetes_cluster"
               },
               {
-                "enabled": true,
-                "property": "kubernetes_name"
-              },
-              {
                 "enabled": false,
-                "property": "kubernetes_namespace"
+                "property": "kubernetes_role"
               },
               {
                 "enabled": false,
@@ -2686,20 +3100,33 @@
                 "property": "sf_metric"
               },
               {
-                "enabled": false,
-                "property": "uid"
+                "enabled": true,
+                "property": "machine_id"
+              },
+              {
+                "enabled": true,
+                "property": "AWSUniqueId"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": true,
+                "property": "gcp_id"
               }
             ]
           },
-          "maximumPrecision": null,
+          "maximumPrecision": 4,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "available pods",
+              "displayName": "",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -2707,27 +3134,21 @@
               "valueSuffix": null,
               "valueUnit": null,
               "yAxis": 0
-            },
-            {
-              "displayName": "desired pods",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
             }
           ],
-          "refreshInterval": 60000,
+          "refreshInterval": null,
           "secondaryVisualization": "Sparkline",
-          "sortBy": "+kubernetes_name",
-          "time": null,
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
           "type": "List",
-          "unitPrefix": "Metric"
+          "unitPrefix": "Binary"
         },
         "packageSpecifications": "",
-        "programText": "A = data('kubernetes.deployment.available').publish(label='A', enable=False)\nB = data('kubernetes.deployment.desired').publish(label='B')",
+        "programText": "A = data('machine_memory_bytes', filter=filter('kubernetes_cluster', '*', match_missing=True)).mean(over='1m').top(count=10).publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -2736,100 +3157,63 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "per node",
-        "id": "DkBkyr2AcAA",
+        "description": "",
+        "id": "DkBnCMpAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Top 10 Nodes by Memory Capacity Used",
+        "name": "Container Restarts by Pod",
         "options": {
-          "colorBy": "Scale",
-          "colorScale2": [
-            {
-              "gt": 80,
-              "gte": null,
-              "lt": null,
-              "lte": null,
-              "paletteIndex": 16
-            },
-            {
-              "gt": 60,
-              "gte": null,
-              "lt": null,
-              "lte": 80,
-              "paletteIndex": 17
-            },
-            {
-              "gt": 40,
-              "gte": null,
-              "lt": null,
-              "lte": 60,
-              "paletteIndex": 18
-            },
-            {
-              "gt": 20,
-              "gte": null,
-              "lt": null,
-              "lte": 40,
-              "paletteIndex": 19
-            },
-            {
-              "gt": null,
-              "gte": null,
-              "lt": null,
-              "lte": 20,
-              "paletteIndex": 20
-            }
-          ],
+          "colorBy": "Dimension",
+          "colorScale2": null,
           "legendOptions": {
-            "fields": null
+            "fields": [
+              {
+                "enabled": false,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              }
+            ]
           },
-          "maximumPrecision": 3,
+          "maximumPrecision": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "memory usage per node",
-              "label": "D",
+              "displayName": "container restarts by pod",
+              "label": "A",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "memory capacity per node",
-              "label": "E",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "",
-              "label": "F",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "%",
               "valueUnit": null,
               "yAxis": 0
             }
           ],
           "refreshInterval": null,
-          "secondaryVisualization": "None",
+          "secondaryVisualization": "Sparkline",
           "sortBy": "-value",
           "time": null,
           "type": "List",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "D = data('container_memory_usage_bytes').sum(by=['kubernetes_cluster', 'host']).mean(over='1m').publish(label='D', enable=False)\nE = data('machine_memory_bytes').sum(by=['kubernetes_cluster', 'host']).mean(over='1m').publish(label='E', enable=False)\nF = (D/E).scale(100).top(count=10).publish(label='F')",
+        "programText": "A = data('kubernetes.container_restart_count', rollup='sum').sum(by=['kubernetes_pod_name']).publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -2839,68 +3223,51 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBnaELAcAE",
+        "id": "D2SmTISAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "# Clusters",
+        "name": "Top Nodes by # Pods",
         "options": {
           "colorBy": "Dimension",
-          "colorScale": null,
           "colorScale2": null,
-          "maximumPrecision": 3,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": true,
+                "property": "machine_id"
+              }
+            ]
           },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "D",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": null,
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "D = data('container_cpu_utilization').sum(by=['kubernetes_cluster']).mean(over='1m').count().publish(label='D')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnJQ3AYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Total # Pods",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
           "maximumPrecision": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "container_cpu_utilization - Sum by kubernetes_pod_name - Mean(1m) - Count",
+              "displayName": "container_cpu_utilization - Sum by kubernetes_pod_name - Mean(1m) - Count by host",
               "label": "A",
               "paletteIndex": 1,
               "plotType": null,
@@ -2911,200 +3278,18 @@
             }
           ],
           "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": null,
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes'), extrapolation='last_value').sum(by=['kubernetes_pod_name']).mean(over='1m').count().publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnI_OAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "CPU Use per Pod (%)",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "%",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "CPU %",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 3600001,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_pod_name']).publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "per cluster",
-        "id": "DkBncDiAgAI",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "CPU Capacity Used",
-        "options": {
-          "colorBy": "Scale",
-          "colorScale2": [
-            {
-              "gt": 80,
-              "gte": null,
-              "lt": null,
-              "lte": null,
-              "paletteIndex": 16
-            },
-            {
-              "gt": 60,
-              "gte": null,
-              "lt": null,
-              "lte": 80,
-              "paletteIndex": 17
-            },
-            {
-              "gt": 40,
-              "gte": null,
-              "lt": null,
-              "lte": 60,
-              "paletteIndex": 18
-            },
-            {
-              "gt": 20,
-              "gte": null,
-              "lt": null,
-              "lte": 40,
-              "paletteIndex": 19
-            },
-            {
-              "gt": null,
-              "gte": null,
-              "lt": null,
-              "lte": 20,
-              "paletteIndex": 20
-            }
-          ],
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": true,
-                "property": "kubernetes_cluster"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              }
-            ]
-          },
-          "maximumPrecision": 3,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "centi-cores per cluster",
-              "label": "D",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "# cores per cluster",
-              "label": "E",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "CPU Capacity Usage %",
-              "label": "F",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "%",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
           "secondaryVisualization": "Sparkline",
           "sortBy": "-value",
-          "time": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
           "type": "List",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "D = data('container_cpu_utilization').sum(by=['kubernetes_cluster']).publish(label='D', enable=False)\nE = data('machine_cpu_cores').sum(by=['kubernetes_cluster']).publish(label='E', enable=False)\nF = (D/E).publish(label='F')",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*', match_missing=True), extrapolation='last_value').sum(by=['kubernetes_pod_name']).mean(over='1m').count(by=['host']).publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -3181,7 +3366,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -3204,6 +3390,7 @@
         },
         "packageSpecifications": "",
         "programText": "A = data('kubernetes.container_restart_count', rollup='sum', extrapolation='zero').sum(by=['host']).publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -3213,7 +3400,513 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBmbEbAgAA",
+        "id": "D2SlWAnAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Bytes In per Pod",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "interface"
+              },
+              {
+                "enabled": false,
+                "property": "container_image"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "container_spec_name"
+              },
+              {
+                "enabled": false,
+                "property": "container_id"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "bytes received",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'kubernetes_node', 'kubernetes_pod_name', 'kubernetes_pod_uid']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2Sl4AoAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Network Errors / sec",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "+sf_metric",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_errors_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True) ).sum().publish(label='A')\nB = data('pod_network_transmit_errors_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True) ).sum().publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBncFkAYAI",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# Containers per Cluster",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization').mean(over='1m').count(by=['kubernetes_cluster']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2Sl4UpAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top 10 Pods by Average Container Memory Usage",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": 4,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).mean(by=['kubernetes_pod_name']).top(count=10).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SlVhwAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": ".",
+        "options": {
+          "markdown": "<table width=\"100%\" height=\"50%\" rules=\"none\"><tr><td valign=\"middle\" align=\"center\" bgcolor=\"#59a200\">\n<font size=\"5\" color=\"white\">K8s Pods</font>\n</td></tr></table>\n\n<p align=\"center\" ><br /><font>Charts below refer to the health of your Kubernetes Pods. Use the filters at the top to narrow down pods by Cluster, Namespace, Nodes, Services, or Deployments.  <br />\nService tag syncing was added with agent version <a href=\"https://github.com/signalfx/signalfx-agent/releases/tag/v4.1.0\" target=\"_blank\">v4.1.0</a> and deployment property syncing in <a href=\"https://github.com/signalfx/signalfx-agent/releases/tag/v4.3.0\" target=\"_blank\">v4.3.0</a>.<br></p></font>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "number of pods that should be created by deployments",
+        "id": "D2Sl4P3AgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Desired Pods by Deployments",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.deployment.desired', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace']).sum().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnJQ3AYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Total # Pods",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "container_cpu_utilization - Sum by kubernetes_pod_name - Mean(1m) - Count",
+              "label": "A",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes'), extrapolation='last_value').sum(by=['kubernetes_pod_name']).mean(over='1m').count().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2Sl4ATAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# of Pods by Phase",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Running",
+              "label": "B",
+              "paletteIndex": 15,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Pending",
+              "label": "A",
+              "paletteIndex": 6,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Succeeded",
+              "label": "C",
+              "paletteIndex": 2,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Failed",
+              "label": "D",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Unknown",
+              "label": "E",
+              "paletteIndex": 11,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "B = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count().publish(label='B')\nA = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count().publish(label='A')\nC = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(2.5, 3.5, low_inclusive=True, high_inclusive=True).count().publish(label='C')\nD = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(3.5, 4.5, low_inclusive=True, high_inclusive=True).count().publish(label='D')\nE = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(4.5, 5.5, low_inclusive=True, high_inclusive=True).count().publish(label='E')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2Sl4ZAAYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "name": "Network Throughput (bytes/sec)",
@@ -3262,7 +3955,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -3296,7 +3990,8 @@
           "unitPrefix": "Binary"
         },
         "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum().publish(label='A')\nB = data('pod_network_transmit_bytes_total', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum().publish(label='B')",
+        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), extrapolation='zero').sum().publish(label='A')\nB = data('pod_network_transmit_bytes_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), extrapolation='zero').sum().publish(label='B')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -3305,103 +4000,11 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "",
-        "id": "DkBncFkAYAI",
+        "description": "This may include \"pause\" containers used internally by K8s",
+        "id": "D2Sl5crAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "# Containers per Cluster",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization').mean(over='1m').count(by=['kubernetes_cluster']).publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBm2FzAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Major Page Faults per Container",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_memory_failures_total', filter=filter('metric_source', 'kubernetes') and filter('type', 'pgmajfault')).sum(by=['container_name']).publish(label='A')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnHTuAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Total # CPU Cores",
+        "name": "# Active Pods",
         "options": {
           "colorBy": "Dimension",
           "colorScale": null,
@@ -3410,11 +4013,12 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "cpu cores",
+              "displayName": "number of pods",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -3427,13 +4031,17 @@
           "refreshInterval": null,
           "secondaryVisualization": "None",
           "showSparkLine": false,
-          "time": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
           "timestampHidden": false,
           "type": "SingleValue",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('machine_cpu_cores', filter=filter('metric_source', 'kubernetes')).sum().mean(over='1m').publish(label='A')",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_pod_uid']).count().publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -3443,10 +4051,10 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBnBZnAgAA",
+        "id": "DkBnHSwAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Pods by Phase",
+        "name": "Memory Use per Pod (bytes)",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -3455,7 +4063,7 @@
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "pods",
+              "label": "bytes",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
@@ -3463,7 +4071,7 @@
             }
           ],
           "axisPrecision": null,
-          "colorBy": "Metric",
+          "colorBy": "Dimension",
           "defaultPlotType": "AreaChart",
           "eventPublishLabelOptions": [],
           "histogramChartOptions": {
@@ -3477,58 +4085,19 @@
             "showDataMarkers": false
           },
           "onChartLegendOptions": {
-            "dimensionInLegend": "sf_metric",
-            "showLegend": true
+            "dimensionInLegend": null,
+            "showLegend": false
           },
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 30000
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "Pending",
+              "displayName": "memory use (bytes)",
               "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Running",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Succeeded",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Failed",
-              "label": "D",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Unknown",
-              "label": "E",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
@@ -3540,14 +4109,15 @@
           "showEventLines": false,
           "stacked": true,
           "time": {
-            "range": 900000,
+            "range": 3600000,
             "type": "relative"
           },
           "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
+          "unitPrefix": "Binary"
         },
         "packageSpecifications": "",
-        "programText": "A = data('kubernetes.pod_phase', rollup='latest').below(1, inclusive=True).count().publish(label='A')\nB = data('kubernetes.pod_phase', rollup='latest').between(1.1, 2, low_inclusive=True, high_inclusive=True).count().publish(label='B')\nC = data('kubernetes.pod_phase', rollup='latest').between(2.1, 3, low_inclusive=True, high_inclusive=True).count().publish(label='C')\nD = data('kubernetes.pod_phase', rollup='latest').between(3.1, 4, low_inclusive=True, high_inclusive=True).count().publish(label='D')\nE = data('kubernetes.pod_phase', rollup='latest').above(4).count().publish(label='E')",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_pod_name']).publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -3557,36 +4127,155 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBmcY0AgAA",
+        "id": "D2Sl55LAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Network Errors / sec",
+        "name": "CPU Usage per Pod",
         "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
+          "areaChartOptions": {
+            "showDataMarkers": false
           },
-          "maximumPrecision": null,
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": true,
+                "property": "sf_metric"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "Rx",
+              "displayName": "conatiner centi-core usage",
               "label": "A",
-              "paletteIndex": 4,
+              "paletteIndex": null,
               "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
+              "valuePrefix": "",
+              "valueSuffix": "",
               "valueUnit": null,
               "yAxis": 0
             },
             {
-              "displayName": "Tx",
-              "label": "B",
+              "displayName": "num cores on host",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "pod cpu usage",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": true,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['kubernetes_pod_name', 'host', 'kubernetes_pod_name', 'kubernetes_namespace', 'kubernetes_cluster', 'kubernetes_node']).publish(label='A', enable=False)\nB = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['kubernetes_node']).publish(label='E', enable=False)\nC = (A/B).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnaELAcAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# Clusters",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "D",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
@@ -3596,85 +4285,6 @@
             }
           ],
           "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "+sf_metric",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_errors_total', filter=filter('metric_source', 'kubernetes')).sum().publish(label='A')\nB = data('pod_network_transmit_errors_total', filter=filter('metric_source', 'kubernetes')).sum().publish(label='B')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnAvVAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Deployments Not at Spec",
-        "options": {
-          "colorBy": "Scale",
-          "colorScale": null,
-          "colorScale2": [
-            {
-              "gt": 0,
-              "gte": null,
-              "lt": null,
-              "lte": null,
-              "paletteIndex": 16
-            },
-            {
-              "gt": null,
-              "gte": null,
-              "lt": null,
-              "lte": 0,
-              "paletteIndex": 14
-            }
-          ],
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "available pods",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "desired pods",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "pods desired but not available",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": 60000,
           "secondaryVisualization": "None",
           "showSparkLine": false,
           "time": null,
@@ -3683,7 +4293,108 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('kubernetes.deployment.available', extrapolation='zero').publish(label='A', enable=False)\nB = data('kubernetes.deployment.desired', extrapolation='zero').publish(label='B', enable=False)\nC = (B-A).above(0).count().publish(label='C')",
+        "programText": "D = data('container_cpu_utilization').sum(by=['kubernetes_cluster']).mean(over='1m').count().publish(label='D')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "grouped by namespace",
+        "id": "D2SlUA5AcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "CPU Usage per Pod",
+        "options": {
+          "colorBy": "Scale",
+          "colorRange": null,
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 80,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 60,
+              "gte": null,
+              "lt": null,
+              "lte": 80,
+              "paletteIndex": 17
+            },
+            {
+              "gt": 40,
+              "gte": null,
+              "lt": null,
+              "lte": 60,
+              "paletteIndex": 18
+            },
+            {
+              "gt": 20,
+              "gte": null,
+              "lt": null,
+              "lte": 40,
+              "paletteIndex": 19
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 20,
+              "paletteIndex": 20
+            }
+          ],
+          "groupBy": [
+            "kubernetes_namespace"
+          ],
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "conatiner centi-core usage",
+              "label": "A",
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null
+            },
+            {
+              "displayName": "num cores on host",
+              "label": "E",
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null
+            },
+            {
+              "displayName": "pod cpu usage",
+              "label": "C",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
+            }
+          ],
+          "refreshInterval": null,
+          "sortDirection": "Ascending",
+          "sortProperty": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "Heatmap",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['kubernetes_pod_name', 'host', 'kubernetes_pod_name', 'kubernetes_namespace', 'kubernetes_cluster', 'kubernetes_node']).publish(label='A', enable=False)\nB = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['host']).publish(label='E', enable=False)\nC = (A/B).publish(label='C')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -3707,7 +4418,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -3740,6 +4452,7 @@
         },
         "packageSpecifications": "",
         "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).publish(label='A', enable=False)\nB = (A).sum(by=['kubernetes_pod_name']).mean(over='1m').top(count=10).publish(label='B')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -3748,170 +4461,11 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "Network receive and transmit errors from pods on this node",
-        "id": "DkBnHTDAYAA",
+        "description": "created by Deployments",
+        "id": "D2SlXg8AYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Pod Network Errors by Interface",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Rx",
-              "label": "A",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Tx",
-              "label": "B",
-              "paletteIndex": 1,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['interface']).publish(label='A')\nB = data('pod_network_transmit_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['interface']).publish(label='B')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Based on Kubernetes resource limits.  If no limits, will be blank.",
-        "id": "DkBm2N8AgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "% Memory Used per Container",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "container",
-              "label": "A",
-              "paletteIndex": 1,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "limit",
-              "label": "B",
-              "paletteIndex": 6,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 1
-            },
-            {
-              "displayName": "",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 3600001,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).publish(label='A', enable=False)\nB = data('container_spec_memory_limit_bytes', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).above(0, inclusive=True).publish(label='B', enable=False)\nC = (A/B*100).publish(label='C')",
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "This may include \"pause\" containers used internally by K8s",
-        "id": "DkBmcAEAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "# Active Pods",
+        "name": "Available Pods",
         "options": {
           "colorBy": "Dimension",
           "colorScale": null,
@@ -3919,12 +4473,13 @@
           "maximumPrecision": null,
           "programOptions": {
             "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "container_cpu_utilization - Mean(1m) - Sum by kubernetes_pod_name - Count",
+              "displayName": "",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -3937,13 +4492,173 @@
           "refreshInterval": null,
           "secondaryVisualization": "None",
           "showSparkLine": false,
-          "time": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
           "timestampHidden": false,
           "type": "SingleValue",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).mean(over='1m').sum(by=['kubernetes_pod_name']).count().publish(label='A')",
+        "programText": "A = data('kubernetes.deployment.available', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_name']).sum().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SlUknAgCU",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Number of Pods per Node",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": true,
+                "property": "machine_id"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "container_image"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "metric_source"
+              },
+              {
+                "enabled": true,
+                "property": "container_name"
+              },
+              {
+                "enabled": true,
+                "property": "container_spec_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), extrapolation='last_value').sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_node', 'kubernetes_pod_name']).count(by=['kubernetes_node']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBm16iAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Memory Used per Container (Bytes)",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes')).mean(by=['container_name']).publish(label='A')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -4002,7 +4717,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -4037,6 +4753,7 @@
         },
         "packageSpecifications": "",
         "programText": "A = data('pod_network_receive_bytes_total', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum().publish(label='A')\nB = data('pod_network_transmit_bytes_total', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum().publish(label='B')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     },
@@ -4045,11 +4762,552 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "per cluster",
-        "id": "DkBnb24AYAA",
+        "description": "",
+        "id": "D2SlXF0AcAE",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Memory Capacity Used",
+        "name": "CPU Capacity Used per Node",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": 100,
+              "highWatermarkLabel": null,
+              "label": "cpu %",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": true,
+                "property": "container_image"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "metric_source"
+              },
+              {
+                "enabled": true,
+                "property": "container_name"
+              },
+              {
+                "enabled": true,
+                "property": "container_spec_name"
+              },
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": true,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "centi-cores per cluster",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "# cores per cluster",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Node CPU Capacity Usage %",
+              "label": "F",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": true,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "D = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['kubernetes_node']).publish(label='D', enable=False)\nE = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['kubernetes_node']).publish(label='E', enable=False)\nF = (D/E).publish(label='F')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "bytes in + bytes out",
+        "id": "D2SmUtjAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top Nodes by Network Usage",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx (bytes/sec)",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx (bytes/sec)",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            },
+            {
+              "displayName": "A+B",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('kubernetes_cluster', '*', match_missing=True), extrapolation='zero').sum(by=['host']).publish(label='A', enable=False)\nB = data('pod_network_transmit_bytes_total', filter=filter('kubernetes_cluster', '*', match_missing=True), extrapolation='zero').sum(by=['host']).publish(label='B', enable=False)\nC = (A+B).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnBFnAcAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Net Pods Desired by Replica Set",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_name"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "uid"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "available pods",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "desired pods",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "pods desired but not available",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.replica_set.available').publish(label='A', enable=False)\nB = data('kubernetes.replica_set.desired').publish(label='B', enable=False)\nC = (B-A).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SlWE-AcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# of Pods by Phase",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Running",
+              "label": "B",
+              "paletteIndex": 15,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Pending",
+              "label": "A",
+              "paletteIndex": 6,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Succeeded",
+              "label": "C",
+              "paletteIndex": 2,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Failed",
+              "label": "D",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Unknown",
+              "label": "E",
+              "paletteIndex": 11,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "+sf_originatingMetric",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "B = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count().publish(label='B')\nA = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count().publish(label='A')\nC = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(2.5, 3.5, low_inclusive=True, high_inclusive=True).count().publish(label='C')\nD = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(3.5, 4.5, low_inclusive=True, high_inclusive=True).count().publish(label='D')\nE = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(4.5, 5.5, low_inclusive=True, high_inclusive=True).count().publish(label='E')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Based on Pod spec's resources.limits.cpu value if present, otherwise chart will be blank.",
+        "id": "D2Sl4VWAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "% CPU Limit Used per Pod",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": 80,
+              "highWatermarkLabel": null,
+              "label": "CPU %",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Centicores used",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "CFS quota",
+              "label": "B",
+              "paletteIndex": 6,
+              "plotType": "LineChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "CFS period",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "% of Limit",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).publish(label='A', enable=False)\nB = data('container_spec_cpu_quota', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).publish(label='B', enable=False)\nC = data('container_spec_cpu_period', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).publish(label='C', enable=False)\nD = (A/(B/C)).sum(by=['kubernetes_pod_name']).publish(label='D')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "per node",
+        "id": "D2SmUhoAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top 10 Nodes by Memory Capacity Used",
         "options": {
           "colorBy": "Scale",
           "colorScale2": [
@@ -4090,26 +5348,18 @@
             }
           ],
           "legendOptions": {
-            "fields": [
-              {
-                "enabled": true,
-                "property": "kubernetes_cluster"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              }
-            ]
+            "fields": null
           },
           "maximumPrecision": 3,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "memory usage per cluster",
+              "displayName": "memory usage per node",
               "label": "D",
               "paletteIndex": null,
               "plotType": null,
@@ -4119,7 +5369,7 @@
               "yAxis": 0
             },
             {
-              "displayName": "memory capacity per cluster",
+              "displayName": "memory capacity per node",
               "label": "E",
               "paletteIndex": null,
               "plotType": null,
@@ -4129,12 +5379,63 @@
               "yAxis": 0
             },
             {
-              "displayName": "% used per cluster",
+              "displayName": "",
               "label": "F",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "D = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'host']).mean(over='1m').publish(label='D', enable=False)\nE = data('machine_memory_bytes', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'host']).mean(over='1m').publish(label='E', enable=False)\nF = (D/E).scale(100).top(count=10).publish(label='F')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBm2FzAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Major Page Faults per Container",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
               "valueUnit": null,
               "yAxis": 0
             }
@@ -4147,74 +5448,1671 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "D = data('container_memory_usage_bytes').sum(by=['kubernetes_cluster']).publish(label='D', enable=False)\nE = data('machine_memory_bytes').sum(by=['kubernetes_cluster']).publish(label='E', enable=False)\nF = (D/E).scale(100).publish(label='F')",
+        "programText": "A = data('container_memory_failures_total', filter=filter('metric_source', 'kubernetes') and filter('type', 'pgmajfault')).sum(by=['container_name']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SmSKEAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Total Memory (bytes)",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": 4,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "machine_memory_bytes - Sum",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "A/1024/1024",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('machine_memory_bytes', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum().publish(label='A')\nB = (A/1024/1024).publish(label='B', enable=False)",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnCV1AcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pods by Phase",
+        "options": {
+          "colorBy": "Metric",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Pending",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Running",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Succeeded",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Failed",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Unknown",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": 60000,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.pod_phase', rollup='latest').below(1, inclusive=True).count().publish(label='A')\nB = data('kubernetes.pod_phase', rollup='latest').between(1.1, 2, low_inclusive=True, high_inclusive=True).count().publish(label='B')\nC = data('kubernetes.pod_phase', rollup='latest').between(2.1, 3, low_inclusive=True, high_inclusive=True).count().publish(label='C')\nD = data('kubernetes.pod_phase', rollup='latest').between(3.1, 4, low_inclusive=True, high_inclusive=True).count().publish(label='D')\nE = data('kubernetes.pod_phase', rollup='latest').above(4).count().publish(label='E')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnHZUAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "% Memory Capacity Used",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "% memory used",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 110,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "memory usage per node",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "memory capacity per node",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "",
+              "label": "F",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "D = data('container_memory_usage_bytes').sum(by=['host']).mean(over='1m').publish(label='D', enable=False)\nE = data('machine_memory_bytes').sum(by=['host']).mean(over='1m').publish(label='E', enable=False)\nF = (D/E).scale(100).publish(label='F')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SmSX4AgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# Nodes",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['host']).mean(over='1m').count().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Network receive and transmit errors from pods on this node",
+        "id": "D2SmSLNAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Network Errors by Interface",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_errors_total', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['interface']).publish(label='A')\nB = data('pod_network_transmit_errors_total', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['interface']).publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnJksAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Total Memory (bytes)",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": 4,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "machine_memory_bytes - Sum",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "A/1024/1024",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('machine_memory_bytes', filter=filter('metric_source', 'kubernetes')).sum().publish(label='A')\nB = (A/1024/1024).publish(label='B', enable=False)",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnBhCAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Daemon Sets by Stage",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_name"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": true,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "uid"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "current",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "desired",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "misscheduled",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "ready",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "+kubernetes_cluster",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.daemon_set.current_scheduled').sum(by=['kubernetes_cluster']).publish(label='A')\nB = data('kubernetes.daemon_set.desired_scheduled').sum(by=['kubernetes_cluster']).publish(label='B')\nC = data('kubernetes.daemon_set.misscheduled').sum(by=['kubernetes_cluster']).publish(label='C')\nD = data('kubernetes.daemon_set.ready').sum(by=['kubernetes_cluster']).publish(label='D')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Network receive and transmit errors from pods on this node",
+        "id": "DkBnHTDAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod Network Errors by Interface",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['interface']).publish(label='A')\nB = data('pod_network_transmit_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['interface']).publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SlUMWAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": ".",
+        "options": {
+          "markdown": "<table width=\"100%\" height=\"50%\" rules=\"none\"><tr><td valign=\"middle\" align=\"center\" bgcolor=\"#59a200\">\n<font size=\"5\" color=\"white\">K8s Nodes</font>\n</td></tr></table>\n\n<p align=\"center\" ><br /><font>This dashboard is populated by the metrics emitted from the <a href=\"https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-cluster.html\" target=\"_blank\">kubernetes-cluster</a> monitor and  <a href=\"https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubelet-stats.html\" target=\"_blank\">kubelet-stats</a> . Charts below refer to the health of your Kubernetes Nodes. When filtered by Deployment or Service, charts below will be filtered by the selected pods running on the nodes.<br></p></font>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2Sl4O-AcAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top 10 Pods by Major Page Faults",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_failures_total', filter=filter('type', 'pgmajfault') and filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).top(count=10).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SlWkWAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Desired Pods by Deployments",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": false,
+                "property": "deployment"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_uid"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_deployment_uid"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": "kubernetes_name",
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "desired pods",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": true,
+          "stacked": true,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.deployment.desired', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_name']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "number of pods ready by deploments",
+        "id": "D2Sl4JuAYAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Available Pods by Deployments",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.deployment.available', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_name', 'kubernetes_uid']).sum().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "grouped by cluster",
+        "id": "D2SlUmAAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "CPU Capacity Used per Node",
+        "options": {
+          "colorBy": "Scale",
+          "colorRange": null,
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 80,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 60,
+              "gte": null,
+              "lt": null,
+              "lte": 80,
+              "paletteIndex": 17
+            },
+            {
+              "gt": 40,
+              "gte": null,
+              "lt": null,
+              "lte": 60,
+              "paletteIndex": 18
+            },
+            {
+              "gt": 20,
+              "gte": null,
+              "lt": null,
+              "lte": 40,
+              "paletteIndex": 19
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 20,
+              "paletteIndex": 20
+            }
+          ],
+          "groupBy": [
+            "kubernetes_cluster"
+          ],
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "conatiner centi-core usage",
+              "label": "A",
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null
+            },
+            {
+              "displayName": "num cores on host",
+              "label": "E",
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null
+            },
+            {
+              "displayName": "node cpu usage",
+              "label": "C",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
+            }
+          ],
+          "refreshInterval": null,
+          "sortDirection": "Ascending",
+          "sortProperty": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "Heatmap",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['host', 'kubernetes_cluster', 'kubernetes_node']).publish(label='A', enable=False)\nB = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['host']).publish(label='E', enable=False)\nC = (A/B).publish(label='C')",
+        "relatedDetectorIds": [],
         "tags": null
       }
     }
   ],
+  "crossLinkExports": [],
   "dashboardExports": [
     {
       "dashboard": {
         "chartDensity": "DEFAULT",
         "charts": [
           {
-            "chartId": "DkBkyDZAgAI",
-            "column": 0,
+            "chartId": "D2Sl4ZAAYAA",
+            "column": 4,
             "height": 1,
             "row": 0,
             "width": 4
           },
           {
-            "chartId": "DkBkzLZAgAA",
+            "chartId": "D2Sl4AoAgAA",
             "column": 8,
             "height": 1,
             "row": 0,
             "width": 4
           },
           {
-            "chartId": "DkBky-7AgAA",
-            "column": 4,
+            "chartId": "D2Sl5crAcAA",
+            "column": 0,
             "height": 1,
             "row": 0,
             "width": 4
           },
           {
-            "chartId": "DkBkzShAcAA",
-            "column": 4,
-            "height": 1,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBkzFUAcAA",
-            "column": 0,
-            "height": 1,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBkyr2AcAA",
+            "chartId": "D2Sl4P3AgAA",
             "column": 8,
             "height": 1,
             "row": 1,
             "width": 4
           },
           {
-            "chartId": "DkBkzRrAYAA",
+            "chartId": "D2Sl4JuAYAE",
+            "column": 4,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "D2Sl4ATAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "D2Sl4UpAYAA",
             "column": 4,
             "height": 1,
             "row": 2,
             "width": 4
           },
           {
-            "chartId": "DkBkzjnAgAA",
+            "chartId": "D2Sl4zpAYAA",
             "column": 0,
             "height": 1,
             "row": 2,
             "width": 4
           },
           {
-            "chartId": "DkBkzE4AYAA",
+            "chartId": "D2Sl4rMAgAA",
+            "column": 8,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "D2Sl55LAgAA",
+            "column": 4,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "D2Sl4VWAcAA",
+            "column": 8,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "D2Sl4O-AcAE",
+            "column": 0,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "",
+        "discoveryOptions": {
+          "query": "_exists_:kubernetes_pod_name AND _exists_:kubernetes_cluster",
+          "selectors": [
+            "sf_key:kubernetes_pod_name"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": [
+            {
+              "alias": "Cluster",
+              "applyIfExists": false,
+              "description": "",
+              "preferredSuggestions": [],
+              "property": "kubernetes_cluster",
+              "replaceOnly": true,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            },
+            {
+              "alias": "Namespace",
+              "applyIfExists": false,
+              "description": "",
+              "preferredSuggestions": [],
+              "property": "kubernetes_namespace",
+              "replaceOnly": true,
+              "required": false,
+              "restricted": false,
+              "value": "default"
+            },
+            {
+              "alias": "Deployment",
+              "applyIfExists": false,
+              "description": "",
+              "preferredSuggestions": [],
+              "property": "kubernetes_deployment_name",
+              "replaceOnly": true,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            },
+            {
+              "alias": "Service",
+              "applyIfExists": false,
+              "description": "",
+              "preferredSuggestions": [
+                "kubernetes_service*"
+              ],
+              "property": "sf_tags",
+              "replaceOnly": true,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            }
+          ]
+        },
+        "groupId": "DiVWf-iAgAA",
+        "id": "D2Sl37TAYAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "K8s Pods",
+        "selectedEventOverlays": [],
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DkBnaELAcAE",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DkBncFkAYAI",
+            "column": 8,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnaDJAYAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DkBncDiAgAI",
+            "column": 0,
+            "height": 2,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnb24AYAA",
+            "column": 8,
+            "height": 2,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnaCuAgDg",
+            "column": 4,
+            "height": 2,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnaH0AgFc",
+            "column": 6,
+            "height": 1,
+            "row": 3,
+            "width": 6
+          },
+          {
+            "chartId": "DkBnb_OAcAE",
+            "column": 0,
+            "height": 1,
+            "row": 3,
+            "width": 6
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": null,
+        "discoveryOptions": {
+          "query": "sf_metric:cpu.utilization AND _exists_:kubernetes_cluster",
+          "selectors": [
+            "_exists_:kubernetes_cluster"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": null
+        },
+        "groupId": "DiVWf-iAgAA",
+        "id": "DkBnZ_qAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "K8s Clusters",
+        "selectedEventOverlays": [],
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DkBnJQ3AYAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnHTuAcAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnJksAcAA",
+            "column": 8,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnHSwAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 6
+          },
+          {
+            "chartId": "DkBnI_OAcAA",
+            "column": 6,
+            "height": 1,
+            "row": 1,
+            "width": 6
+          },
+          {
+            "chartId": "DkBnHTDAYAA",
+            "column": 8,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnJmPAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnHS4AgAA",
+            "column": 4,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnJHhAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 3,
+            "width": 6
+          },
+          {
+            "chartId": "DkBnHZUAgAA",
+            "column": 6,
+            "height": 1,
+            "row": 3,
+            "width": 6
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": null,
+        "discoveryOptions": {
+          "query": "_exists_:kubernetes_cluster AND _exists_:host",
+          "selectors": [
+            "_exists_:host"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": [
+            {
+              "alias": "host",
+              "applyIfExists": false,
+              "description": "K8s node",
+              "preferredSuggestions": [],
+              "property": "host",
+              "replaceOnly": false,
+              "required": true,
+              "restricted": false,
+              "value": ""
+            }
+          ]
+        },
+        "groupId": "DiVWf-iAgAA",
+        "id": "DkBnHSpAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "K8s Node",
+        "selectedEventOverlays": [],
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "D2SlUMWAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "D2SlVhwAcAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 8
+          },
+          {
+            "chartId": "D2SlUA5AcAA",
+            "column": 6,
+            "height": 2,
+            "row": 1,
+            "width": 6
+          },
+          {
+            "chartId": "D2SlWE-AcAA",
+            "column": 4,
+            "height": 1,
+            "row": 1,
+            "width": 2
+          },
+          {
+            "chartId": "D2SlUmAAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "D2SlXplAcAE",
+            "column": 4,
+            "height": 1,
+            "row": 2,
+            "width": 2
+          },
+          {
+            "chartId": "D2SlUknAgCU",
+            "column": 0,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "D2SlUGlAgAc",
+            "column": 4,
+            "height": 1,
+            "row": 3,
+            "width": 3
+          },
+          {
+            "chartId": "D2SlYW-AYAA",
+            "column": 0,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "D2SlYGhAgAA",
+            "column": 7,
+            "height": 1,
+            "row": 3,
+            "width": 2
+          },
+          {
+            "chartId": "D2SlWkWAYAA",
+            "column": 9,
+            "height": 1,
+            "row": 3,
+            "width": 3
+          },
+          {
+            "chartId": "D2SlUbdAcDo",
+            "column": 4,
+            "height": 1,
+            "row": 4,
+            "width": 3
+          },
+          {
+            "chartId": "D2SlXF0AcAE",
+            "column": 0,
+            "height": 1,
+            "row": 4,
+            "width": 4
+          },
+          {
+            "chartId": "D2SlXg8AYAA",
+            "column": 7,
+            "height": 1,
+            "row": 4,
+            "width": 2
+          },
+          {
+            "chartId": "D2SlWheAgAA",
+            "column": 9,
+            "height": 1,
+            "row": 4,
+            "width": 3
+          },
+          {
+            "chartId": "D2SlXcSAgAI",
+            "column": 0,
+            "height": 1,
+            "row": 5,
+            "width": 4
+          },
+          {
+            "chartId": "D2SlSy6AYB8",
+            "column": 8,
+            "height": 1,
+            "row": 5,
+            "width": 4
+          },
+          {
+            "chartId": "D2SlWAnAYAA",
+            "column": 4,
+            "height": 1,
+            "row": 5,
+            "width": 4
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "An overview of multiple Kubernetes clusters",
+        "discoveryOptions": null,
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": {
+            "end": "Now",
+            "start": "-1h"
+          },
+          "variables": [
+            {
+              "alias": "Cluster",
+              "applyIfExists": false,
+              "description": "",
+              "preferredSuggestions": [],
+              "property": "kubernetes_cluster",
+              "replaceOnly": true,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            },
+            {
+              "alias": "Namespace",
+              "applyIfExists": false,
+              "description": "",
+              "preferredSuggestions": [],
+              "property": "kubernetes_namespace",
+              "replaceOnly": true,
+              "required": false,
+              "restricted": false,
+              "value": "default"
+            },
+            {
+              "alias": "Node",
+              "applyIfExists": false,
+              "description": "",
+              "preferredSuggestions": [],
+              "property": "kubernetes_node",
+              "replaceOnly": true,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            },
+            {
+              "alias": "Deployment",
+              "applyIfExists": false,
+              "description": "",
+              "preferredSuggestions": [],
+              "property": "deployment",
+              "replaceOnly": true,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            },
+            {
+              "alias": "Service",
+              "applyIfExists": false,
+              "description": "",
+              "preferredSuggestions": [
+                "kubernetes_service*"
+              ],
+              "property": "sf_tags",
+              "replaceOnly": true,
+              "required": false,
+              "restricted": true,
+              "value": ""
+            }
+          ]
+        },
+        "groupId": "DiVWf-iAgAA",
+        "id": "D2SlSb5AgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "K8s Overview",
+        "selectedEventOverlays": [],
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DkBm18SAgAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DkBm2ftAYCM",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DkBm2CNAYAA",
+            "column": 8,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DkBm2N8AgAA",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DkBm16iAcAA",
+            "column": 4,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DkBm2FzAcAA",
+            "column": 8,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DkBm2jfAcDo",
+            "column": 4,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DkBm1ulAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": null,
+        "discoveryOptions": {
+          "query": "_exists_:kubernetes_pod_name AND _exists_:kubernetes_cluster",
+          "selectors": [
+            "_exists_:kubernetes_pod_name"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": [
+            {
+              "alias": "pod",
+              "applyIfExists": false,
+              "description": "K8s pod",
+              "preferredSuggestions": [],
+              "property": "kubernetes_pod_name",
+              "replaceOnly": false,
+              "required": true,
+              "restricted": false,
+              "value": null
+            }
+          ]
+        },
+        "groupId": "DiVWf-iAgAA",
+        "id": "DkBm1lEAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "K8s Pod",
+        "selectedEventOverlays": [],
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "D2SmSX4AgAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "D2SmSKEAYAA",
+            "column": 8,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "D2SmR8XAgAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "D2SmUQbAgAA",
+            "column": 4,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "D2SmTISAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "D2SmUhoAYAA",
+            "column": 8,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "D2SmSj3AYAA",
+            "column": 4,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "D2SmUtjAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "D2SmSLNAcAA",
             "column": 8,
             "height": 1,
             "row": 2,
@@ -4224,7 +7122,7 @@
         "created": 0,
         "creator": null,
         "customProperties": null,
-        "description": "",
+        "description": "An overview of multiple Kubernetes nodes",
         "discoveryOptions": {
           "query": "_exists_:kubernetes_cluster AND _exists_:host",
           "selectors": [
@@ -4235,10 +7133,22 @@
         "filters": {
           "sources": null,
           "time": null,
-          "variables": null
+          "variables": [
+            {
+              "alias": "Cluster",
+              "applyIfExists": false,
+              "description": "Kubernetes Cluster Name",
+              "preferredSuggestions": [],
+              "property": "kubernetes_cluster",
+              "replaceOnly": true,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            }
+          ]
         },
         "groupId": "DiVWf-iAgAA",
-        "id": "DkBkyBFAcEs",
+        "id": "D2SmRRbAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "locked": false,
@@ -4368,403 +7278,6 @@
         "selectedEventOverlays": [],
         "tags": null
       }
-    },
-    {
-      "dashboard": {
-        "chartDensity": "DEFAULT",
-        "charts": [
-          {
-            "chartId": "DkBm18SAgAA",
-            "column": 4,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBm2ftAYCM",
-            "column": 0,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBm2CNAYAA",
-            "column": 8,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBm2N8AgAA",
-            "column": 0,
-            "height": 1,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBm16iAcAA",
-            "column": 4,
-            "height": 1,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBm2FzAcAA",
-            "column": 8,
-            "height": 1,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBm2jfAcDo",
-            "column": 4,
-            "height": 1,
-            "row": 2,
-            "width": 4
-          },
-          {
-            "chartId": "DkBm1ulAYAA",
-            "column": 0,
-            "height": 1,
-            "row": 2,
-            "width": 4
-          }
-        ],
-        "created": 0,
-        "creator": null,
-        "customProperties": null,
-        "description": null,
-        "discoveryOptions": {
-          "query": "_exists_:kubernetes_pod_name AND _exists_:kubernetes_cluster",
-          "selectors": [
-            "_exists_:kubernetes_pod_name"
-          ]
-        },
-        "eventOverlays": null,
-        "filters": {
-          "sources": null,
-          "time": null,
-          "variables": [
-            {
-              "alias": "pod",
-              "applyIfExists": false,
-              "description": "K8s pod",
-              "preferredSuggestions": [],
-              "property": "kubernetes_pod_name",
-              "replaceOnly": false,
-              "required": true,
-              "restricted": false,
-              "value": null
-            }
-          ]
-        },
-        "groupId": "DiVWf-iAgAA",
-        "id": "DkBm1lEAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "locked": false,
-        "maxDelayOverride": null,
-        "name": "K8s Pod",
-        "selectedEventOverlays": [],
-        "tags": null
-      }
-    },
-    {
-      "dashboard": {
-        "chartDensity": "DEFAULT",
-        "charts": [
-          {
-            "chartId": "DkBnaELAcAE",
-            "column": 0,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBncFkAYAI",
-            "column": 8,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnaDJAYAA",
-            "column": 4,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBncDiAgAI",
-            "column": 0,
-            "height": 2,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnb24AYAA",
-            "column": 8,
-            "height": 2,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnaCuAgDg",
-            "column": 4,
-            "height": 2,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnaH0AgFc",
-            "column": 6,
-            "height": 1,
-            "row": 3,
-            "width": 6
-          },
-          {
-            "chartId": "DkBnb_OAcAE",
-            "column": 0,
-            "height": 1,
-            "row": 3,
-            "width": 6
-          }
-        ],
-        "created": 0,
-        "creator": null,
-        "customProperties": null,
-        "description": null,
-        "discoveryOptions": {
-          "query": "sf_metric:cpu.utilization AND _exists_:kubernetes_cluster",
-          "selectors": [
-            "_exists_:kubernetes_cluster"
-          ]
-        },
-        "eventOverlays": null,
-        "filters": {
-          "sources": null,
-          "time": null,
-          "variables": null
-        },
-        "groupId": "DiVWf-iAgAA",
-        "id": "DkBnZ_qAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "locked": false,
-        "maxDelayOverride": null,
-        "name": "K8s Clusters",
-        "selectedEventOverlays": [],
-        "tags": null
-      }
-    },
-    {
-      "dashboard": {
-        "chartDensity": "DEFAULT",
-        "charts": [
-          {
-            "chartId": "DkBmbEbAgAA",
-            "column": 4,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBmcY0AgAA",
-            "column": 8,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBmcAEAcAA",
-            "column": 0,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBmciwAcAA",
-            "column": 0,
-            "height": 1,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBmckkAgAA",
-            "column": 4,
-            "height": 1,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBmbAEAcAE",
-            "column": 8,
-            "height": 1,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBmclKAYAA",
-            "column": 0,
-            "height": 1,
-            "row": 2,
-            "width": 4
-          },
-          {
-            "chartId": "DkBmbNpAYAA",
-            "column": 4,
-            "height": 1,
-            "row": 2,
-            "width": 4
-          },
-          {
-            "chartId": "DkBmcgVAYAA",
-            "column": 8,
-            "height": 1,
-            "row": 2,
-            "width": 4
-          }
-        ],
-        "created": 0,
-        "creator": null,
-        "customProperties": null,
-        "description": "",
-        "discoveryOptions": {
-          "query": "_exists_:kubernetes_pod_name AND _exists_:kubernetes_cluster",
-          "selectors": [
-            "sf_key:kubernetes_pod_name"
-          ]
-        },
-        "eventOverlays": null,
-        "filters": {
-          "sources": null,
-          "time": null,
-          "variables": null
-        },
-        "groupId": "DiVWf-iAgAA",
-        "id": "DkBma1YAYDg",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "locked": false,
-        "maxDelayOverride": null,
-        "name": "K8s Pods",
-        "selectedEventOverlays": [],
-        "tags": null
-      }
-    },
-    {
-      "dashboard": {
-        "chartDensity": "DEFAULT",
-        "charts": [
-          {
-            "chartId": "DkBnJQ3AYAA",
-            "column": 0,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnHTuAcAA",
-            "column": 4,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnJksAcAA",
-            "column": 8,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnHSwAcAA",
-            "column": 0,
-            "height": 1,
-            "row": 1,
-            "width": 6
-          },
-          {
-            "chartId": "DkBnI_OAcAA",
-            "column": 6,
-            "height": 1,
-            "row": 1,
-            "width": 6
-          },
-          {
-            "chartId": "DkBnHTDAYAA",
-            "column": 8,
-            "height": 1,
-            "row": 2,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnJmPAgAA",
-            "column": 0,
-            "height": 1,
-            "row": 2,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnHS4AgAA",
-            "column": 4,
-            "height": 1,
-            "row": 2,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnJHhAgAA",
-            "column": 0,
-            "height": 1,
-            "row": 3,
-            "width": 6
-          },
-          {
-            "chartId": "DkBnHZUAgAA",
-            "column": 6,
-            "height": 1,
-            "row": 3,
-            "width": 6
-          }
-        ],
-        "created": 0,
-        "creator": null,
-        "customProperties": null,
-        "description": null,
-        "discoveryOptions": {
-          "query": "_exists_:kubernetes_cluster AND _exists_:host",
-          "selectors": [
-            "_exists_:host"
-          ]
-        },
-        "eventOverlays": null,
-        "filters": {
-          "sources": null,
-          "time": null,
-          "variables": [
-            {
-              "alias": "host",
-              "applyIfExists": false,
-              "description": "K8s node",
-              "preferredSuggestions": [],
-              "property": "host",
-              "replaceOnly": false,
-              "required": true,
-              "restricted": false,
-              "value": ""
-            }
-          ]
-        },
-        "groupId": "DiVWf-iAgAA",
-        "id": "DkBnHSpAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "locked": false,
-        "maxDelayOverride": null,
-        "name": "K8s Node",
-        "selectedEventOverlays": [],
-        "tags": null
-      }
     }
   ],
   "groupExport": {
@@ -4772,12 +7285,13 @@
       "created": 0,
       "creator": null,
       "dashboards": [
-        "DkBm1lEAgAA",
-        "DkBm_nVAcAA",
-        "DkBnHSpAYAA",
+        "D2SlSb5AgAA",
         "DkBnZ_qAcAA",
-        "DkBkyBFAcEs",
-        "DkBma1YAYDg"
+        "DkBnHSpAYAA",
+        "D2SmRRbAcAA",
+        "DkBm_nVAcAA",
+        "DkBm1lEAgAA",
+        "D2Sl37TAYAE"
       ],
       "description": "Dashboards about Kubernetes clusters, nodes and pods.",
       "email": null,
@@ -4802,7 +7316,7 @@
       "teams": null
     }
   },
-  "hashCode": -1198143988,
+  "hashCode": 782617621,
   "id": "DiVWf-iAgAA",
   "modelVersion": 1,
   "packageType": "GROUP"


### PR DESCRIPTION
- Add new "K8s Overview" dashboard which is a combination view of cluster, node, and pod level metrics with 5 dashboard variables to filter by Cluster, Namespace, Node, Deployment (property), and Service (tags)
- Add the same dashboard variables to the "Pods" dashboard
- Add Cluster dashboard variable to "Nodes" dashboard
- Update discovery selectors on Nodes, Pods dashboard to make them appear correctly again in dashboard discovery for infra-nav