### PR TITLE
Make ES dashboard groups compatible with collectd/ES and ES monitors

### DIFF
--- a/group/Elasticsearch Index.json
+++ b/group/Elasticsearch Index.json
@@ -6,6 +6,176 @@
         "creator": null,
         "customProperties": {},
         "description": "",
+        "id": "DiVWZJYAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Indexing Requests/sec",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "requests / sec",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Indexing Requests per sec",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices*.indexing.index-total', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *')) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True)), rollup='max', extrapolation='last_value', maxExtrapolations=100).max(by=['index']).rateofchange().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWa9aAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Search Requests/sec",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "requests / sec",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Search Requests per sec",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices*.search.query-total', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total')), rollup='max', extrapolation='last_value', maxExtrapolations=100).max(by=['index']).rateofchange().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
         "id": "DiVWcP3AgLc",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
@@ -55,7 +225,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -99,395 +270,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('counter.indices.total.indexing.index-total', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch'), rollup='delta', extrapolation='last_value', maxExtrapolations=100).max(by=['index']).publish(label='A', enable=False)\nB = data('counter.indices.total.indexing.index-time', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch'), rollup='delta', extrapolation='last_value', maxExtrapolations=100).max(by=['index']).publish(label='B', enable=False)\nC = (B/A).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "last day",
-        "id": "DiVWYVvAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Top Indexes by Index Size Growth %",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 3,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "gauge.indices.total.store.size - Mean by index",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "gauge.indices.total.store.size - Mean by index - Timeshift 1d",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('gauge.indices.total.store.size', filter=filter('plugin', 'elasticsearch')).mean(by=['index']).publish(label='A', enable=False)\nB = data('gauge.indices.total.store.size', filter=filter('plugin', 'elasticsearch')).mean(by=['index']).timeshift('1d').publish(label='B', enable=False)\nC = ((A-B)*100/B).top(count=5).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWZDKAcK0",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Merge Latency (ms)",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "Time (ms)",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "counter.indices.total.merges.total - Maximum by index",
-              "label": "A",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "counter.indices.total.merges.total-time - Maximum by index",
-              "label": "B",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "latency",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('counter.indices.total.merges.total', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch'), rollup='delta', extrapolation='last_value', maxExtrapolations=100).max(by=['index']).publish(label='A', enable=False)\nB = data('counter.indices.total.merges.total-time', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch'), rollup='delta', extrapolation='last_value', maxExtrapolations=100).max(by=['index']).publish(label='B', enable=False)\nC = (B/A).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "last hour",
-        "id": "DiVWaKnAYH0",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Document Growth %",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "growth %",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "gauge.indices.total.docs.count - Mean by index",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "A - Timeshift 1h",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Growth %",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('gauge.indices.total.docs.count', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch'), extrapolation='last_value', maxExtrapolations=100).mean(by=['index']).publish(label='A', enable=False)\nB = (A).timeshift('1h').publish(label='B', enable=False)\nC = ((A-B)*100/B).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWYYHAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Top Indexes by Search Requests",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 3,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('counter.indices.total.search.query-total', filter=filter('plugin', 'elasticsearch'), rollup='max').max(by=['index']).rateofchange().top(count=5).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWa9aAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Search Requests/sec",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "requests / sec",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "counter.indices.total.search.query-total - Maximum by index - Rate of Change",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('counter.indices.total.search.query-total', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch') and (not filter('AWSUniqueId', 'i-0480a3a8_us-east-1_134183635603')), rollup='max', extrapolation='last_value', maxExtrapolations=100).max(by=['index']).rateofchange().publish(label='A')",
+        "programText": "A = data('*.indices*.indexing.index-total', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True)), extrapolation='last_value', maxExtrapolations=100).max(by=['index']).publish(label='A', enable=False)\nB = data('*.indices*.indexing.index-time', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True)), extrapolation='last_value', maxExtrapolations=100).max(by=['index']).publish(label='B', enable=False)\nC = (B/A).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -547,7 +330,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -591,319 +375,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('counter.indices.total.search.query-total', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch'), rollup='delta', extrapolation='last_value', maxExtrapolations=100).max(by=['index']).publish(label='A', enable=False)\nB = data('counter.indices.total.search.query-time', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch'), rollup='delta', extrapolation='last_value', maxExtrapolations=100).max(by=['index']).publish(label='B', enable=False)\nC = (B/A).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "last hour",
-        "id": "DiVWYkXAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Document Growth %",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "growth %",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "gauge.indices.total.docs.count - Mean by index",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "A - Timeshift 1h",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Growth %",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('gauge.indices.total.docs.count', filter=filter('plugin', 'elasticsearch')).mean(by=['index']).publish(label='A', enable=False)\nB = (A).timeshift('1h').publish(label='B', enable=False)\nC = ((A-B)*100/B).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWYOAAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Search Requests/sec",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "requests / sec",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "counter.indices.total.search.query-total - Maximum by index - Rate of Change",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('counter.indices.total.search.query-total', filter=filter('plugin', 'elasticsearch'), rollup='max').max(by=['index']).rateofchange().publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWYYwAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Top Indexes by Indexing Requests",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 2,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('counter.indices.total.indexing.index-total', filter=filter('plugin', 'elasticsearch'), rollup='max').max(by=['index']).rateofchange().top(count=5).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWcWKAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Elasticsearch Tips",
-        "options": {
-          "markdown": "<br>\n**Optimization Tip**\n\nIf your fielddata cache and heap usage are high, consider using [doc values](https://www.elastic.co/guide/en/elasticsearch/reference/current/doc-values.html)!",
-          "type": "Text"
-        },
-        "packageSpecifications": "",
-        "programText": "",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWYI4AYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Indexing Requests/sec",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "requests / sec",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "counter.indices.total.indexing.index-total - Maximum by index - Rate of Change",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('counter.indices.total.indexing.index-total', filter=filter('plugin', 'elasticsearch'), rollup='max').max(by=['index']).rateofchange().publish(label='A')",
+        "programText": "A = data('*.indices*.search.query-total', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', '*', match_missing=True)), rollup='delta', extrapolation='last_value', maxExtrapolations=100).max(by=['index']).publish(label='A', enable=False)\nB = data('*.indices*.search.query-time', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)), rollup='delta', extrapolation='last_value', maxExtrapolations=100).max(by=['index']).publish(label='B', enable=False)\nC = (B/A).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -928,7 +400,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -995,12 +468,15 @@
           "refreshInterval": null,
           "secondaryVisualization": "Sparkline",
           "sortBy": "-value",
-          "time": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
           "type": "List",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('counter.indices.total.search.query-total', filter=filter('plugin', 'elasticsearch'), rollup='max').max(by=['index']).publish(label='A', enable=False)\nB = data('counter.indices.total.search.query-time', filter=filter('plugin', 'elasticsearch'), rollup='max').max(by=['index']).publish(label='B', enable=False)\nC = (A).timeshift('1h').publish(label='C', enable=False)\nD = (B).timeshift('1h').publish(label='D', enable=False)\nE = ((B-D)/(A-C)).publish(label='E', enable=False)\nF = (E).percentile(pct=99, by=['index']).top(count=5).publish(label='F')",
+        "programText": "A = data('*.indices*.search.query-total', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', '*', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True)), rollup='max').max(by=['index']).publish(label='A', enable=False)\nB = data('*.indices*.search.query-time', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True)), rollup='max').max(by=['index']).publish(label='B', enable=False)\nC = (A).timeshift('1h').publish(label='C', enable=False)\nD = (B).timeshift('1h').publish(label='D', enable=False)\nE = ((B-D)/(A-C)).publish(label='E', enable=False)\nF = (E).percentile(pct=99, by=['index']).top(count=5).publish(label='F')\n",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1011,10 +487,61 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DiVWZJYAgAA",
+        "id": "DiVWYYHAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Indexing Requests/sec",
+        "name": "Top Indexes by Search Requests",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices*.search.query-total', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True)), rollup='max').max(by=['index']).rateofchange().top(count=5).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWYskAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Merges/sec",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -1023,7 +550,16 @@
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "requests / sec",
+              "label": "merges / sec",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
@@ -1051,82 +587,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "counter.indices.total.indexing.index-total - Maximum by index - Rate of Change",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('counter.indices.total.indexing.index-total', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch') and (not filter('AWSUniqueId', 'i-0480a3a8_us-east-1_134183635603')), rollup='max', extrapolation='last_value', maxExtrapolations=100).max(by=['index']).rateofchange().publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWXq1AgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Merges/sec",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "merges / sec",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -1150,7 +612,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('counter.indices.total.merges.total', filter=filter('plugin', 'elasticsearch'), rollup='max').max(by=['index']).rateofchange().publish(label='A')",
+        "programText": "A = data('*.indices*.merges.total', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True)), rollup='max', extrapolation='last_value', maxExtrapolations=100).max(by=['index']).rateofchange().publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1160,11 +622,11 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "",
-        "id": "DiVWbs7AgAA",
+        "description": "last hour",
+        "id": "DiVWaKnAYH0",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Deleted Documents %",
+        "name": "Document Growth %",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -1173,7 +635,16 @@
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "deleted %",
+              "label": "growth %",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
@@ -1182,7 +653,7 @@
           ],
           "axisPrecision": null,
           "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
+          "defaultPlotType": "AreaChart",
           "eventPublishLabelOptions": [],
           "histogramChartOptions": {
             "colorThemeIndex": 16
@@ -1201,11 +672,12 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "gauge.indices.total.docs.deleted - Mean by index",
+              "displayName": "gauge.indices.total.docs.count - Mean by index",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -1215,7 +687,7 @@
               "yAxis": 0
             },
             {
-              "displayName": "gauge.indices.total.docs.count - Mean by index",
+              "displayName": "A - Timeshift 1h",
               "label": "B",
               "paletteIndex": null,
               "plotType": null,
@@ -1225,7 +697,7 @@
               "yAxis": 0
             },
             {
-              "displayName": "% of Deleted Documents",
+              "displayName": "Growth %",
               "label": "C",
               "paletteIndex": null,
               "plotType": null,
@@ -1236,7 +708,7 @@
             }
           ],
           "showEventLines": false,
-          "stacked": false,
+          "stacked": true,
           "time": {
             "range": 7200000,
             "type": "relative"
@@ -1245,84 +717,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('gauge.indices.total.docs.deleted', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch') and (not filter('AWSUniqueId', 'i-0480a3a8_us-east-1_134183635603')), extrapolation='last_value', maxExtrapolations=100).mean(by=['index']).publish(label='A', enable=False)\nB = data('gauge.indices.total.docs.count', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch') and (not filter('AWSUniqueId', 'i-0480a3a8_us-east-1_134183635603')), extrapolation='last_value', maxExtrapolations=100).mean(by=['index']).publish(label='B', enable=False)\nC = (A*100/B).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "General Index Statistics: Size, Growth Rate & Document Count",
-        "id": "DiVWcfwAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Index Statistics",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 3,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Index Size",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "gauge.indices.total.store.size - Mean by index - Timeshift 1d",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Index Growth Rate",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Index Document Count",
-              "label": "D",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "+index",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('gauge.indices.total.store.size', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch'), extrapolation='last_value').mean(by=['index']).publish(label='A')\nB = data('gauge.indices.total.store.size', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch'), extrapolation='last_value').mean(by=['index']).timeshift('1d').publish(label='B', enable=False)\nC = ((A-B)*100/B).publish(label='C')\nD = data('gauge.indices.total.docs.count', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch'), extrapolation='last_value').mean(by=['index']).publish(label='D')",
+        "programText": "A = data('*.indices*.docs.count', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', '*', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True)), extrapolation='last_value', maxExtrapolations=100).mean(by=['index']).publish(label='A', enable=False)\nB = (A).timeshift('1h').publish(label='B', enable=False)\nC = ((A-B)*100/B).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1382,14 +777,15 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
               "displayName": "Filter Cache",
               "label": "A",
               "paletteIndex": null,
-              "plotType": "AreaChart",
+              "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
               "valueUnit": null,
@@ -1398,6 +794,36 @@
             {
               "displayName": "Field Cache",
               "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Query Cache",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Filter Cache",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Field Cache",
+              "label": "E",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
@@ -1416,7 +842,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('gauge.indices.total.filter-cache.memory-size', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).mean(by=['index']).publish(label='A')\nB = data('gauge.indices.total.fielddata.memory-size', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).mean(by=['index']).publish(label='B')",
+        "programText": "A = data('gauge.indices.total.filter-cache.memory-size', filter=filter('plugin', 'elasticsearch')).mean(by=['index']).publish(label='A')\nB = data('gauge.indices.total.fielddata.memory-size', filter=filter('plugin', 'elasticsearch')).mean(by=['index']).publish(label='B')\nC = data('elasticsearch.indices.query-cache.memory-size', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True))).mean(by=['index']).publish(label='C')\nD = data('elasticsearch.indices.filter-cache.memory-size', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True))).mean(by=['index']).publish(label='D')\nE = data('elasticsearch.indices.fielddata.memory-size', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True))).mean(by=['index']).publish(label='E')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1427,7 +853,7 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DiVWYskAYAA",
+        "id": "DiVWXq1AgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "name": "Merges/sec",
@@ -1444,6 +870,15 @@
               "lowWatermarkLabel": null,
               "max": null,
               "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
             }
           ],
           "axisPrecision": null,
@@ -1467,7 +902,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -1491,113 +927,762 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('counter.indices.total.merges.total', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch') and (not filter('AWSUniqueId', 'i-0480a3a8_us-east-1_134183635603')), rollup='max', extrapolation='last_value', maxExtrapolations=100).max(by=['index']).rateofchange().publish(label='A')",
+        "programText": "A = data('*.indices*.merges.total', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', '*', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True)), rollup='max').max(by=['index']).rateofchange().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "last day",
+        "id": "DiVWYVvAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top Indexes by Index Size Growth %",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "gauge.indices.total.store.size - Mean by index",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "gauge.indices.total.store.size - Mean by index - Timeshift 1d",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices*.store.size', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', '*', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True))).mean(by=['index']).publish(label='A', enable=False)\nB = data('*.indices*.store.size', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', '*', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True))).mean(by=['index']).timeshift('1d').publish(label='B', enable=False)\nC = ((A-B)*100/B).top(count=5).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWYI4AYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Indexing Requests/sec",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "requests / sec",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "counter.indices.total.indexing.index-total - Maximum by index - Rate of Change",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices*.indexing.index-total', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True)), rollup='max').max(by=['index']).rateofchange().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "last hour",
+        "id": "DiVWYkXAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Document Growth %",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "growth %",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "gauge.indices.total.docs.count - Mean by index",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "A - Timeshift 1h",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Growth %",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices*.docs.count', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', '*', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True))).mean(by=['index']).publish(label='A', enable=False)\nB = (A).timeshift('1h').publish(label='B', enable=False)\nC = ((A-B)*100/B).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWYYwAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top Indexes by Indexing Requests",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": 2,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices*.indexing.index-total', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', '  *', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True)), rollup='max').max(by=['index']).rateofchange().top(count=5).publish(label='A')\n",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWbs7AgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Deleted Documents %",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "deleted %",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "gauge.indices.total.docs.deleted - Mean by index",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "gauge.indices.total.docs.count - Mean by index",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "% of Deleted Documents",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices*.docs.deleted', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True)), extrapolation='last_value', maxExtrapolations=100).mean(by=['index']).publish(label='A', enable=False)\nB = data('*.indices*.docs.count', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True)), extrapolation='last_value', maxExtrapolations=100).mean(by=['index']).publish(label='B', enable=False)\nC = (A*100/B).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D3Ey6thAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Note",
+        "options": {
+          "markdown": "Charts of this dashboard are meant to be compatible with both metrics from the old collectd/elasticsearch and the new elasticsearch monitor. Metrics from the old monitor have the metric type as prefixes. Whereas, metrics from the new monitor have \"elasticsearch.\" as the prefix on all metrics.",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWcWKAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Elasticsearch Tips",
+        "options": {
+          "markdown": "<br>\n**Optimization Tip**\n\nIf your fielddata cache and heap usage are high, consider using [doc values](https://www.elastic.co/guide/en/elasticsearch/reference/current/doc-values.html)!",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "General Index Statistics: Size, Growth Rate & Document Count",
+        "id": "DiVWcfwAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Index Statistics",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Index Size",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "gauge.indices.total.store.size - Mean by index - Timeshift 1d",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Index Growth Rate",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Index Document Count",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "+index",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices*.store.size', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregaiton', ' * OR aggregation: total', match_missing=True)), extrapolation='last_value').mean(by=['index']).publish(label='A')\nB = data('*.indices*.store.size', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregaiton', ' * OR aggregation: total', match_missing=True)), extrapolation='last_value').mean(by=['index']).timeshift('1d').publish(label='B', enable=False)\nC = ((A-B)*100/B).publish(label='C')\nD = data('*.indices*.docs.count', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregaiton', ' * OR aggregation: total', match_missing=True)), extrapolation='last_value').mean(by=['index']).publish(label='D')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D3Ey_MQAYAk",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Note",
+        "options": {
+          "markdown": "Charts of this dashboard are meant to be compatible with both metrics from the old collectd/elasticsearch and the new elasticsearch monitor. Metrics from the old monitor have the metric type as prefixes. Whereas, metrics from the new monitor have \"elasticsearch.\" as the prefix on all metrics.",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWZDKAcK0",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Merge Latency (ms)",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Time (ms)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "counter.indices.total.merges.total - Maximum by index",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "counter.indices.total.merges.total-time - Maximum by index",
+              "label": "B",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "latency",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices*.merges.total', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True)), extrapolation='last_value', maxExtrapolations=100).max(by=['index']).publish(label='A', enable=False)\nB = data('*.indices*.merges.total-time', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', ' *', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True)), extrapolation='last_value', maxExtrapolations=100).max(by=['index']).publish(label='B', enable=False)\nC = (B/A).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWYOAAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Search Requests/sec",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "requests / sec",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "counter.indices.total.search.query-total - Maximum by index - Rate of Change",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices*.search.query-total', filter=filter('plugin', 'elasticsearch') and (not filter('node_id', '*', match_missing=True)) and (not filter('aggregation', ' * OR aggregation: total', match_missing=True)), rollup='max').max(by=['index']).rateofchange().publish(label='A')\n",
         "relatedDetectorIds": [],
         "tags": null
       }
     }
   ],
+  "crossLinkExports": [],
   "dashboardExports": [
-    {
-      "dashboard": {
-        "chartDensity": "DEFAULT",
-        "charts": [
-          {
-            "chartId": "DiVWYI4AYAA",
-            "column": 0,
-            "height": 1,
-            "row": 0,
-            "width": 6
-          },
-          {
-            "chartId": "DiVWXq1AgAA",
-            "column": 6,
-            "height": 1,
-            "row": 0,
-            "width": 6
-          },
-          {
-            "chartId": "DiVWYkXAYAA",
-            "column": 0,
-            "height": 1,
-            "row": 1,
-            "width": 6
-          },
-          {
-            "chartId": "DiVWYOAAgAA",
-            "column": 6,
-            "height": 1,
-            "row": 1,
-            "width": 6
-          },
-          {
-            "chartId": "DiVWYYwAYAA",
-            "column": 6,
-            "height": 1,
-            "row": 2,
-            "width": 6
-          },
-          {
-            "chartId": "DiVWYYHAcAA",
-            "column": 0,
-            "height": 1,
-            "row": 2,
-            "width": 6
-          },
-          {
-            "chartId": "DiVWX-dAcAA",
-            "column": 6,
-            "height": 1,
-            "row": 3,
-            "width": 6
-          },
-          {
-            "chartId": "DiVWYVvAYAA",
-            "column": 0,
-            "height": 1,
-            "row": 3,
-            "width": 6
-          }
-        ],
-        "created": 0,
-        "creator": null,
-        "customProperties": null,
-        "description": "Default dashboard.",
-        "discoveryOptions": {
-          "query": "plugin:elasticsearch",
-          "selectors": [
-            "sf_key:index"
-          ]
-        },
-        "eventOverlays": null,
-        "filters": {
-          "sources": null,
-          "time": null,
-          "variables": [
-            {
-              "alias": "cluster",
-              "applyIfExists": false,
-              "description": "Elasticsearch cluster",
-              "preferredSuggestions": [],
-              "property": "plugin_instance",
-              "replaceOnly": false,
-              "required": false,
-              "restricted": false,
-              "value": ""
-            }
-          ]
-        },
-        "groupId": "DiVWXcUAcAA",
-        "id": "DiVWXpYAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "locked": false,
-        "maxDelayOverride": null,
-        "name": "Elasticsearch Indexes",
-        "selectedEventOverlays": [],
-        "tags": null
-      }
-    },
     {
       "dashboard": {
         "chartDensity": "DEFAULT",
@@ -1678,6 +1763,13 @@
             "height": 1,
             "row": 3,
             "width": 4
+          },
+          {
+            "chartId": "D3Ey_MQAYAk",
+            "column": 0,
+            "height": 1,
+            "row": 4,
+            "width": 4
           }
         ],
         "created": 0,
@@ -1730,6 +1822,113 @@
         "selectedEventOverlays": [],
         "tags": null
       }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DiVWYI4AYAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 6
+          },
+          {
+            "chartId": "DiVWXq1AgAA",
+            "column": 6,
+            "height": 1,
+            "row": 0,
+            "width": 6
+          },
+          {
+            "chartId": "DiVWYkXAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 6
+          },
+          {
+            "chartId": "DiVWYOAAgAA",
+            "column": 6,
+            "height": 1,
+            "row": 1,
+            "width": 6
+          },
+          {
+            "chartId": "DiVWYYwAYAA",
+            "column": 6,
+            "height": 1,
+            "row": 2,
+            "width": 6
+          },
+          {
+            "chartId": "DiVWYYHAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 2,
+            "width": 6
+          },
+          {
+            "chartId": "DiVWX-dAcAA",
+            "column": 6,
+            "height": 1,
+            "row": 3,
+            "width": 6
+          },
+          {
+            "chartId": "DiVWYVvAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 3,
+            "width": 6
+          },
+          {
+            "chartId": "D3Ey6thAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 4,
+            "width": 6
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "Default dashboard.",
+        "discoveryOptions": {
+          "query": "plugin:elasticsearch",
+          "selectors": [
+            "sf_key:index"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": [
+            {
+              "alias": "cluster",
+              "applyIfExists": false,
+              "description": "Elasticsearch cluster",
+              "preferredSuggestions": [],
+              "property": "plugin_instance",
+              "replaceOnly": false,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            }
+          ]
+        },
+        "groupId": "DiVWXcUAcAA",
+        "id": "DiVWXpYAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "Elasticsearch Indexes",
+        "selectedEventOverlays": [],
+        "tags": null
+      }
     }
   ],
   "groupExport": {
@@ -1737,8 +1936,8 @@
       "created": 0,
       "creator": null,
       "dashboards": [
-        "DiVWXpYAYAA",
-        "DiVWYpeAgAA"
+        "DiVWYpeAgAA",
+        "DiVWXpYAYAA"
       ],
       "description": "Dashboards about Elasticsearch indexes.",
       "email": null,
@@ -1763,7 +1962,7 @@
       "teams": null
     }
   },
-  "hashCode": 1376178506,
+  "hashCode": -1971042894,
   "id": "DiVWXcUAcAA",
   "modelVersion": 1,
   "packageType": "GROUP"

--- a/group/Elasticsearch.json
+++ b/group/Elasticsearch.json
@@ -6,10 +6,10 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DiVWlpFAgAA",
+        "id": "DiVWmb-AcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Memory Heap Size (bytes)",
+        "name": "Deleted Documents %",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -18,237 +18,16 @@
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "size (bytes)",
+              "label": "deleted %",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
-              "max": null,
+              "max": 110,
               "min": 0
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "used",
-              "label": "A",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
             },
-            {
-              "displayName": "committed",
-              "label": "B",
-              "paletteIndex": 13,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "timezone": null,
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('gauge.jvm.mem.heap-used', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='A')\nB = data('gauge.jvm.mem.heap-committed', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='B')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWoAcAgBs",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Top Clusters by Indexing Requests",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 2,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": 10,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "",
-          "time": null,
-          "timezone": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('counter.indices.indexing.index-total', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).top(count=3).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "last hour",
-        "id": "DiVWouSAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Document Growth %",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "growth %",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "gauge.indices.docs.count - Sum by plugin_instance",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "gauge.indices.docs.count - Sum by plugin_instance - Timeshift 1h",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Growth rate",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "timezone": null,
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('gauge.indices.docs.count', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='A', enable=False)\nB = data('gauge.indices.docs.count', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).timeshift('1h').publish(label='B', enable=False)\nC = ((A-B)*100/B).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWm2UAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Thread Pool Rejections",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "rejections / sec",
+              "label": "",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
@@ -276,13 +55,14 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "Bulk rejections",
+              "displayName": "gauge.indices.total.docs.deleted - Mean by index",
               "label": "A",
-              "paletteIndex": 0,
+              "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -290,9 +70,9 @@
               "yAxis": 0
             },
             {
-              "displayName": "Flush rejections",
+              "displayName": "gauge.indices.total.docs.count - Mean by index",
               "label": "B",
-              "paletteIndex": 1,
+              "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -300,88 +80,8 @@
               "yAxis": 0
             },
             {
-              "displayName": "Generic rejections",
+              "displayName": "% of Deleted Documents",
               "label": "C",
-              "paletteIndex": 2,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Get rejections",
-              "label": "D",
-              "paletteIndex": 3,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Index rejections",
-              "label": "E",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Merge rejections",
-              "label": "F",
-              "paletteIndex": 5,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Optimize rejections",
-              "label": "G",
-              "paletteIndex": 6,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Refresh rejections",
-              "label": "H",
-              "paletteIndex": 7,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Search rejections",
-              "label": "I",
-              "paletteIndex": 13,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Snapshot rejections",
-              "label": "J",
-              "paletteIndex": 10,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "rejections by thread pool",
-              "label": "K",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
@@ -396,12 +96,11 @@
             "range": 7200000,
             "type": "relative"
           },
-          "timezone": null,
           "type": "TimeSeriesChart",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('counter.thread_pool.bulk.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='A')\nB = data('counter.thread_pool.flush.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='B', enable=False)\nC = data('counter.thread_pool.generic.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='C')\nD = data('counter.thread_pool.get.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='D')\nE = data('counter.thread_pool.index.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='E')\nF = data('counter.thread_pool.merge.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='F')\nG = data('counter.thread_pool.optimize.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='G')\nH = data('counter.thread_pool.refresh.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='H')\nI = data('counter.thread_pool.search.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='I')\nJ = data('counter.thread_pool.snapshot.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='J')\nK = data('counter.thread_pool.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance', 'thread_pool']).publish(label='K')",
+        "programText": "A = data('*.indices.total.docs.deleted', filter=filter('plugin', 'elasticsearch') and (not filter('aaggregation', ' * OR aggregation: total', match_missing=True))).mean(by=['index']).publish(label='A', enable=False)\nB = data('*.indices.total.docs.count', filter=filter('plugin', 'elasticsearch') and (not filter('aaggregation', ' * OR aggregation: total', match_missing=True))).mean(by=['index']).publish(label='B', enable=False)\nC = (A*100/B).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -411,79 +110,11 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "last day",
-        "id": "DiVWpC3AgAA",
+        "description": "percentile distribution",
+        "id": "DiVWoQ8AgIw",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Top Clusters by Index Growth %",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 3,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "gauge.indices.store.size - Sum by plugin_instance",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "gauge.indices.store.size - Sum by plugin_instance - Timeshift 1d",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "",
-          "time": null,
-          "timezone": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('gauge.indices.store.size', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='A', enable=False)\nB = data('gauge.indices.store.size', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).timeshift('1d').publish(label='B', enable=False)\nC = ((A-B)*100/B).top(count=3).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWmIZAcEg",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Cluster Shard Allocation",
+        "name": "Heap %",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -492,7 +123,16 @@
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "# shards",
+              "label": "% used",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 110,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Used %",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
@@ -520,13 +160,14 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "Unassigned",
+              "displayName": "Used (bytes)",
               "label": "A",
-              "paletteIndex": 4,
+              "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -534,9 +175,9 @@
               "yAxis": 0
             },
             {
-              "displayName": "Relocating",
+              "displayName": "Used (bytes)",
               "label": "B",
-              "paletteIndex": 1,
+              "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -544,9 +185,9 @@
               "yAxis": 0
             },
             {
-              "displayName": "Primary",
+              "displayName": "A*100/G",
               "label": "C",
-              "paletteIndex": 13,
+              "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -554,7 +195,162 @@
               "yAxis": 0
             },
             {
-              "displayName": "Active",
+              "displayName": "min",
+              "label": "D",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "p10",
+              "label": "E",
+              "paletteIndex": 15,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "p50",
+              "label": "F",
+              "paletteIndex": 2,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "p90",
+              "label": "G",
+              "paletteIndex": 5,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "max",
+              "label": "H",
+              "paletteIndex": 7,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.jvm.mem.heap-used', filter=filter('plugin', 'elasticsearch')).mean(by=['host', 'plugin_instance']).publish(label='A', enable=False)\nB = data('*.jvm.mem.heap-committed', filter=filter('plugin', 'elasticsearch')).mean(by=['host', 'plugin_instance']).publish(label='B', enable=False)\nC = (A*100/B).publish(label='C', enable=False)\nD = (C).min().publish(label='D')\nE = (C).percentile(pct=10).publish(label='E')\nF = (C).percentile(pct=50).publish(label='F')\nG = (C).percentile(pct=90).publish(label='G')\nH = (C).max().publish(label='H')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWliXAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Cache Sizes (bytes)",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "size (bytes)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Metric",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "filter cache size",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "field cache size",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "filter cache size",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "field cache size",
               "label": "D",
               "paletteIndex": null,
               "plotType": null,
@@ -564,9 +360,9 @@
               "yAxis": 0
             },
             {
-              "displayName": "Replica",
+              "displayName": "query cache size",
               "label": "E",
-              "paletteIndex": 14,
+              "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -580,12 +376,96 @@
             "range": 7200000,
             "type": "relative"
           },
-          "timezone": null,
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('gauge.indices.cache.filter.size', filter=filter('plugin', 'elasticsearch')).publish(label='A')\nB = data('gauge.indices.cache.field.size', filter=filter('plugin', 'elasticsearch')).publish(label='B')\nC = data('elasticsearch.indices.filter-cache.memory-size', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).publish(label='C')\nD = data('elasticsearch.indices.fielddata.memory-size', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).publish(label='D')\nE = data('elasticsearch.indices.query-cache.memory-size', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).publish(label='E')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWnPQAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Search Requests",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "requests / sec",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "counter.indices.search.query-total - Sum by plugin_instance",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
           "type": "TimeSeriesChart",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('gauge.cluster.unassigned-shards', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).mean().publish(label='A')\nB = data('gauge.cluster.relocating-shards', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).mean().publish(label='B')\nC = data('gauge.cluster.active-primary-shards', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).mean().publish(label='C')\nD = data('gauge.cluster.active-shards', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).mean().publish(label='D', enable=False)\nE = (D-C).publish(label='E')",
+        "programText": "A = data('*.indices.search.query-total', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).mean(by=['host', 'plugin_instance']).sum(by=['plugin_instance']).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -613,6 +493,15 @@
               "lowWatermarkLabel": null,
               "max": null,
               "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
             }
           ],
           "axisPrecision": null,
@@ -636,7 +525,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -748,6 +638,16 @@
               "valueSuffix": null,
               "valueUnit": null,
               "yAxis": 0
+            },
+            {
+              "displayName": "L",
+              "label": "L",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
             }
           ],
           "showEventLines": false,
@@ -756,12 +656,11 @@
             "range": 7200000,
             "type": "relative"
           },
-          "timezone": null,
           "type": "TimeSeriesChart",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('counter.thread_pool.bulk.rejected', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='A')\nB = data('counter.thread_pool.flush.rejected', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='B')\nC = data('counter.thread_pool.generic.rejected', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='C')\nD = data('counter.thread_pool.get.rejected', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='D')\nE = data('counter.thread_pool.index.rejected', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='E')\nF = data('counter.thread_pool.merge.rejected', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='F')\nG = data('counter.thread_pool.optimize.rejected', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='G')\nH = data('counter.thread_pool.refresh.rejected', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='H')\nI = data('counter.thread_pool.search.rejected', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='I')\nJ = data('counter.thread_pool.snapshot.rejected', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='J')\nK = data('counter.thread_pool.rejected').sum(by=['plugin_instance', 'thread_pool']).publish(label='K')",
+        "programText": "A = data('counter.thread_pool.bulk.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='A')\nB = data('counter.thread_pool.flush.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='B')\nC = data('counter.thread_pool.generic.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='C')\nD = data('counter.thread_pool.get.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='D')\nE = data('counter.thread_pool.index.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='E')\nF = data('counter.thread_pool.merge.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='F')\nG = data('counter.thread_pool.optimize.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='G')\nH = data('counter.thread_pool.refresh.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='H')\nI = data('counter.thread_pool.search.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='I')\nJ = data('counter.thread_pool.snapshot.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='J')\nK = data('counter.thread_pool.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance', 'thread_pool']).publish(label='K')\nL = data('elasticsearch.thread_pool.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance', 'thread_pool']).publish(label='L')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -772,10 +671,121 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DiVWlf2AgAA",
+        "id": "DiVWkt9AYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "File Descriptors and Segments",
+        "name": "Document Growth Rate %",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": 4,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Total",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Total",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Total",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Total",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "last hour",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "last day",
+              "label": "F",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "last week",
+              "label": "G",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices.docs.count', filter=filter('plugin', 'elasticsearch') and (not filter('aggregagtion', ' *', match_missing=True))).mean(by=['host']).mean().publish(label='A', enable=False)\nB = data('*.indices.docs.count', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).timeshift('1h').mean(by=['host']).mean().publish(label='B', enable=False)\nC = data('*.indices.docs.count', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).timeshift('1d').mean(by=['host']).publish(label='C', enable=False)\nD = data('*.indices.docs.count', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).timeshift('1w').mean(by=['host']).mean().publish(label='D', enable=False)\nE = ((A-B)*100/B).publish(label='E')\nF = ((A-C)*100/C).publish(label='F')\nG = ((A-D)*100/D).publish(label='G')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWmIZAcEg",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Cluster Shard Allocation",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -784,25 +794,25 @@
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "# FD - RED",
+              "label": "# shards",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
-              "min": 0
+              "min": null
             },
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "# segment - BLUE",
+              "label": "",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
-              "min": 0
+              "min": null
             }
           ],
           "axisPrecision": null,
           "colorBy": "Metric",
-          "defaultPlotType": "ColumnChart",
+          "defaultPlotType": "AreaChart",
           "eventPublishLabelOptions": [],
           "histogramChartOptions": {
             "colorThemeIndex": 16
@@ -821,11 +831,12 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "# file descriptors",
+              "displayName": "Unassigned",
               "label": "A",
               "paletteIndex": 4,
               "plotType": null,
@@ -835,28 +846,57 @@
               "yAxis": 0
             },
             {
-              "displayName": "# segments",
+              "displayName": "Relocating",
               "label": "B",
               "paletteIndex": 1,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
               "valueUnit": null,
-              "yAxis": 1
+              "yAxis": 0
+            },
+            {
+              "displayName": "Primary",
+              "label": "C",
+              "paletteIndex": 13,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Active",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Replica",
+              "label": "E",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
             }
           ],
           "showEventLines": false,
-          "stacked": false,
+          "stacked": true,
           "time": {
             "range": 7200000,
             "type": "relative"
           },
-          "timezone": null,
           "type": "TimeSeriesChart",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('gauge.process.open_file_descriptors', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='A')\nB = data('gauge.indices.segments.count', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='B')",
+        "programText": "A = data('*.cluster.unassigned-shards', filter=filter('plugin', 'elasticsearch')).mean(by=['host', 'plugin_instance']).mean().publish(label='A')\nB = data('*.cluster.relocating-shards', filter=filter('plugin', 'elasticsearch')).mean(by=['host', 'plugin_instance']).mean().publish(label='B')\nC = data('*.cluster.active-primary-shards', filter=filter('plugin', 'elasticsearch')).mean(by=['host', 'plugin_instance']).mean().publish(label='C')\nD = data('*.cluster.active-shards', filter=filter('plugin', 'elasticsearch')).mean(by=['host', 'plugin_instance']).mean().publish(label='D', enable=False)\nE = (D-C).publish(label='E')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -866,11 +906,11 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "",
-        "id": "DiVWliXAYAA",
+        "description": "last hour",
+        "id": "DiVWlfvAcAI",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Cache Sizes (bytes)",
+        "name": "GC Time %",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -879,11 +919,20 @@
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "size (bytes)",
+              "label": "gc time %",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
               "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
             }
           ],
           "axisPrecision": null,
@@ -907,11 +956,12 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "filter cache size",
+              "displayName": "GC time",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -921,7 +971,7 @@
               "yAxis": 0
             },
             {
-              "displayName": "field cache size",
+              "displayName": "counter.jvm.uptime",
               "label": "B",
               "paletteIndex": null,
               "plotType": null,
@@ -929,153 +979,31 @@
               "valueSuffix": null,
               "valueUnit": null,
               "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "timezone": null,
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('gauge.indices.cache.filter.size', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='A')\nB = data('gauge.indices.cache.field.size', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='B')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWoIpAcAE",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Indexing Requests",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
+            },
             {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "requests / sec",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "counter.indices.indexing.index-total - Sum by plugin_instance",
-              "label": "A",
+              "displayName": "A - Timeshift 1h",
+              "label": "C",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
               "valueUnit": null,
               "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "timezone": null,
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('counter.indices.indexing.index-total', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWlfjAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Search Requests/sec",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
+            },
             {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "requests/sec",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "requests/sec",
-              "label": "A",
+              "displayName": "B - Timeshift 1h",
+              "label": "D",
               "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "(A-E)*100/(B-F)",
+              "label": "E",
+              "paletteIndex": 1,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -1089,12 +1017,204 @@
             "range": 7200000,
             "type": "relative"
           },
-          "timezone": null,
           "type": "TimeSeriesChart",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('counter.indices.search.query-total', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='A')",
+        "programText": "A = data('*.jvm.gc.time', filter=filter('plugin', 'elasticsearch'), rollup='max').mean(by=['host']).publish(label='A', enable=False)\nB = data('*.jvm.uptime', filter=filter('plugin', 'elasticsearch'), rollup='max').mean(by=['host']).publish(label='B', enable=False)\nC = (A).timeshift('1h').publish(label='C', enable=False)\nD = (B).timeshift('1h').publish(label='D', enable=False)\nE = ((A-C)*100/(B-D)).publish(label='E')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWmkiAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# Nodes",
+        "options": {
+          "colorBy": "Metric",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "total",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "data nodes",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.cluster.number-of-nodes', filter=filter('plugin', 'elasticsearch')).max().publish(label='A')\nB = data('*.cluster.number-of-data_nodes', filter=filter('plugin', 'elasticsearch')).max().publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWm1fAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# Hosts/Clusters",
+        "options": {
+          "colorBy": "Metric",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "# hosts",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "# clusters",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices.indexing.index-total', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *'))).sum(by=['host']).count().publish(label='A')\nB = data('*.indices.indexing.index-total', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).sum(by=['plugin_instance']).count().publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWoAcAgBs",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top Clusters by Indexing Requests",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": 2,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": 10,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices.indexing.index-total', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).mean(by=['host', 'plugin_instance']).sum(by=['plugin_instance']).top(count=3).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D3Ex1ghAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Note",
+        "options": {
+          "markdown": "Charts of this dashboard are meant to be compatible with both metrics from the old collectd/elasticsearch and the new elasticsearch monitor. Metrics from the old monitor have the metric type as prefixes. Whereas, metrics from the new monitor have \"elasticsearch.\" as the prefix on all metrics.",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1106,139 +1226,6 @@
         "customProperties": {},
         "description": "",
         "id": "DiVWozyAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Cache Size (bytes)",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "size (bytes)",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Metric",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Filter Cache",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Field Cache",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "timezone": null,
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('gauge.indices.cache.filter.size', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='A')\nB = data('gauge.indices.cache.field.size', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='B')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWklGAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Active Merges",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "gauge.indices.merges.current",
-              "label": "A",
-              "paletteIndex": 5,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": null,
-          "timestampHidden": false,
-          "timezone": null,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('gauge.indices.merges.current', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWl3mAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "name": "Cache Size (bytes)",
@@ -1287,7 +1274,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -1308,7 +1296,37 @@
               "valuePrefix": null,
               "valueSuffix": null,
               "valueUnit": null,
-              "yAxis": 1
+              "yAxis": 0
+            },
+            {
+              "displayName": "Filter Cache",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Field Cache",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Query Cache",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
             }
           ],
           "showEventLines": false,
@@ -1317,12 +1335,11 @@
             "range": 7200000,
             "type": "relative"
           },
-          "timezone": null,
           "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
+          "unitPrefix": "Binary"
         },
         "packageSpecifications": "",
-        "programText": "A = data('gauge.indices.total.filter-cache.memory-size', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).mean(by=['index']).publish(label='A')\nB = data('gauge.indices.total.fielddata.memory-size', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).mean(by=['index']).publish(label='B')",
+        "programText": "A = data('gauge.indices.cache.filter.size', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='A')\nB = data('gauge.indices.cache.field.size', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='B')\nC = data('elasticsearch.indices.filter-cache.memory-size', filter=filter('plugin', ' elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).sum(by=['plugin_instance']).publish(label='C')\nD = data('elasticsearch.indices.fielddata.memory-size', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).sum(by=['plugin_instance']).publish(label='D')\nE = data('elasticsearch.indices.query-cache.memory-size', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).sum(by=['plugin_instance']).publish(label='E')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1332,11 +1349,11 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "percentile distribution over the last hour",
-        "id": "DiVWsQaAcAA",
+        "description": "last hour",
+        "id": "DiVWouSAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "GC Time %",
+        "name": "Document Growth %",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -1345,16 +1362,16 @@
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "% gc time",
+              "label": "growth %",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
-              "min": 0
+              "min": null
             },
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "Used %",
+              "label": "",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
@@ -1362,7 +1379,7 @@
             }
           ],
           "axisPrecision": null,
-          "colorBy": "Metric",
+          "colorBy": "Dimension",
           "defaultPlotType": "AreaChart",
           "eventPublishLabelOptions": [],
           "histogramChartOptions": {
@@ -1382,11 +1399,12 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "Used (bytes)",
+              "displayName": "gauge.indices.docs.count - Sum by plugin_instance",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -1396,7 +1414,7 @@
               "yAxis": 0
             },
             {
-              "displayName": "Used (bytes)",
+              "displayName": "gauge.indices.docs.count - Sum by plugin_instance - Timeshift 1h",
               "label": "B",
               "paletteIndex": null,
               "plotType": null,
@@ -1406,79 +1424,9 @@
               "yAxis": 0
             },
             {
-              "displayName": "Used (bytes)",
+              "displayName": "Growth rate",
               "label": "C",
               "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Used (bytes)",
-              "label": "D",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "min",
-              "label": "E",
-              "paletteIndex": 14,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "min",
-              "label": "F",
-              "paletteIndex": 14,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "p10",
-              "label": "G",
-              "paletteIndex": 15,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "p50",
-              "label": "H",
-              "paletteIndex": 2,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "p90",
-              "label": "I",
-              "paletteIndex": 5,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "max",
-              "label": "J",
-              "paletteIndex": 7,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -1487,172 +1435,16 @@
             }
           ],
           "showEventLines": false,
-          "stacked": false,
+          "stacked": true,
           "time": {
             "range": 7200000,
             "type": "relative"
           },
-          "timezone": null,
           "type": "TimeSeriesChart",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('counter.jvm.gc.time', filter=filter('plugin', 'elasticsearch'), rollup='max').publish(label='A', enable=False)\nB = data('counter.jvm.uptime', filter=filter('plugin', 'elasticsearch'), rollup='max').publish(label='B', enable=False)\nC = data('counter.jvm.gc.time', filter=filter('plugin', 'elasticsearch'), rollup='max').timeshift('1h').publish(label='C', enable=False)\nD = data('counter.jvm.uptime', filter=filter('plugin', 'elasticsearch'), rollup='max').timeshift('1h').publish(label='D', enable=False)\nE = ((A-C)*100/(B-D)).publish(label='E', enable=False)\nF = (E).min().publish(label='F')\nG = (E).percentile(pct=10).publish(label='G')\nH = (E).percentile(pct=50).publish(label='H')\nI = (E).percentile(pct=90).publish(label='I')\nJ = (E).max().publish(label='J')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "percentile distribution",
-        "id": "DiVWl2hAYHQ",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Heap %",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "% used",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": 110,
-              "min": 0
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "Used %",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Metric",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Used (bytes)",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Used (bytes)",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "A*100/G",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "min",
-              "label": "D",
-              "paletteIndex": 14,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "p10",
-              "label": "E",
-              "paletteIndex": 15,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "p50",
-              "label": "F",
-              "paletteIndex": 2,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "p90",
-              "label": "G",
-              "paletteIndex": 5,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "max",
-              "label": "H",
-              "paletteIndex": 7,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "timezone": null,
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('gauge.jvm.mem.heap-used', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).publish(label='A', enable=False)\nB = data('gauge.jvm.mem.heap-committed', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).publish(label='B', enable=False)\nC = (A*100/B).publish(label='C', enable=False)\nD = (C).min().publish(label='D')\nE = (C).percentile(pct=10).publish(label='E')\nF = (C).percentile(pct=50).publish(label='F')\nG = (C).percentile(pct=90).publish(label='G')\nH = (C).max().publish(label='H')",
+        "programText": "A = data('*.indices.docs.count', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).mean(by=['host', 'plugin_instance']).sum(by=['plugin_instance']).publish(label='A', enable=False)\nB = data('*.indices.docs.count', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).mean(by=['host', 'plugin_instance']).sum(by=['plugin_instance']).timeshift('1h').publish(label='B', enable=False)\nC = ((A-B)*100/B).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1680,6 +1472,15 @@
               "lowWatermarkLabel": null,
               "max": null,
               "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
             }
           ],
           "axisPrecision": null,
@@ -1703,7 +1504,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -1815,6 +1617,16 @@
               "valueSuffix": null,
               "valueUnit": null,
               "yAxis": 0
+            },
+            {
+              "displayName": "rejections by thread pool",
+              "label": "L",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
             }
           ],
           "showEventLines": false,
@@ -1823,12 +1635,153 @@
             "range": 7200000,
             "type": "relative"
           },
-          "timezone": null,
           "type": "TimeSeriesChart",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('counter.thread_pool.bulk.rejected', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='A')\nB = data('counter.thread_pool.flush.rejected', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='B')\nC = data('counter.thread_pool.generic.rejected', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='C')\nD = data('counter.thread_pool.get.rejected', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='D')\nE = data('counter.thread_pool.index.rejected', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='E')\nF = data('counter.thread_pool.merge.rejected', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='F')\nG = data('counter.thread_pool.optimize.rejected', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='G')\nH = data('counter.thread_pool.refresh.rejected', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='H')\nI = data('counter.thread_pool.search.rejected', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='I')\nJ = data('counter.thread_pool.snapshot.rejected', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='J')\nK = data('counter.thread_pool.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['thread_pool']).publish(label='K')",
+        "programText": "A = data('counter.thread_pool.bulk.rejected', filter=filter('plugin', 'elasticsearch')).publish(label='A')\nB = data('counter.thread_pool.flush.rejected', filter=filter('plugin', 'elasticsearch')).publish(label='B')\nC = data('counter.thread_pool.generic.rejected', filter=filter('plugin', 'elasticsearch')).publish(label='C')\nD = data('counter.thread_pool.get.rejected', filter=filter('plugin', 'elasticsearch')).publish(label='D')\nE = data('counter.thread_pool.index.rejected', filter=filter('plugin', 'elasticsearch')).publish(label='E')\nF = data('counter.thread_pool.merge.rejected', filter=filter('plugin', 'elasticsearch')).publish(label='F')\nG = data('counter.thread_pool.optimize.rejected', filter=filter('plugin', 'elasticsearch')).publish(label='G')\nH = data('counter.thread_pool.refresh.rejected', filter=filter('plugin', 'elasticsearch')).publish(label='H')\nI = data('counter.thread_pool.search.rejected', filter=filter('plugin', 'elasticsearch')).publish(label='I')\nJ = data('counter.thread_pool.snapshot.rejected', filter=filter('plugin', 'elasticsearch')).publish(label='J')\nK = data('counter.thread_pool.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['thread_pool']).publish(label='K')\nL = data('elasticsearch.thread_pool.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['thread_pool']).publish(label='L')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "last day",
+        "id": "DiVWpC3AgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top Clusters by Index Growth %",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "gauge.indices.store.size - Sum by plugin_instance",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "gauge.indices.store.size - Sum by plugin_instance - Timeshift 1d",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices.store.size', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).mean(by=['host', 'plugin_instance']).sum(by=['plugin_instance']).publish(label='A', enable=False)\nB = data('*.indices.store.size', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).mean(by=['host', 'plugin_instance']).sum(by=['plugin_instance']).timeshift('1d').publish(label='B', enable=False)\nC = ((A-B)*100/B).top(count=3).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWliRAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Requests/sec",
+        "options": {
+          "colorBy": "Metric",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Search",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Index",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Get",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('counter.indices.search.query-total', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).mean().publish(label='A')\nB = data('counter.indices.indexing.index-total', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).mean().publish(label='B')\nC = data('counter.indices.get.total', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).mean().publish(label='C')\n",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1853,7 +1806,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -1970,378 +1924,15 @@
           "refreshInterval": null,
           "secondaryVisualization": "Sparkline",
           "sortBy": "+sf_metric",
-          "time": null,
-          "timezone": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
           "type": "List",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('counter.indices.search.query-total', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2'), rollup='max').publish(label='A', enable=False)\nB = data('counter.indices.search.query-time', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2'), rollup='max').publish(label='B', enable=False)\nC = (A).timeshift('1m').publish(label='C', enable=False)\nD = (B).timeshift('1m').publish(label='D', enable=False)\nE = ((B-D)/(A-C)).mean().publish(label='E')\nF = (A).timeshift('5m').publish(label='F', enable=False)\nG = (B).timeshift('5m').publish(label='G', enable=False)\nH = ((B-G)/(A-F)).mean().publish(label='H')\nI = (A).timeshift('1h').publish(label='I', enable=False)\nJ = (B).timeshift('1h').publish(label='J', enable=False)\nK = ((B-J)/(A-I)).mean().publish(label='K')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWmkiAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "# Nodes",
-        "options": {
-          "colorBy": "Metric",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "total",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "data nodes",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "timezone": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('gauge.cluster.number-of-nodes', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).max().publish(label='A')\nB = data('gauge.cluster.number-of-data_nodes', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).max().publish(label='B')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWnPQAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Search Requests",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "requests / sec",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "counter.indices.search.query-total - Sum by plugin_instance",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "timezone": null,
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('counter.indices.search.query-total', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "percentile distribution",
-        "id": "DiVWoQ8AgIw",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Heap %",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "% used",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": 110,
-              "min": 0
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "Used %",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Metric",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Used (bytes)",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Used (bytes)",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "A*100/G",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "min",
-              "label": "D",
-              "paletteIndex": 14,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "p10",
-              "label": "E",
-              "paletteIndex": 15,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "p50",
-              "label": "F",
-              "paletteIndex": 2,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "p90",
-              "label": "G",
-              "paletteIndex": 5,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "max",
-              "label": "H",
-              "paletteIndex": 7,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "timezone": null,
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('gauge.jvm.mem.heap-used', filter=filter('plugin', 'elasticsearch')).publish(label='A', enable=False)\nB = data('gauge.jvm.mem.heap-committed', filter=filter('plugin', 'elasticsearch')).publish(label='B', enable=False)\nC = (A*100/B).publish(label='C', enable=False)\nD = (C).min().publish(label='D')\nE = (C).percentile(pct=10).publish(label='E')\nF = (C).percentile(pct=50).publish(label='F')\nG = (C).percentile(pct=90).publish(label='G')\nH = (C).max().publish(label='H')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWlSeAgGg",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Indexing Requests/sec",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "requests/sec",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "requests/sec",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "timezone": null,
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('counter.indices.indexing.index-total', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='A')",
+        "programText": "A = data('*.indices.search.query-total', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True)), rollup='max').mean(by=['host']).publish(label='A', enable=False)\nB = data('*.indices.search.query-time', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True)), rollup='max').mean(by=['host']).publish(label='B', enable=False)\nC = (A).timeshift('1m').publish(label='C', enable=False)\nD = (B).timeshift('1m').publish(label='D', enable=False)\nE = ((B-D)/(A-C)).mean().publish(label='E')\nF = (A).timeshift('5m').publish(label='F', enable=False)\nG = (B).timeshift('5m').publish(label='G', enable=False)\nH = ((B-G)/(A-F)).mean().publish(label='H')\nI = (A).timeshift('1h').publish(label='I', enable=False)\nJ = (B).timeshift('1h').publish(label='J', enable=False)\nK = ((B-J)/(A-I)).mean().publish(label='K')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -2369,6 +1960,15 @@
               "lowWatermarkLabel": null,
               "max": null,
               "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
             }
           ],
           "axisPrecision": null,
@@ -2392,7 +1992,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -2412,12 +2013,11 @@
             "range": 7200000,
             "type": "relative"
           },
-          "timezone": null,
           "type": "TimeSeriesChart",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('counter.indices.merges.total', filter=filter('plugin_instance', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).publish(label='A')",
+        "programText": "A = data('*.indices.merges.total', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).mean(by=['host']).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -2428,10 +2028,10 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DiVWmb-AcAA",
+        "id": "DiVWm2UAYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Deleted Documents %",
+        "name": "Thread Pool Rejections",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -2440,11 +2040,20 @@
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "deleted %",
+              "label": "rejections / sec",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
-              "max": 110,
-              "min": 0
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
             }
           ],
           "axisPrecision": null,
@@ -2468,11 +2077,387 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "gauge.indices.total.docs.deleted - Mean by index",
+              "displayName": "Bulk rejections",
+              "label": "A",
+              "paletteIndex": 0,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Flush rejections",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Generic rejections",
+              "label": "C",
+              "paletteIndex": 2,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Get rejections",
+              "label": "D",
+              "paletteIndex": 3,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Index rejections",
+              "label": "E",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Merge rejections",
+              "label": "F",
+              "paletteIndex": 5,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Optimize rejections",
+              "label": "G",
+              "paletteIndex": 6,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Refresh rejections",
+              "label": "H",
+              "paletteIndex": 7,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Search rejections",
+              "label": "I",
+              "paletteIndex": 13,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Snapshot rejections",
+              "label": "J",
+              "paletteIndex": 10,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "rejections by thread pool",
+              "label": "K",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "rejections by thread pool",
+              "label": "L",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('counter.thread_pool.bulk.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='A')\nB = data('counter.thread_pool.flush.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='B', enable=False)\nC = data('counter.thread_pool.generic.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='C')\nD = data('counter.thread_pool.get.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='D')\nE = data('counter.thread_pool.index.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='E')\nF = data('counter.thread_pool.merge.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='F')\nG = data('counter.thread_pool.optimize.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='G')\nH = data('counter.thread_pool.refresh.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='H')\nI = data('counter.thread_pool.search.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='I')\nJ = data('counter.thread_pool.snapshot.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='J')\nK = data('counter.thread_pool.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance', 'thread_pool']).publish(label='K')\nL = data('elasticsearch.thread_pool.rejected', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance', 'thread_pool']).publish(label='L')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWlpFAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Memory Heap Size (bytes)",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "size (bytes)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "used",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "committed",
+              "label": "B",
+              "paletteIndex": 13,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.jvm.mem.heap-used', filter=filter('plugin', 'elasticsearch')).mean(by=['host']).publish(label='A')\nB = data('*.jvm.mem.heap-committed', filter=filter('plugin', 'elasticsearch')).mean(by=['host']).publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWoIpAcAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Indexing Requests",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "requests / sec",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "counter.indices.indexing.index-total - Sum by plugin_instance",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices.indexing.index-total', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', '*', match_missing=True))).mean(by=['host', 'plugin_instance']).sum(by=['plugin_instance']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWsiUAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Deleted Documents %",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "deleted %",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "gauge.indices.docs.deleted - Sum by plugin_instance",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -2482,7 +2467,7 @@
               "yAxis": 0
             },
             {
-              "displayName": "gauge.indices.total.docs.count - Mean by index",
+              "displayName": "gauge.indices.docs.count - Sum by plugin_instance",
               "label": "B",
               "paletteIndex": null,
               "plotType": null,
@@ -2508,342 +2493,11 @@
             "range": 7200000,
             "type": "relative"
           },
-          "timezone": null,
           "type": "TimeSeriesChart",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('gauge.indices.total.docs.deleted', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).mean(by=['index']).publish(label='A', enable=False)\nB = data('gauge.indices.total.docs.count', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch')).mean(by=['index']).publish(label='B', enable=False)\nC = (A*100/B).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "p99 latency over the last hour",
-        "id": "DiVWn4UAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Top Clusters by Query Latency (ms)",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 3,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "counter.indices.search.query-total",
-              "label": "A",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "counter.indices.search.query-time",
-              "label": "B",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "counter.indices.search.query-total - Timeshift 1h",
-              "label": "C",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "counter.indices.search.query-time - Timeshift 1h",
-              "label": "D",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "(B-D)/(A-C)",
-              "label": "E",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "",
-              "label": "F",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "timezone": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('counter.indices.search.query-total', filter=filter('plugin', 'elasticsearch'), rollup='max').publish(label='A', enable=False)\nB = data('counter.indices.search.query-time', filter=filter('plugin', 'elasticsearch'), rollup='max').publish(label='B', enable=False)\nC = data('counter.indices.search.query-total', filter=filter('plugin', 'elasticsearch'), rollup='max').timeshift('1h').publish(label='C', enable=False)\nD = data('counter.indices.search.query-time', filter=filter('plugin', 'elasticsearch'), rollup='max').timeshift('1h').publish(label='D', enable=False)\nE = ((B-D)/(A-C)).publish(label='E', enable=False)\nF = (E).percentile(pct=99, by=['plugin_instance']).top(count=5).publish(label='F')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWn5rAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Top Clusters by Search Requests",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 3,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": 13,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "",
-          "time": null,
-          "timezone": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('counter.indices.search.query-total', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).top(count=3).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWkt9AYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Document Growth Rate %",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 4,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Total",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Total",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Total",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Total",
-              "label": "D",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "last hour",
-              "label": "E",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "last day",
-              "label": "F",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "last week",
-              "label": "G",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "timezone": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('gauge.indices.docs.count', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).mean().publish(label='A', enable=False)\nB = data('gauge.indices.docs.count', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).timeshift('1h').mean().publish(label='B', enable=False)\nC = data('gauge.indices.docs.count', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).timeshift('1d').mean().publish(label='C', enable=False)\nD = data('gauge.indices.docs.count', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).timeshift('1w').mean().publish(label='D', enable=False)\nE = ((A-B)*100/B).publish(label='E')\nF = ((A-C)*100/C).publish(label='F')\nG = ((A-D)*100/D).publish(label='G')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DiVWoQrAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Merges/sec",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "merges / sec",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "counter.indices.merges.total - Sum by plugin_instance",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": "AreaChart",
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "timezone": null,
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('counter.indices.merges.total', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).publish(label='A')",
+        "programText": "A = data('*.indices.docs.deleted', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).mean(by=['host', 'plugin_instance']).sum(by=['plugin_instance']).publish(label='A', enable=False)\nB = data('*.indices.docs.count', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).mean(by=['host', 'plugin_instance']).sum(by=['plugin_instance']).publish(label='B', enable=False)\nC = (A*100/B).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -2903,7 +2557,8 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
@@ -3013,12 +2668,11 @@
             "range": 7200000,
             "type": "relative"
           },
-          "timezone": null,
           "type": "TimeSeriesChart",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('counter.jvm.gc.time', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch'), rollup='max').publish(label='A', enable=False)\nB = data('counter.jvm.uptime', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch'), rollup='max').publish(label='B', enable=False)\nC = data('counter.jvm.gc.time', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch'), rollup='max').timeshift('1h').publish(label='C', enable=False)\nD = data('counter.jvm.uptime', filter=filter('plugin', 'elasticsearch') and filter('plugin_instance', 'elasticsearch'), rollup='max').timeshift('1h').publish(label='D', enable=False)\nE = ((A-C)*100/(B-D)).publish(label='E', enable=False)\nF = (E).min().publish(label='F')\nG = (E).percentile(pct=10).publish(label='G')\nH = (E).percentile(pct=50).publish(label='H')\nI = (E).percentile(pct=90).publish(label='I')\nJ = (E).max().publish(label='J')",
+        "programText": "A = data('*.jvm.gc.time', filter=filter('plugin', 'elasticsearch'), rollup='max').mean(by=['host', 'plugin_instance']).publish(label='A', enable=False)\nB = data('*.jvm.uptime', filter=filter('plugin', 'elasticsearch'), rollup='max').mean(by=['host', 'plugin_instance']).publish(label='B', enable=False)\nC = data('*.jvm.gc.time', filter=filter('plugin', 'elasticsearch'), rollup='max').mean(by=['host', 'plugin_instance']).timeshift('1h').publish(label='C', enable=False)\nD = data('*.jvm.uptime', filter=filter('plugin', 'elasticsearch'), rollup='max').mean(by=['host', 'plugin_instance']).timeshift('1h').publish(label='D', enable=False)\nE = ((A-C)*100/(B-D)).publish(label='E', enable=False)\nF = (E).min().publish(label='F')\nG = (E).percentile(pct=10).publish(label='G')\nH = (E).percentile(pct=50).publish(label='H')\nI = (E).percentile(pct=90).publish(label='I')\nJ = (E).max().publish(label='J')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -3028,11 +2682,11 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "",
-        "id": "DiVWsiUAYAA",
+        "description": "percentile distribution",
+        "id": "DiVWl2hAYHQ",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Deleted Documents %",
+        "name": "Heap %",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -3041,107 +2695,20 @@
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "deleted %",
+              "label": "% used",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 110,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Used %",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
               "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "gauge.indices.docs.deleted - Sum by plugin_instance",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "gauge.indices.docs.count - Sum by plugin_instance",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "% of Deleted Documents",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 7200000,
-            "type": "relative"
-          },
-          "timezone": null,
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('gauge.indices.docs.deleted').sum(by=['plugin_instance']).publish(label='A', enable=False)\nB = data('gauge.indices.docs.count').sum(by=['plugin_instance']).publish(label='B', enable=False)\nC = (A*100/B).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "last hour",
-        "id": "DiVWlfvAcAI",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "GC Time %",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "gc time %",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
             }
           ],
           "axisPrecision": null,
@@ -3165,11 +2732,12 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "GC time",
+              "displayName": "Used (bytes)",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -3179,7 +2747,7 @@
               "yAxis": 0
             },
             {
-              "displayName": "counter.jvm.uptime",
+              "displayName": "Used (bytes)",
               "label": "B",
               "paletteIndex": null,
               "plotType": null,
@@ -3189,7 +2757,7 @@
               "yAxis": 0
             },
             {
-              "displayName": "A - Timeshift 1h",
+              "displayName": "A*100/G",
               "label": "C",
               "paletteIndex": null,
               "plotType": null,
@@ -3199,9 +2767,9 @@
               "yAxis": 0
             },
             {
-              "displayName": "B - Timeshift 1h",
+              "displayName": "min",
               "label": "D",
-              "paletteIndex": null,
+              "paletteIndex": 14,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -3209,9 +2777,39 @@
               "yAxis": 0
             },
             {
-              "displayName": "(A-E)*100/(B-F)",
+              "displayName": "p10",
               "label": "E",
-              "paletteIndex": 1,
+              "paletteIndex": 15,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "p50",
+              "label": "F",
+              "paletteIndex": 2,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "p90",
+              "label": "G",
+              "paletteIndex": 5,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "max",
+              "label": "H",
+              "paletteIndex": 7,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -3225,12 +2823,11 @@
             "range": 7200000,
             "type": "relative"
           },
-          "timezone": null,
           "type": "TimeSeriesChart",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('counter.jvm.gc.time', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2'), rollup='max').publish(label='A', enable=False)\nB = data('counter.jvm.uptime', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2'), rollup='max').publish(label='B', enable=False)\nC = (A).timeshift('1h').publish(label='C', enable=False)\nD = (B).timeshift('1h').publish(label='D', enable=False)\nE = ((A-C)*100/(B-D)).publish(label='E')",
+        "programText": "A = data('*.jvm.mem.heap-used', filter=filter('plugin', 'elasticsearch')).mean(by=['host', 'plugin_instance']).publish(label='A', enable=False)\nB = data('*.jvm.mem.heap-committed', filter=filter('plugin', 'elasticsearch')).mean(by=['host', 'plugin_instance']).publish(label='B', enable=False)\nC = (A*100/B).publish(label='C', enable=False)\nD = (C).min().publish(label='D')\nE = (C).percentile(pct=10).publish(label='E')\nF = (C).percentile(pct=50).publish(label='F')\nG = (C).percentile(pct=90).publish(label='G')\nH = (C).max().publish(label='H')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -3241,12 +2838,32 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DiVWliRAcAA",
+        "id": "D3Ey2peAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Requests/sec",
+        "name": "Note",
         "options": {
-          "colorBy": "Metric",
+          "markdown": "Charts of this dashboard are meant to be compatible with both metrics from the old collectd/elasticsearch and the new elasticsearch monitor. Metrics from the old monitor have the metric type as prefixes. Whereas, metrics from the new monitor have \"elasticsearch.\" as the prefix on all metrics.",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWn5rAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top Clusters by Search Requests",
+        "options": {
+          "colorBy": "Dimension",
           "colorScale2": null,
           "legendOptions": {
             "fields": null
@@ -3255,33 +2872,14 @@
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "Search",
+              "displayName": "",
               "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Index",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Get",
-              "label": "C",
-              "paletteIndex": null,
+              "paletteIndex": 13,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -3291,14 +2889,191 @@
           ],
           "refreshInterval": null,
           "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "timezone": null,
+          "sortBy": "",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
           "type": "List",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('counter.indices.search.query-total', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).mean().publish(label='A')\nB = data('counter.indices.indexing.index-total', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).mean().publish(label='B')\nC = data('counter.indices.get.total', filter=filter('plugin', 'elasticsearch') and filter('host', 'integration-test-elasticsearch-1.7.1-2')).mean().publish(label='C')",
+        "programText": "A = data('*.indices.search.query-total', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).mean(by=['host']).sum(by=['plugin_instance']).top(count=3).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "percentile distribution over the last hour",
+        "id": "DiVWsQaAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "GC Time %",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "% gc time",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Used %",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Metric",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Used (bytes)",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Used (bytes)",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Used (bytes)",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Used (bytes)",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "min",
+              "label": "E",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "min",
+              "label": "F",
+              "paletteIndex": 14,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "p10",
+              "label": "G",
+              "paletteIndex": 15,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "p50",
+              "label": "H",
+              "paletteIndex": 2,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "p90",
+              "label": "I",
+              "paletteIndex": 5,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "max",
+              "label": "J",
+              "paletteIndex": 7,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.jvm.gc.time', filter=filter('plugin', 'elasticsearch'), rollup='max').mean(by=['host', 'plugin_instance']).publish(label='A', enable=False)\nB = data('*.jvm.uptime', filter=filter('plugin', 'elasticsearch'), rollup='max').mean(by=['host', 'plugin_instance']).publish(label='B', enable=False)\nC = data('*.jvm.gc.time', filter=filter('plugin', 'elasticsearch'), rollup='max').mean(by=['host', 'plugin_instance']).timeshift('1h').publish(label='C', enable=False)\nD = data('*.jvm.uptime', filter=filter('plugin', 'elasticsearch'), rollup='max').mean(by=['host', 'plugin_instance']).timeshift('1h').publish(label='D', enable=False)\nE = ((A-C)*100/(B-D)).publish(label='E', enable=False)\nF = (E).min().publish(label='F')\nG = (E).percentile(pct=10).publish(label='G')\nH = (E).percentile(pct=50).publish(label='H')\nI = (E).percentile(pct=90).publish(label='I')\nJ = (E).max().publish(label='J')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -3309,25 +3084,331 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DiVWm1fAcAA",
+        "id": "DiVWklGAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "# Hosts/Clusters",
+        "name": "Active Merges",
         "options": {
-          "colorBy": "Metric",
+          "colorBy": "Dimension",
+          "colorScale": null,
           "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
           "maximumPrecision": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
-            "minimumResolution": 0
+            "minimumResolution": 0,
+            "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "# hosts",
+              "displayName": "gauge.indices.merges.current",
+              "label": "A",
+              "paletteIndex": 5,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices.merges.current', filter=filter('plugin', 'elasticsearch')).sum(by=['host']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWlfjAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Search Requests/sec",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "requests/sec",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "requests/sec",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices.search.query-total', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).mean(by=['host']).publish(label='A')\n",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWoQrAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Merges/sec",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "merges / sec",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "counter.indices.merges.total - Sum by plugin_instance",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": "AreaChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices.merges.total', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).mean(by=['host', 'plugin_instance']).sum(by=['plugin_instance']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWlSeAgGg",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Indexing Requests/sec",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "requests/sec",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "requests/sec",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.indices.indexing.index-total', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).mean(by=['host']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "p99 latency over the last hour",
+        "id": "DiVWn4UAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top Clusters by Query Latency (ms)",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "A",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -3337,8 +3418,48 @@
               "yAxis": 0
             },
             {
-              "displayName": "# clusters",
+              "displayName": "B",
               "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "C",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "D",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "E",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "F",
+              "label": "F",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
@@ -3350,13 +3471,255 @@
           "refreshInterval": null,
           "secondaryVisualization": "Sparkline",
           "sortBy": "-value",
-          "time": null,
-          "timezone": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
           "type": "List",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('counter.indices.indexing.index-total', filter=filter('plugin', 'elasticsearch')).count().publish(label='A')\nB = data('counter.indices.indexing.index-total', filter=filter('plugin', 'elasticsearch')).sum(by=['plugin_instance']).count().publish(label='B')",
+        "programText": "A = data('*.indices.search.query-total', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True)), rollup='max').mean(by=['host', 'plugin_instance']).publish(label='A', enable=False)\nB = data('*.indices.search.query-time', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True)), rollup='max').mean(by=['host', 'plugin_instance']).publish(label='B', enable=False)\nC = data('*.indices.search.query-total', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True)), rollup='max').mean(by=['host', 'plugin_instance']).timeshift('1h').publish(label='C', enable=False)\nD = data('*.indices.search.query-time', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True)), rollup='max').mean(by=['host', 'plugin_instance']).timeshift('1h').publish(label='D', enable=False)\nE = ((B-D)/(A-C)).publish(label='E', enable=False)\nF = (E).percentile(pct=99, by=['plugin_instance']).top(count=5).publish(label='F')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWlf2AgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "File Descriptors and Segments",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "# FD - RED",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "# segment - BLUE",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Metric",
+          "defaultPlotType": "ColumnChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "# file descriptors",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "# segments",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('*.process.open_file_descriptors', filter=filter('plugin', 'elasticsearch')).mean(by=['host']).publish(label='A')\nB = data('*.indices.segments.count', filter=filter('plugin', 'elasticsearch') and (not filter('aggregation', ' *', match_missing=True))).mean(by=['host']).publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D3EynT9AcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Note",
+        "options": {
+          "markdown": "Charts of this dashboard are meant to be compatible with both metrics from the old collectd/elasticsearch and the new elasticsearch monitor. Metrics from the old monitor have the metric type as prefixes. Whereas, metrics from the new monitor have \"elasticsearch.\" as the prefix on all metrics.",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DiVWl3mAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Cache Size (bytes)",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "size (bytes)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Metric",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Filter Cache",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Field Cache",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Filter Cache",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Field Cache",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Query Cache",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 7200000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('gauge.indices.total.filter-cache.memory-size', filter=filter('plugin', 'elasticsearch')).mean(by=['index']).publish(label='A')\nB = data('gauge.indices.total.fielddata.memory-size', filter=filter('plugin', 'elasticsearch')).mean(by=['index']).publish(label='B')\nC = data('elasticsearch.indices.filter-cache.memory-size', filter=filter('plugin', ' elasticsearch') and filter('aggregation', ' total')).mean(by=['index']).publish(label='C')\nD = data('elasticsearch.indices.fielddata.memory-size', filter=filter('plugin', 'elasticsearch') and filter('aggregation', 'total')).mean(by=['index']).publish(label='D')\nE = data('elasticsearch.indices.query-cache.memory-size', filter=filter('plugin', 'elasticsearch') and filter('aggregation', 'total')).mean(by=['index']).publish(label='E')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -3364,137 +3727,6 @@
   ],
   "crossLinkExports": [],
   "dashboardExports": [
-    {
-      "dashboard": {
-        "chartDensity": "DEFAULT",
-        "charts": [
-          {
-            "chartId": "DiVWm1fAcAA",
-            "column": 0,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DiVWoQ8AgIw",
-            "column": 4,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DiVWsQaAcAA",
-            "column": 8,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DiVWn5rAYAA",
-            "column": 0,
-            "height": 1,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DiVWn4UAcAA",
-            "column": 8,
-            "height": 2,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DiVWnPQAgAA",
-            "column": 4,
-            "height": 1,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DiVWoAcAgBs",
-            "column": 0,
-            "height": 1,
-            "row": 2,
-            "width": 4
-          },
-          {
-            "chartId": "DiVWoIpAcAE",
-            "column": 4,
-            "height": 1,
-            "row": 2,
-            "width": 4
-          },
-          {
-            "chartId": "DiVWouSAcAA",
-            "column": 0,
-            "height": 1,
-            "row": 3,
-            "width": 4
-          },
-          {
-            "chartId": "DiVWoQrAYAA",
-            "column": 4,
-            "height": 1,
-            "row": 3,
-            "width": 4
-          },
-          {
-            "chartId": "DiVWpC3AgAA",
-            "column": 8,
-            "height": 1,
-            "row": 3,
-            "width": 4
-          },
-          {
-            "chartId": "DiVWsiUAYAA",
-            "column": 0,
-            "height": 1,
-            "row": 4,
-            "width": 4
-          },
-          {
-            "chartId": "DiVWozyAYAA",
-            "column": 4,
-            "height": 1,
-            "row": 4,
-            "width": 4
-          },
-          {
-            "chartId": "DiVWm2UAYAA",
-            "column": 8,
-            "height": 1,
-            "row": 4,
-            "width": 4
-          }
-        ],
-        "created": 0,
-        "creator": null,
-        "customProperties": null,
-        "description": "",
-        "discoveryOptions": {
-          "query": "plugin:elasticsearch",
-          "selectors": [
-            "sf_hostHasService:elasticsearch",
-            "plugin:elasticsearch"
-          ]
-        },
-        "eventOverlays": null,
-        "filters": {
-          "sources": null,
-          "time": null,
-          "variables": null
-        },
-        "groupId": "DiVWkghAYAA",
-        "id": "DiVWmlbAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "locked": false,
-        "maxDelayOverride": null,
-        "name": "Elasticsearch",
-        "selectedEventOverlays": null,
-        "tags": null
-      }
-    },
     {
       "dashboard": {
         "chartDensity": "DEFAULT",
@@ -3546,6 +3778,13 @@
             "column": 0,
             "height": 1,
             "row": 2,
+            "width": 6
+          },
+          {
+            "chartId": "D3EynT9AcAA",
+            "column": 0,
+            "height": 1,
+            "row": 3,
             "width": 6
           }
         ],
@@ -3675,6 +3914,13 @@
             "height": 1,
             "row": 3,
             "width": 4
+          },
+          {
+            "chartId": "D3Ey2peAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 4,
+            "width": 4
           }
         ],
         "created": 0,
@@ -3715,6 +3961,144 @@
         "selectedEventOverlays": null,
         "tags": null
       }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DiVWm1fAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVWoQ8AgIw",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVWsQaAcAA",
+            "column": 8,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DiVWn5rAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVWn4UAcAA",
+            "column": 8,
+            "height": 2,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVWnPQAgAA",
+            "column": 4,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DiVWoAcAgBs",
+            "column": 0,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DiVWoIpAcAE",
+            "column": 4,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DiVWouSAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "DiVWoQrAYAA",
+            "column": 4,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "DiVWpC3AgAA",
+            "column": 8,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "DiVWsiUAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 4,
+            "width": 4
+          },
+          {
+            "chartId": "DiVWozyAYAA",
+            "column": 4,
+            "height": 1,
+            "row": 4,
+            "width": 4
+          },
+          {
+            "chartId": "DiVWm2UAYAA",
+            "column": 8,
+            "height": 1,
+            "row": 4,
+            "width": 4
+          },
+          {
+            "chartId": "D3Ex1ghAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 5,
+            "width": 4
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "",
+        "discoveryOptions": {
+          "query": "plugin:elasticsearch",
+          "selectors": [
+            "sf_hostHasService:elasticsearch",
+            "plugin:elasticsearch"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": null
+        },
+        "groupId": "DiVWkghAYAA",
+        "id": "DiVWmlbAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "locked": false,
+        "maxDelayOverride": null,
+        "name": "Elasticsearch",
+        "selectedEventOverlays": null,
+        "tags": null
+      }
     }
   ],
   "groupExport": {
@@ -3722,9 +4106,9 @@
       "created": 0,
       "creator": null,
       "dashboards": [
+        "DiVWmlbAgAA",
         "DiVWlvuAcAA",
-        "DiVWkjDAgAA",
-        "DiVWmlbAgAA"
+        "DiVWkjDAgAA"
       ],
       "description": "Dashboards about Elasticsearch.",
       "email": null,
@@ -3749,7 +4133,7 @@
       "teams": null
     }
   },
-  "hashCode": 1025304078,
+  "hashCode": 1624735772,
   "id": "DiVWkghAYAA",
   "modelVersion": 1,
   "packageType": "GROUP"


### PR DESCRIPTION
- Make charts compatible with metrics from old collectd/elasticsearch and new elasticsearch monitors
- Remove extraneous filters from charts 