### PR TITLE
K8s: Change # of nodes charts to use different metric for counting

### DIFF
--- a/group/Kubernetes.json
+++ b/group/Kubernetes.json
@@ -6,347 +6,10 @@
         "creator": null,
         "customProperties": {},
         "description": "per cluster",
-        "id": "DkBncDiAgAI",
+        "id": "D8I6aRTAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "CPU Capacity Used",
-        "options": {
-          "colorBy": "Scale",
-          "colorScale2": [
-            {
-              "gt": 80,
-              "gte": null,
-              "lt": null,
-              "lte": null,
-              "paletteIndex": 16
-            },
-            {
-              "gt": 60,
-              "gte": null,
-              "lt": null,
-              "lte": 80,
-              "paletteIndex": 17
-            },
-            {
-              "gt": 40,
-              "gte": null,
-              "lt": null,
-              "lte": 60,
-              "paletteIndex": 18
-            },
-            {
-              "gt": 20,
-              "gte": null,
-              "lt": null,
-              "lte": 40,
-              "paletteIndex": 19
-            },
-            {
-              "gt": null,
-              "gte": null,
-              "lt": null,
-              "lte": 20,
-              "paletteIndex": 20
-            }
-          ],
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": true,
-                "property": "kubernetes_cluster"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              }
-            ]
-          },
-          "maximumPrecision": 3,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "centi-cores per cluster",
-              "label": "D",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "# cores per cluster",
-              "label": "E",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "CPU Capacity Usage %",
-              "label": "F",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "%",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "D = data('container_cpu_utilization').sum(by=['kubernetes_cluster']).publish(label='D', enable=False)\nE = data('machine_cpu_cores').sum(by=['kubernetes_cluster']).publish(label='E', enable=False)\nF = (D/E).publish(label='F')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnAW2AgAI",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Available Pods by Deployment",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": false,
-                "property": "kubernetes_cluster"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_name"
-              },
-              {
-                "enabled": false,
-                "property": "kubernetes_namespace"
-              },
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": false,
-                "property": "metric_source"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              },
-              {
-                "enabled": false,
-                "property": "uid"
-              }
-            ]
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "available pods",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "desired pods",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": 60000,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "+kubernetes_name",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('kubernetes.deployment.available').publish(label='A')\nB = data('kubernetes.deployment.desired').publish(label='B', enable=False)",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnCXLAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Desired Pods by Deployment",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": false,
-                "property": "kubernetes_cluster"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_name"
-              },
-              {
-                "enabled": false,
-                "property": "kubernetes_namespace"
-              },
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": false,
-                "property": "metric_source"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              },
-              {
-                "enabled": false,
-                "property": "uid"
-              }
-            ]
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "available pods",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "desired pods",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": 60000,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "+kubernetes_name",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('kubernetes.deployment.available').publish(label='A', enable=False)\nB = data('kubernetes.deployment.desired').publish(label='B')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "created by Deployments",
-        "id": "D2SlYGhAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Desired Pods",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": 0,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('kubernetes.deployment.desired', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace']).sum().publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "D4rhYsaAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Top 10 Pods by Major Page Faults",
+        "name": "Network Transmit Errors",
         "options": {
           "colorBy": "Dimension",
           "colorScale2": null,
@@ -362,28 +25,25 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "",
-              "label": "A",
+              "displayName": "Tx (Bytes)",
+              "label": "B",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
-              "valueUnit": null,
+              "valueUnit": "Byte",
               "yAxis": 0
             }
           ],
           "refreshInterval": null,
           "secondaryVisualization": "None",
           "sortBy": "-value",
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
+          "time": null,
           "type": "List",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_memory_failures_total', filter=filter('type', 'pgmajfault') and filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).top(count=10).publish(label='A')",
+        "programText": "B = data('pod_network_transmit_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_cluster']).publish(label='B')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -394,7 +54,7 @@
         "creator": null,
         "customProperties": {},
         "description": "per cluster",
-        "id": "DkBnb24AYAA",
+        "id": "D8I6Z29AYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "name": "Memory Capacity Used",
@@ -507,16 +167,517 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBm2FzAcAA",
+        "id": "DkBnCXLAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Major Page Faults per Container",
+        "name": "Desired Pods by Deployment",
         "options": {
           "colorBy": "Dimension",
           "colorScale2": null,
           "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_name"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "uid"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "available pods",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "desired pods",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": 60000,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "+kubernetes_name",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.deployment.available').publish(label='A', enable=False)\nB = data('kubernetes.deployment.desired').publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "per cluster",
+        "id": "D8I6ZNBAgAQ",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "CPU Capacity Used",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale2": [
+            {
+              "gt": 80,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 60,
+              "gte": null,
+              "lt": null,
+              "lte": 80,
+              "paletteIndex": 17
+            },
+            {
+              "gt": 40,
+              "gte": null,
+              "lt": null,
+              "lte": 60,
+              "paletteIndex": 18
+            },
+            {
+              "gt": 20,
+              "gte": null,
+              "lt": null,
+              "lte": 40,
+              "paletteIndex": 19
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 20,
+              "paletteIndex": 20
+            }
+          ],
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              }
+            ]
+          },
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "centi-cores per cluster",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "# cores per cluster",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "CPU Capacity Usage %",
+              "label": "F",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "D = data('container_cpu_utilization').sum(by=['kubernetes_cluster']).publish(label='D', enable=False)\nE = data('machine_cpu_cores').sum(by=['kubernetes_cluster']).publish(label='E', enable=False)\nF = (D/E).publish(label='F')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D8I6ZUjAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# Clusters",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "D = data('kubernetes.node_ready').sum(by=['kubernetes_cluster']).mean(over='1m').count().publish(label='D')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SmSj3AYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Network Throughput (bytes/sec)",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Rx Bytes /sec (RED)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Tx Bytes /sec (BLUE)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "ColumnChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
             "fields": null
           },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx (bytes/sec)",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx (bytes/sec)",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('kubernetes_cluster', '*', match_missing=True), extrapolation='zero').sum().publish(label='A')\nB = data('pod_network_transmit_bytes_total', filter=filter('kubernetes_cluster', '*', match_missing=True), extrapolation='zero').sum().publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SlXF0AcAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "CPU Capacity Used per Node",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": 100,
+              "highWatermarkLabel": null,
+              "label": "cpu %",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": true,
+                "property": "container_image"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "metric_source"
+              },
+              {
+                "enabled": true,
+                "property": "container_name"
+              },
+              {
+                "enabled": true,
+                "property": "container_spec_name"
+              },
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": true,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "centi-cores per cluster",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "# cores per cluster",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Node CPU Capacity Usage %",
+              "label": "F",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": true,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "D = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['kubernetes_node']).publish(label='D', enable=False)\nE = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['kubernetes_node']).publish(label='E', enable=False)\nF = (D/E).publish(label='F')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "of all phases",
+        "id": "D2SlXplAcAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Total of Pods",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
           "maximumPrecision": null,
           "programOptions": {
             "disableSampling": false,
@@ -530,54 +691,8 @@
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_memory_failures_total', filter=filter('metric_source', 'kubernetes') and filter('type', 'pgmajfault')).sum(by=['container_name']).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "This may include \"pause\" containers used internally by K8s",
-        "id": "DkBm2ftAYCM",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "# Active Containers",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "container_cpu_utilization - Mean(1m) - Count",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
+              "valuePrefix": "",
+              "valueSuffix": "pods",
               "valueUnit": null,
               "yAxis": 0
             }
@@ -585,13 +700,16 @@
           "refreshInterval": null,
           "secondaryVisualization": "None",
           "showSparkLine": false,
-          "time": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
           "timestampHidden": false,
           "type": "SingleValue",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).mean(over='1m').count().publish(label='A')",
+        "programText": "A = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='latest').count().publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -601,68 +719,11 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "",
-        "id": "DkBnJksAcAA",
+        "description": "Based on Kubernetes resource limits.  If no limits, will be blank.",
+        "id": "D4rhaiFAYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Total Memory (bytes)",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": 4,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "machine_memory_bytes - Sum",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "A/1024/1024",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": null,
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('machine_memory_bytes', filter=filter('metric_source', 'kubernetes')).sum().publish(label='A')\nB = (A/1024/1024).publish(label='B', enable=False)",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnHZUAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "% Memory Capacity Used",
+        "name": "% Memory Used per Pod",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -676,11 +737,20 @@
               "lowWatermarkLabel": null,
               "max": 110,
               "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
             }
           ],
           "axisPrecision": null,
           "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
+          "defaultPlotType": "LineChart",
           "eventPublishLabelOptions": [],
           "histogramChartOptions": {
             "colorThemeIndex": 16
@@ -704,9 +774,9 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "memory usage per node",
-              "label": "D",
-              "paletteIndex": null,
+              "displayName": "container",
+              "label": "A",
+              "paletteIndex": 1,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -714,9 +784,9 @@
               "yAxis": 0
             },
             {
-              "displayName": "memory capacity per node",
-              "label": "E",
-              "paletteIndex": null,
+              "displayName": "limit",
+              "label": "B",
+              "paletteIndex": 6,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -725,11 +795,11 @@
             },
             {
               "displayName": "",
-              "label": "F",
+              "label": "C",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
-              "valueSuffix": "%",
+              "valueSuffix": null,
               "valueUnit": null,
               "yAxis": 0
             }
@@ -744,108 +814,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "D = data('container_memory_usage_bytes').sum(by=['host']).mean(over='1m').publish(label='D', enable=False)\nE = data('machine_memory_bytes').sum(by=['host']).mean(over='1m').publish(label='E', enable=False)\nF = (D/E).scale(100).publish(label='F')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "This may include \"pause\" containers used internally by K8s",
-        "id": "D4rhZLXAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "# Active Pods",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "number of pods",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_pod_uid']).count().publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "D4rhW0mAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Top 10 Pods by Average Container Memory Usage",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 4,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Byte",
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "sortBy": "-value",
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "List",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).mean(by=['kubernetes_pod_name']).top(count=10).publish(label='A')",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).publish(label='A', enable=False)\nB = data('container_spec_memory_limit_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).above(0, inclusive=True).publish(label='B', enable=False)\nC = (A/B*100).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -944,57 +913,10 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBnHTuAcAA",
+        "id": "D2SlUbdAcDo",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Total # CPU Cores",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "cpu cores",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": null,
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('machine_cpu_cores', filter=filter('metric_source', 'kubernetes')).sum().mean(over='1m').publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "D2SlWAnAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Bytes In per Pod",
+        "name": "CPU Usage per Pod",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -1003,7 +925,7 @@
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "",
+              "label": "cpu %",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
@@ -1046,40 +968,12 @@
                 "property": "kubernetes_node"
               },
               {
-                "enabled": true,
-                "property": "kubernetes_pod_uid"
-              },
-              {
                 "enabled": false,
                 "property": "host"
               },
               {
-                "enabled": false,
+                "enabled": true,
                 "property": "sf_metric"
-              },
-              {
-                "enabled": false,
-                "property": "interface"
-              },
-              {
-                "enabled": false,
-                "property": "container_image"
-              },
-              {
-                "enabled": false,
-                "property": "metric_source"
-              },
-              {
-                "enabled": false,
-                "property": "container_spec_name"
-              },
-              {
-                "enabled": false,
-                "property": "container_id"
-              },
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
               }
             ]
           },
@@ -1098,27 +992,47 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "bytes received",
+              "displayName": "conatiner centi-core usage",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Byte",
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "num cores on host",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "pod cpu usage",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null,
               "yAxis": 0
             }
           ],
-          "showEventLines": false,
+          "showEventLines": true,
           "stacked": false,
           "time": {
             "range": 900000,
             "type": "relative"
           },
           "type": "TimeSeriesChart",
-          "unitPrefix": "Binary"
+          "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'kubernetes_node', 'kubernetes_pod_name', 'kubernetes_pod_uid']).publish(label='A')",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['kubernetes_pod_name', 'host', 'kubernetes_pod_name', 'kubernetes_namespace', 'kubernetes_cluster', 'kubernetes_node']).publish(label='A', enable=False)\nB = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['kubernetes_node']).publish(label='E', enable=False)\nC = (A/B).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1129,10 +1043,10 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBnaDJAYAA",
+        "id": "D8I_-3UAYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "# Nodes per Cluster",
+        "name": "Major Page Faults per Container",
         "options": {
           "colorBy": "Dimension",
           "colorScale2": null,
@@ -1159,14 +1073,14 @@
             }
           ],
           "refreshInterval": null,
-          "secondaryVisualization": "None",
+          "secondaryVisualization": "Sparkline",
           "sortBy": "-value",
           "time": null,
           "type": "List",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization').sum(by=['host', 'kubernetes_cluster']).mean(over='1m').count(by=['kubernetes_cluster']).publish(label='A')",
+        "programText": "A = data('container_memory_failures_total', filter=filter('metric_source', 'kubernetes') and filter('type', 'pgmajfault')).sum(by=['container_name']).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1177,162 +1091,10 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "D4rhYciAcAA",
+        "id": "D4rhW0mAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "# of Pods by Phase",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Running",
-              "label": "B",
-              "paletteIndex": 15,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "pods",
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Pending",
-              "label": "A",
-              "paletteIndex": 6,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "pods",
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Succeeded",
-              "label": "C",
-              "paletteIndex": 2,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "pods",
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Failed",
-              "label": "D",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "pods",
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Unknown",
-              "label": "E",
-              "paletteIndex": 11,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "pods",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "B = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count().publish(label='B')\nA = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count().publish(label='A')\nC = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(2.5, 3.5, low_inclusive=True, high_inclusive=True).count().publish(label='C')\nD = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(3.5, 4.5, low_inclusive=True, high_inclusive=True).count().publish(label='D')\nE = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(4.5, 5.5, low_inclusive=True, high_inclusive=True).count().publish(label='E')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Network receive and transmit errors from pods on this node",
-        "id": "D2SmSLNAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Network Errors by Interface",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Rx",
-              "label": "A",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Tx",
-              "label": "B",
-              "paletteIndex": 1,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "sortBy": "-value",
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_errors_total', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['interface']).publish(label='A')\nB = data('pod_network_transmit_errors_total', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['interface']).publish(label='B')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "per cluster",
-        "id": "DkBnaCuAgDg",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Memory Usage",
+        "name": "Top 10 Pods by Average Container Memory Usage",
         "options": {
           "colorBy": "Dimension",
           "colorScale2": null,
@@ -1359,6 +1121,57 @@
             }
           ],
           "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).mean(by=['kubernetes_pod_name']).top(count=10).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D8JAAiDAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Memory Used per Container (Bytes)",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
           "secondaryVisualization": "Sparkline",
           "sortBy": "-value",
           "time": null,
@@ -1366,7 +1179,7 @@
           "unitPrefix": "Binary"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_memory_usage_bytes').sum(by=['kubernetes_cluster']).publish(label='A')",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes')).mean(by=['container_name']).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1538,6 +1351,1414 @@
         "creator": null,
         "customProperties": {},
         "description": "",
+        "id": "D4rhZ6mAgCU",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "CPU Usage per Pod",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": true,
+                "property": "sf_metric"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "conatiner centi-core usage",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "num cores on host",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "pod cpu usage",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": true,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['kubernetes_pod_name', 'host', 'kubernetes_pod_name', 'kubernetes_namespace', 'kubernetes_cluster', 'kubernetes_node']).publish(label='A', enable=False)\nB = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['kubernetes_node']).publish(label='E', enable=False)\nC = (A/B).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "number of pods that should be created by deployments",
+        "id": "D4rhWwPAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Desired Pods by Deployments",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.deployment.desired', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace']).sum().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnCUjAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Container Restarts by Node",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_role"
+              },
+              {
+                "enabled": true,
+                "property": "container_image"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "metric_source"
+              },
+              {
+                "enabled": true,
+                "property": "container_spec_name"
+              },
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "kubernetes.container_restart_count - Sum by host",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.container_restart_count', rollup='sum', extrapolation='zero').sum(by=['host']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D4rhYBRAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Network Throughput (bytes/sec)",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Rx Bytes /sec (RED)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Tx Bytes /sec (BLUE)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "ColumnChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx (bytes/sec)",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx (bytes/sec)",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), extrapolation='zero').sum().publish(label='A')\nB = data('pod_network_transmit_bytes_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), extrapolation='zero').sum().publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Based on Pod spec's resources.limits.cpu value if present, otherwise chart will be blank.",
+        "id": "D4rhZA5AYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "% CPU Limit Used per Pod",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": 80,
+              "highWatermarkLabel": null,
+              "label": "CPU %",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Centicores used",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "CFS quota",
+              "label": "B",
+              "paletteIndex": 6,
+              "plotType": "LineChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "CFS period",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "% of Limit",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).publish(label='A', enable=False)\nB = data('container_spec_cpu_quota', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).publish(label='B', enable=False)\nC = data('container_spec_cpu_period', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).publish(label='C', enable=False)\nD = (A/(B/C)).sum(by=['kubernetes_pod_name']).publish(label='D')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SmSKEAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Total Memory (bytes)",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": 4,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "machine_memory_bytes - Sum",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "A/1024/1024",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('machine_memory_bytes', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum().publish(label='A')\nB = (A/1024/1024).publish(label='B', enable=False)",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D8I_-tTAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Network Throughput (bytes/sec)",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Rx Bytes /sec (RED)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Tx Bytes /sec (BLUE)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "ColumnChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx (bytes/sec)",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx (bytes/sec)",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum().publish(label='A')\nB = data('pod_network_transmit_bytes_total', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum().publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D8I_-rWAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Network Errors / sec",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "+sf_metric",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_errors_total', filter=filter('metric_source', 'kubernetes')).sum().publish(label='A')\nB = data('pod_network_transmit_errors_total', filter=filter('metric_source', 'kubernetes')).sum().publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D4rhauVAcCg",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Memory Usage per Pod",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_pod_uid', 'kubernetes_pod_name']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnBhCAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Daemon Sets by Stage",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_name"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": true,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "uid"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "current",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "desired",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "misscheduled",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "ready",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "+kubernetes_cluster",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.daemon_set.current_scheduled').sum(by=['kubernetes_cluster']).publish(label='A')\nB = data('kubernetes.daemon_set.desired_scheduled').sum(by=['kubernetes_cluster']).publish(label='B')\nC = data('kubernetes.daemon_set.misscheduled').sum(by=['kubernetes_cluster']).publish(label='C')\nD = data('kubernetes.daemon_set.ready').sum(by=['kubernetes_cluster']).publish(label='D')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Based on Kubernetes resource limits.  If no limits, will be blank.",
+        "id": "D8I_-j7AcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "% Memory Used per Container",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "container",
+              "label": "A",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "limit",
+              "label": "B",
+              "paletteIndex": 6,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            },
+            {
+              "displayName": "",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600001,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).publish(label='A', enable=False)\nB = data('container_spec_memory_limit_bytes', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).above(0, inclusive=True).publish(label='B', enable=False)\nC = (A/B*100).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D8I6Zv0AcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# Containers per Cluster",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization').mean(over='1m').count(by=['kubernetes_cluster']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnHSwAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Memory Use per Pod (bytes)",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "bytes",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "memory use (bytes)",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_pod_name']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Network receive and transmit errors from pods on this node",
+        "id": "DkBnHTDAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod Network Errors by Interface",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['interface']).publish(label='A')\nB = data('pod_network_transmit_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['interface']).publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SlWheAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Available Pods by Deployments",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": false,
+                "property": "deployment"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_deployment_uid"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_uid"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "kuberentes_deployment_name"
+              },
+              {
+                "enabled": false,
+                "property": "kuberentes_deployment_uid"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": "kubernetes_name",
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "deployed pods",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": true,
+          "stacked": true,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.deployment.available', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_name']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SmSX4AgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# Nodes",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.node_ready', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['kubernetes_node']).mean(over='1m').count().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SlUMWAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": ".",
+        "options": {
+          "markdown": "<table width=\"100%\" height=\"50%\" rules=\"none\"><tr><td valign=\"middle\" align=\"center\" bgcolor=\"#59a200\">\n<font size=\"5\" color=\"white\">K8s Nodes</font>\n</td></tr></table>\n\n<p align=\"center\" ><br /><font>This dashboard is populated by the metrics emitted from the <a href=\"https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-cluster.html\" target=\"_blank\">kubernetes-cluster</a> monitor and  <a href=\"https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubelet-stats.html\" target=\"_blank\">kubelet-stats</a> . Charts below refer to the health of your Kubernetes Nodes. When filtered by Deployment or Service, charts below will be filtered by the selected pods running on the nodes.<br></p></font>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
         "id": "D2SmUQbAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
@@ -1699,7 +2920,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['host', 'kubernetes_cluster']).mean(over='1m').publish(label='A', enable=False)\nG = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['host', 'kubernetes_cluster']).mean(over='1m').publish(label='G', enable=False)\nL = (A/G).top(count=10).publish(label='L')",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['kubernetes_node', 'kubernetes_cluster']).mean(over='1m').publish(label='A', enable=False)\nG = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['kubernetes_node', 'kubernetes_cluster']).mean(over='1m').publish(label='G', enable=False)\nL = (A/G).top(count=10).publish(label='L')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1709,24 +2930,24 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "Based on Pod spec's resources.limits.cpu value if present, otherwise chart will be blank.",
-        "id": "DkBm1ulAYAA",
+        "description": "",
+        "id": "D2SlUGlAgAc",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "% CPU Limit Used per Container",
+        "name": "Memory Usage per Pod",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
           },
           "axes": [
             {
-              "highWatermark": 80,
+              "highWatermark": null,
               "highWatermarkLabel": null,
               "label": "",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
-              "min": 0
+              "min": null
             },
             {
               "highWatermark": null,
@@ -1740,14 +2961,39 @@
           ],
           "axisPrecision": null,
           "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
+          "defaultPlotType": "LineChart",
           "eventPublishLabelOptions": [],
           "histogramChartOptions": {
             "colorThemeIndex": 16
           },
           "includeZero": false,
           "legendOptions": {
-            "fields": null
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              }
+            ]
           },
           "lineChartOptions": {
             "showDataMarkers": false
@@ -1764,57 +3010,27 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "Centicores used",
+              "displayName": "pod memory usage",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "CFS quota",
-              "label": "B",
-              "paletteIndex": 6,
-              "plotType": "LineChart",
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "CFS period",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "% of Limit",
-              "label": "D",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
+              "valueUnit": "Byte",
               "yAxis": 0
             }
           ],
           "showEventLines": false,
           "stacked": false,
           "time": {
-            "range": 3600000,
+            "range": 900000,
             "type": "relative"
           },
           "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
+          "unitPrefix": "Binary"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).publish(label='A', enable=False)\nB = data('container_spec_cpu_quota', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).publish(label='B', enable=False)\nC = data('container_spec_cpu_period', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).publish(label='C', enable=False)\nD = (A/(B/C)).sum(by=['container_name']).publish(label='D')",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_pod_uid', 'kubernetes_pod_name']).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1825,10 +3041,116 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "D2SmSj3AYAA",
+        "id": "D8I_-n1AYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Network Throughput (bytes/sec)",
+        "name": "% CPU Used per Container",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum(by=['container_name']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnJmPAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Highest CPU Use per Pod (%)",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).publish(label='A', enable=False)\nB = (A).sum(by=['kubernetes_pod_name']).mean(over='1m').top(count=10).publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SlWAnAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Bytes In per Pod",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -1837,32 +3159,85 @@
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "Rx Bytes /sec (RED)",
+              "label": "",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
-              "min": 0
+              "min": null
             },
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "Tx Bytes /sec (BLUE)",
+              "label": "",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
-              "min": 0
+              "min": null
             }
           ],
           "axisPrecision": null,
           "colorBy": "Dimension",
-          "defaultPlotType": "ColumnChart",
+          "defaultPlotType": "LineChart",
           "eventPublishLabelOptions": [],
           "histogramChartOptions": {
             "colorThemeIndex": 16
           },
-          "includeZero": false,
+          "includeZero": true,
           "legendOptions": {
-            "fields": null
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "interface"
+              },
+              {
+                "enabled": false,
+                "property": "container_image"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "container_spec_name"
+              },
+              {
+                "enabled": false,
+                "property": "container_id"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              }
+            ]
           },
           "lineChartOptions": {
             "showDataMarkers": false
@@ -1871,6 +3246,250 @@
             "dimensionInLegend": null,
             "showLegend": false
           },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "bytes received",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'kubernetes_node', 'kubernetes_pod_name', 'kubernetes_pod_uid']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnAW2AgAI",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Available Pods by Deployment",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_name"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "uid"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "available pods",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "desired pods",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": 60000,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "+kubernetes_name",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.deployment.available').publish(label='A')\nB = data('kubernetes.deployment.desired').publish(label='B', enable=False)",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "This may include \"pause\" containers used internally by K8s",
+        "id": "D8I_-iEAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# Active Containers",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "container_cpu_utilization - Mean(1m) - Count",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).mean(over='1m').count().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D4rhYsaAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top 10 Pods by Major Page Faults",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_failures_total', filter=filter('type', 'pgmajfault') and filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).top(count=10).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "bytes in + bytes out",
+        "id": "D2SmUtjAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top Nodes by Network Usage",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              }
+            ]
+          },
+          "maximumPrecision": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
@@ -1897,6 +3516,113 @@
               "valueSuffix": null,
               "valueUnit": null,
               "yAxis": 1
+            },
+            {
+              "displayName": "A+B",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('kubernetes_cluster', '*', match_missing=True), extrapolation='zero').sum(by=['kubernetes_node']).publish(label='A', enable=False)\nB = data('pod_network_transmit_bytes_total', filter=filter('kubernetes_cluster', '*', match_missing=True), extrapolation='zero').sum(by=['kubernetes_node']).publish(label='B', enable=False)\nC = (A+B).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnHZUAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "% Memory Capacity Used",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "% memory used",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 110,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "memory usage per node",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "memory capacity per node",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "",
+              "label": "F",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
             }
           ],
           "showEventLines": false,
@@ -1906,10 +3632,281 @@
             "type": "relative"
           },
           "type": "TimeSeriesChart",
-          "unitPrefix": "Binary"
+          "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('kubernetes_cluster', '*', match_missing=True), extrapolation='zero').sum().publish(label='A')\nB = data('pod_network_transmit_bytes_total', filter=filter('kubernetes_cluster', '*', match_missing=True), extrapolation='zero').sum().publish(label='B')",
+        "programText": "D = data('container_memory_usage_bytes').sum(by=['host']).mean(over='1m').publish(label='D', enable=False)\nE = data('machine_memory_bytes').sum(by=['host']).mean(over='1m').publish(label='E', enable=False)\nF = (D/E).scale(100).publish(label='F')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnB8XAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Net Pods Desired by Replication Controller",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_name"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "uid"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "available pods",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "desired pods",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "pods desired but not available",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.replication_controller.available').publish(label='A', enable=False)\nB = data('kubernetes.replication_controller.desired').publish(label='B', enable=False)\nC = (B-A).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D4rhWtQAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Network Errors / sec",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "+sf_metric",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_errors_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True) ).sum().publish(label='A')\nB = data('pod_network_transmit_errors_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True) ).sum().publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D8I6ZjWAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# Nodes per Cluster",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.node_ready').sum(by=['kubernetes_node', 'kubernetes_cluster']).mean(over='1m').count(by=['kubernetes_cluster']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnCYRAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Container Restarts",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 1,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 1,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "kubernetes.container_restart_count - Sum by kubernetes_cluster",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.container_restart_count', rollup='sum').sum(by=['kubernetes_cluster']).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -2077,753 +4074,11 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "",
-        "id": "D2SlWE-AcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "# of Pods by Phase",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Running",
-              "label": "B",
-              "paletteIndex": 15,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "pods",
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Pending",
-              "label": "A",
-              "paletteIndex": 6,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "pods",
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Succeeded",
-              "label": "C",
-              "paletteIndex": 2,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "pods",
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Failed",
-              "label": "D",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "pods",
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Unknown",
-              "label": "E",
-              "paletteIndex": 11,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "pods",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "+sf_originatingMetric",
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "B = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count().publish(label='B')\nA = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count().publish(label='A')\nC = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(2.5, 3.5, low_inclusive=True, high_inclusive=True).count().publish(label='C')\nD = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(3.5, 4.5, low_inclusive=True, high_inclusive=True).count().publish(label='D')\nE = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(4.5, 5.5, low_inclusive=True, high_inclusive=True).count().publish(label='E')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "D4rhYBRAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Network Throughput (bytes/sec)",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "Rx Bytes /sec (RED)",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "Tx Bytes /sec (BLUE)",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "ColumnChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Rx (bytes/sec)",
-              "label": "A",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Tx (bytes/sec)",
-              "label": "B",
-              "paletteIndex": 1,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 1
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 3600000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), extrapolation='zero').sum().publish(label='A')\nB = data('pod_network_transmit_bytes_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), extrapolation='zero').sum().publish(label='B')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "D4rhauVAcCg",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Memory Usage per Pod",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": true,
-                "property": "kubernetes_pod_name"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_namespace"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_cluster"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_pod_uid"
-              },
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              }
-            ]
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Byte",
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_pod_uid', 'kubernetes_pod_name']).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnCUjAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Container Restarts by Node",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": true,
-                "property": "kubernetes_cluster"
-              },
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_pod_name"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_node"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_role"
-              },
-              {
-                "enabled": true,
-                "property": "container_image"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_namespace"
-              },
-              {
-                "enabled": true,
-                "property": "metric_source"
-              },
-              {
-                "enabled": true,
-                "property": "container_spec_name"
-              },
-              {
-                "enabled": true,
-                "property": "host"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_pod_uid"
-              },
-              {
-                "enabled": true,
-                "property": "container_id"
-              }
-            ]
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "kubernetes.container_restart_count - Sum by host",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('kubernetes.container_restart_count', rollup='sum', extrapolation='zero').sum(by=['host']).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "D2SmSKEAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Total Memory (bytes)",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": 4,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "machine_memory_bytes - Sum",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "A/1024/1024",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('machine_memory_bytes', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum().publish(label='A')\nB = (A/1024/1024).publish(label='B', enable=False)",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "per node",
-        "id": "D2SmUhoAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Top 10 Nodes by Memory Capacity Used",
-        "options": {
-          "colorBy": "Scale",
-          "colorScale2": [
-            {
-              "gt": 80,
-              "gte": null,
-              "lt": null,
-              "lte": null,
-              "paletteIndex": 16
-            },
-            {
-              "gt": 60,
-              "gte": null,
-              "lt": null,
-              "lte": 80,
-              "paletteIndex": 17
-            },
-            {
-              "gt": 40,
-              "gte": null,
-              "lt": null,
-              "lte": 60,
-              "paletteIndex": 18
-            },
-            {
-              "gt": 20,
-              "gte": null,
-              "lt": null,
-              "lte": 40,
-              "paletteIndex": 19
-            },
-            {
-              "gt": null,
-              "gte": null,
-              "lt": null,
-              "lte": 20,
-              "paletteIndex": 20
-            }
-          ],
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 3,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "memory usage per node",
-              "label": "D",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "memory capacity per node",
-              "label": "E",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "",
-              "label": "F",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "%",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "sortBy": "-value",
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "D = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'host']).mean(over='1m').publish(label='D', enable=False)\nE = data('machine_memory_bytes', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'host']).mean(over='1m').publish(label='E', enable=False)\nF = (D/E).scale(100).top(count=10).publish(label='F')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "D2SlUGlAgAc",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Memory Usage per Pod",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": true,
-                "property": "kubernetes_pod_name"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_namespace"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_cluster"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_pod_uid"
-              },
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              }
-            ]
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "pod memory usage",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Byte",
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_pod_uid', 'kubernetes_pod_name']).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "D2SlVhwAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": ".",
-        "options": {
-          "markdown": "<table width=\"100%\" height=\"50%\" rules=\"none\"><tr><td valign=\"middle\" align=\"center\" bgcolor=\"#59a200\">\n<font size=\"5\" color=\"white\">K8s Pods</font>\n</td></tr></table>\n\n<p align=\"center\" ><br /><font>Charts below refer to the health of your Kubernetes Pods. Use the filters at the top to narrow down pods by Cluster, Namespace, Nodes, Services, or Deployments.  <br />\nService tag syncing was added with agent version <a href=\"https://github.com/signalfx/signalfx-agent/releases/tag/v4.1.0\" target=\"_blank\">v4.1.0</a> and deployment property syncing in <a href=\"https://github.com/signalfx/signalfx-agent/releases/tag/v4.3.0\" target=\"_blank\">v4.3.0</a>.<br></p></font>",
-          "type": "Text"
-        },
-        "packageSpecifications": "",
-        "programText": "",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBm2jfAcDo",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "% CPU Used per Container",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 3,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum(by=['container_name']).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
         "description": "created by Deployments",
-        "id": "D2SlXg8AYAA",
+        "id": "D2SlYGhAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Available Pods",
+        "name": "Desired Pods",
         "options": {
           "colorBy": "Dimension",
           "colorScale": null,
@@ -2859,7 +4114,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('kubernetes.deployment.available', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_name']).sum().publish(label='A')",
+        "programText": "A = data('kubernetes.deployment.desired', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace']).sum().publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -2869,24 +4124,24 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "",
-        "id": "D2SlWheAgAA",
+        "description": "Based on Pod spec's resources.limits.cpu value if present, otherwise chart will be blank.",
+        "id": "D8I_-flAYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Available Pods by Deployments",
+        "name": "% CPU Limit Used per Container",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
           },
           "axes": [
             {
-              "highWatermark": null,
+              "highWatermark": 80,
               "highWatermarkLabel": null,
               "label": "",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
-              "min": null
+              "min": 0
             },
             {
               "highWatermark": null,
@@ -2905,91 +4160,76 @@
           "histogramChartOptions": {
             "colorThemeIndex": 16
           },
-          "includeZero": true,
+          "includeZero": false,
           "legendOptions": {
-            "fields": [
-              {
-                "enabled": true,
-                "property": "kubernetes_name"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_namespace"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_cluster"
-              },
-              {
-                "enabled": false,
-                "property": "deployment"
-              },
-              {
-                "enabled": false,
-                "property": "kubernetes_deployment_uid"
-              },
-              {
-                "enabled": false,
-                "property": "kubernetes_uid"
-              },
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              },
-              {
-                "enabled": false,
-                "property": "metric_source"
-              },
-              {
-                "enabled": false,
-                "property": "kuberentes_deployment_name"
-              },
-              {
-                "enabled": false,
-                "property": "kuberentes_deployment_uid"
-              }
-            ]
+            "fields": null
           },
           "lineChartOptions": {
             "showDataMarkers": false
           },
           "onChartLegendOptions": {
-            "dimensionInLegend": "kubernetes_name",
+            "dimensionInLegend": null,
             "showLegend": false
           },
           "programOptions": {
             "disableSampling": false,
-            "maxDelay": 0,
+            "maxDelay": null,
             "minimumResolution": 0,
             "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "deployed pods",
+              "displayName": "Centicores used",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
-              "valueSuffix": "pods",
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "CFS quota",
+              "label": "B",
+              "paletteIndex": 6,
+              "plotType": "LineChart",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "CFS period",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "% of Limit",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
               "valueUnit": null,
               "yAxis": 0
             }
           ],
-          "showEventLines": true,
-          "stacked": true,
+          "showEventLines": false,
+          "stacked": false,
           "time": {
-            "range": 900000,
+            "range": 3600000,
             "type": "relative"
           },
           "type": "TimeSeriesChart",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('kubernetes.deployment.available', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_name']).publish(label='A')",
+        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).publish(label='A', enable=False)\nB = data('container_spec_cpu_quota', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).publish(label='B', enable=False)\nC = data('container_spec_cpu_period', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).publish(label='C', enable=False)\nD = (A/(B/C)).sum(by=['container_name']).publish(label='D')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -3116,115 +4356,23 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "D2SmR8XAgAA",
+        "id": "D2SlWkWAYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Top Nodes by Memory",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": true,
-                "property": "host"
-              },
-              {
-                "enabled": false,
-                "property": "kubernetes_cluster"
-              },
-              {
-                "enabled": false,
-                "property": "kubernetes_role"
-              },
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": false,
-                "property": "metric_source"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              },
-              {
-                "enabled": true,
-                "property": "machine_id"
-              },
-              {
-                "enabled": true,
-                "property": "AWSUniqueId"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_node"
-              },
-              {
-                "enabled": true,
-                "property": "gcp_id"
-              }
-            ]
-          },
-          "maximumPrecision": 4,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "List",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('machine_memory_bytes', filter=filter('kubernetes_cluster', '*', match_missing=True)).mean(over='1m').top(count=10).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Based on Pod spec's resources.limits.cpu value if present, otherwise chart will be blank.",
-        "id": "D4rhZA5AYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "% CPU Limit Used per Pod",
+        "name": "Desired Pods by Deployments",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
           },
           "axes": [
             {
-              "highWatermark": 80,
+              "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "CPU %",
+              "label": "",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
-              "min": 0
+              "min": null
             },
             {
               "highWatermark": null,
@@ -3243,260 +4391,32 @@
           "histogramChartOptions": {
             "colorThemeIndex": 16
           },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Centicores used",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "CFS quota",
-              "label": "B",
-              "paletteIndex": 6,
-              "plotType": "LineChart",
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "CFS period",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "% of Limit",
-              "label": "D",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 3600000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).publish(label='A', enable=False)\nB = data('container_spec_cpu_quota', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).publish(label='B', enable=False)\nC = data('container_spec_cpu_period', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).publish(label='C', enable=False)\nD = (A/(B/C)).sum(by=['kubernetes_pod_name']).publish(label='D')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "bytes in + bytes out",
-        "id": "D2SmUtjAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Top Nodes by Network Usage",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
+          "includeZero": true,
           "legendOptions": {
             "fields": [
               {
                 "enabled": true,
-                "property": "host"
+                "property": "kubernetes_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
               },
               {
                 "enabled": false,
-                "property": "sf_metric"
-              }
-            ]
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Rx (bytes/sec)",
-              "label": "A",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Tx (bytes/sec)",
-              "label": "B",
-              "paletteIndex": 1,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 1
-            },
-            {
-              "displayName": "A+B",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Byte",
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "List",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('kubernetes_cluster', '*', match_missing=True), extrapolation='zero').sum(by=['host']).publish(label='A', enable=False)\nB = data('pod_network_transmit_bytes_total', filter=filter('kubernetes_cluster', '*', match_missing=True), extrapolation='zero').sum(by=['host']).publish(label='B', enable=False)\nC = (A+B).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnAvVAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Deployments Not at Spec",
-        "options": {
-          "colorBy": "Scale",
-          "colorScale": null,
-          "colorScale2": [
-            {
-              "gt": 0,
-              "gte": null,
-              "lt": null,
-              "lte": null,
-              "paletteIndex": 16
-            },
-            {
-              "gt": null,
-              "gte": null,
-              "lt": null,
-              "lte": 0,
-              "paletteIndex": 14
-            }
-          ],
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "available pods",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "desired pods",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "pods desired but not available",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": 60000,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": null,
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('kubernetes.deployment.available', extrapolation='zero').publish(label='A', enable=False)\nB = data('kubernetes.deployment.desired', extrapolation='zero').publish(label='B', enable=False)\nC = (B-A).above(0).count().publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "D2SmTISAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Top Nodes by # Pods",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": [
+                "property": "deployment"
+              },
               {
-                "enabled": true,
-                "property": "host"
+                "enabled": false,
+                "property": "kubernetes_uid"
+              },
+              {
+                "enabled": false,
+                "property": "kubernetes_deployment_uid"
               },
               {
                 "enabled": false,
@@ -3505,52 +4425,45 @@
               {
                 "enabled": false,
                 "property": "sf_metric"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_pod_name"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_node"
-              },
-              {
-                "enabled": true,
-                "property": "machine_id"
               }
             ]
           },
-          "maximumPrecision": null,
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": "kubernetes_name",
+            "showLegend": false
+          },
           "programOptions": {
             "disableSampling": false,
-            "maxDelay": null,
+            "maxDelay": 0,
             "minimumResolution": 0,
             "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "container_cpu_utilization - Sum by kubernetes_pod_name - Mean(1m) - Count by host",
+              "displayName": "desired pods",
               "label": "A",
-              "paletteIndex": 1,
+              "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
-              "valueSuffix": null,
+              "valueSuffix": "pods",
               "valueUnit": null,
               "yAxis": 0
             }
           ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
+          "showEventLines": true,
+          "stacked": true,
           "time": {
             "range": 900000,
             "type": "relative"
           },
-          "type": "List",
+          "type": "TimeSeriesChart",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*', match_missing=True), extrapolation='last_value').sum(by=['kubernetes_pod_name']).mean(over='1m').count(by=['host']).publish(label='A')",
+        "programText": "A = data('kubernetes.deployment.desired', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_name']).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -3560,21 +4473,19 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "",
-        "id": "DkBm16iAcAA",
+        "description": "number of pods ready by deploments",
+        "id": "D4rhW0NAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Memory Used per Container (Bytes)",
+        "name": "Available Pods by Deployments",
         "options": {
           "colorBy": "Dimension",
+          "colorScale": null,
           "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 3,
+          "maximumPrecision": null,
           "programOptions": {
             "disableSampling": false,
-            "maxDelay": null,
+            "maxDelay": 0,
             "minimumResolution": 0,
             "timezone": null
           },
@@ -3591,14 +4502,18 @@
             }
           ],
           "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Binary"
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes')).mean(by=['container_name']).publish(label='A')",
+        "programText": "A = data('kubernetes.deployment.available', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_name', 'kubernetes_uid']).sum().publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -3608,55 +4523,18 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "grouped by cluster",
-        "id": "D2SlUmAAYAA",
+        "description": "",
+        "id": "D4rhYciAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "CPU Capacity Used per Node",
+        "name": "# of Pods by Phase",
         "options": {
-          "colorBy": "Scale",
-          "colorRange": null,
-          "colorScale": null,
-          "colorScale2": [
-            {
-              "gt": 80,
-              "gte": null,
-              "lt": null,
-              "lte": null,
-              "paletteIndex": 16
-            },
-            {
-              "gt": 60,
-              "gte": null,
-              "lt": null,
-              "lte": 80,
-              "paletteIndex": 17
-            },
-            {
-              "gt": 40,
-              "gte": null,
-              "lt": null,
-              "lte": 60,
-              "paletteIndex": 18
-            },
-            {
-              "gt": 20,
-              "gte": null,
-              "lt": null,
-              "lte": 40,
-              "paletteIndex": 19
-            },
-            {
-              "gt": null,
-              "gte": null,
-              "lt": null,
-              "lte": 20,
-              "paletteIndex": 20
-            }
-          ],
-          "groupBy": [
-            "kubernetes_cluster"
-          ],
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
@@ -3665,40 +4543,68 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "conatiner centi-core usage",
+              "displayName": "Running",
+              "label": "B",
+              "paletteIndex": 15,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Pending",
               "label": "A",
-              "valuePrefix": "",
-              "valueSuffix": "",
-              "valueUnit": null
+              "paletteIndex": 6,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
             },
             {
-              "displayName": "num cores on host",
-              "label": "E",
-              "valuePrefix": "",
-              "valueSuffix": "",
-              "valueUnit": null
-            },
-            {
-              "displayName": "node cpu usage",
+              "displayName": "Succeeded",
               "label": "C",
-              "valuePrefix": "",
-              "valueSuffix": "%",
-              "valueUnit": null
+              "paletteIndex": 2,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Failed",
+              "label": "D",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Unknown",
+              "label": "E",
+              "paletteIndex": 11,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
             }
           ],
           "refreshInterval": null,
-          "sortDirection": "Ascending",
-          "sortProperty": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
           "time": {
             "range": 900000,
             "type": "relative"
           },
-          "timestampHidden": false,
-          "type": "Heatmap",
+          "type": "List",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['host', 'kubernetes_cluster', 'kubernetes_node']).publish(label='A', enable=False)\nB = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['host']).publish(label='E', enable=False)\nC = (A/B).publish(label='C')",
+        "programText": "B = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count().publish(label='B')\nA = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count().publish(label='A')\nC = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(2.5, 3.5, low_inclusive=True, high_inclusive=True).count().publish(label='C')\nD = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(3.5, 4.5, low_inclusive=True, high_inclusive=True).count().publish(label='D')\nE = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(4.5, 5.5, low_inclusive=True, high_inclusive=True).count().publish(label='E')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -3866,43 +4772,353 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "",
-        "id": "D2SlXF0AcAE",
+        "description": "per cluster",
+        "id": "D8I6ZZfAYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "CPU Capacity Used per Node",
+        "name": "Memory Usage",
         "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
           },
-          "axes": [
+          "maximumPrecision": 4,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
             {
-              "highWatermark": 100,
-              "highWatermarkLabel": null,
-              "label": "cpu %",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
             }
           ],
-          "axisPrecision": null,
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_usage_bytes').sum(by=['kubernetes_cluster']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnHS4AgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Highest Memory Use per Pod (bytes)",
+        "options": {
           "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
           },
-          "includeZero": true,
+          "maximumPrecision": 4,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes'), extrapolation='last_value').sum(by=['kubernetes_pod_name']).mean(over='1m').top(count=10).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "grouped by namespace",
+        "id": "D2SlUA5AcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "CPU Usage per Pod",
+        "options": {
+          "colorBy": "Scale",
+          "colorRange": null,
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 80,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 60,
+              "gte": null,
+              "lt": null,
+              "lte": 80,
+              "paletteIndex": 17
+            },
+            {
+              "gt": 40,
+              "gte": null,
+              "lt": null,
+              "lte": 60,
+              "paletteIndex": 18
+            },
+            {
+              "gt": 20,
+              "gte": null,
+              "lt": null,
+              "lte": 40,
+              "paletteIndex": 19
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 20,
+              "paletteIndex": 20
+            }
+          ],
+          "groupBy": [
+            "kubernetes_namespace"
+          ],
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "conatiner centi-core usage",
+              "label": "A",
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null
+            },
+            {
+              "displayName": "num cores on host",
+              "label": "E",
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null
+            },
+            {
+              "displayName": "pod cpu usage",
+              "label": "C",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
+            }
+          ],
+          "refreshInterval": null,
+          "sortDirection": "Ascending",
+          "sortProperty": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "Heatmap",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['kubernetes_pod_name', 'host', 'kubernetes_pod_name', 'kubernetes_namespace', 'kubernetes_cluster', 'kubernetes_node']).publish(label='A', enable=False)\nB = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['host']).publish(label='E', enable=False)\nC = (A/B).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnAvVAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Deployments Not at Spec",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 0,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 0,
+              "paletteIndex": 14
+            }
+          ],
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "available pods",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "desired pods",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "pods desired but not available",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": 60000,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.deployment.available', extrapolation='zero').publish(label='A', enable=False)\nB = data('kubernetes.deployment.desired', extrapolation='zero').publish(label='B', enable=False)\nC = (B-A).above(0).count().publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Network receive and transmit errors from pods on this node",
+        "id": "D2SmSLNAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Network Errors by Interface",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_errors_total', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['interface']).publish(label='A')\nB = data('pod_network_transmit_errors_total', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['interface']).publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnBFnAcAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Net Pods Desired by Replica Set",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
           "legendOptions": {
             "fields": [
               {
@@ -3911,53 +5127,117 @@
               },
               {
                 "enabled": true,
-                "property": "sf_metric"
+                "property": "kubernetes_name"
               },
               {
-                "enabled": true,
-                "property": "kubernetes_node"
-              },
-              {
-                "enabled": true,
-                "property": "container_image"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_pod_name"
-              },
-              {
-                "enabled": true,
+                "enabled": false,
                 "property": "kubernetes_namespace"
               },
               {
-                "enabled": true,
-                "property": "metric_source"
-              },
-              {
-                "enabled": true,
-                "property": "container_name"
-              },
-              {
-                "enabled": true,
-                "property": "container_spec_name"
-              },
-              {
-                "enabled": true,
-                "property": "host"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_pod_uid"
-              },
-              {
-                "enabled": true,
+                "enabled": false,
                 "property": "sf_originatingMetric"
               },
               {
-                "enabled": true,
-                "property": "container_id"
+                "enabled": false,
+                "property": "metric_source"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "uid"
               }
             ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "available pods",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "desired pods",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "pods desired but not available",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.replica_set.available').publish(label='A', enable=False)\nB = data('kubernetes.replica_set.desired').publish(label='B', enable=False)\nC = (B-A).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnI_OAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "CPU Use per Pod (%)",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "%",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
           },
           "lineChartOptions": {
             "showDataMarkers": false
@@ -3974,47 +5254,47 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "centi-cores per cluster",
-              "label": "D",
+              "displayName": "CPU %",
+              "label": "A",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "# cores per cluster",
-              "label": "E",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Node CPU Capacity Usage %",
-              "label": "F",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "%",
               "valueUnit": null,
               "yAxis": 0
             }
           ],
-          "showEventLines": true,
-          "stacked": false,
+          "showEventLines": false,
+          "stacked": true,
           "time": {
-            "range": 900000,
+            "range": 3600001,
             "type": "relative"
           },
           "type": "TimeSeriesChart",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "D = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['kubernetes_node']).publish(label='D', enable=False)\nE = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['kubernetes_node']).publish(label='E', enable=False)\nF = (D/E).publish(label='F')",
+        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_pod_name']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SlVhwAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": ".",
+        "options": {
+          "markdown": "<table width=\"100%\" height=\"50%\" rules=\"none\"><tr><td valign=\"middle\" align=\"center\" bgcolor=\"#59a200\">\n<font size=\"5\" color=\"white\">K8s Pods</font>\n</td></tr></table>\n\n<p align=\"center\" ><br /><font>Charts below refer to the health of your Kubernetes Pods. Use the filters at the top to narrow down pods by Cluster, Namespace, Nodes, Services, or Deployments.  <br />\nService tag syncing was added with agent version <a href=\"https://github.com/signalfx/signalfx-agent/releases/tag/v4.1.0\" target=\"_blank\">v4.1.0</a> and deployment property syncing in <a href=\"https://github.com/signalfx/signalfx-agent/releases/tag/v4.3.0\" target=\"_blank\">v4.3.0</a>.<br></p></font>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -4089,451 +5369,97 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "",
-        "id": "DkBnBhCAYAA",
+        "description": "grouped by cluster",
+        "id": "D2SlUmAAYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Daemon Sets by Stage",
+        "name": "CPU Capacity Used per Node",
         "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": false,
-                "property": "kubernetes_cluster"
-              },
-              {
-                "enabled": false,
-                "property": "kubernetes_name"
-              },
-              {
-                "enabled": false,
-                "property": "kubernetes_namespace"
-              },
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": false,
-                "property": "metric_source"
-              },
-              {
-                "enabled": true,
-                "property": "sf_metric"
-              },
-              {
-                "enabled": false,
-                "property": "uid"
-              }
-            ]
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "current",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "desired",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "misscheduled",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "ready",
-              "label": "D",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "+kubernetes_cluster",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('kubernetes.daemon_set.current_scheduled').sum(by=['kubernetes_cluster']).publish(label='A')\nB = data('kubernetes.daemon_set.desired_scheduled').sum(by=['kubernetes_cluster']).publish(label='B')\nC = data('kubernetes.daemon_set.misscheduled').sum(by=['kubernetes_cluster']).publish(label='C')\nD = data('kubernetes.daemon_set.ready').sum(by=['kubernetes_cluster']).publish(label='D')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBm18SAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Network Throughput (bytes/sec)",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "Rx Bytes /sec (RED)",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "Tx Bytes /sec (BLUE)",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "ColumnChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Rx (bytes/sec)",
-              "label": "A",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Tx (bytes/sec)",
-              "label": "B",
-              "paletteIndex": 1,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 1
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 3600000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum().publish(label='A')\nB = data('pod_network_transmit_bytes_total', filter=filter('metric_source', 'kubernetes'), extrapolation='zero').sum().publish(label='B')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnJmPAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Highest CPU Use per Pod (%)",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).publish(label='A', enable=False)\nB = (A).sum(by=['kubernetes_pod_name']).mean(over='1m').top(count=10).publish(label='B')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "per cluster",
-        "id": "DkBnb_OAcAE",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Network Receieve Errors",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Rx (Bytes)",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Byte",
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_cluster']).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBncFkAYAI",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "# Containers per Cluster",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization').mean(over='1m').count(by=['kubernetes_cluster']).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnHS4AgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Highest Memory Use per Pod (bytes)",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": 4,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes'), extrapolation='last_value').sum(by=['kubernetes_pod_name']).mean(over='1m').top(count=10).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "number of pods that should be created by deployments",
-        "id": "D4rhWwPAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Desired Pods by Deployments",
-        "options": {
-          "colorBy": "Dimension",
+          "colorBy": "Scale",
+          "colorRange": null,
           "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": null,
+          "colorScale2": [
+            {
+              "gt": 80,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 60,
+              "gte": null,
+              "lt": null,
+              "lte": 80,
+              "paletteIndex": 17
+            },
+            {
+              "gt": 40,
+              "gte": null,
+              "lt": null,
+              "lte": 60,
+              "paletteIndex": 18
+            },
+            {
+              "gt": 20,
+              "gte": null,
+              "lt": null,
+              "lte": 40,
+              "paletteIndex": 19
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 20,
+              "paletteIndex": 20
+            }
+          ],
+          "groupBy": [
+            "kubernetes_cluster"
+          ],
           "programOptions": {
             "disableSampling": false,
-            "maxDelay": 0,
+            "maxDelay": null,
             "minimumResolution": 0,
             "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "",
+              "displayName": "conatiner centi-core usage",
               "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null
+            },
+            {
+              "displayName": "num cores on host",
+              "label": "E",
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null
+            },
+            {
+              "displayName": "node cpu usage",
+              "label": "C",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
             }
           ],
           "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
+          "sortDirection": "Ascending",
+          "sortProperty": null,
           "time": {
             "range": 900000,
             "type": "relative"
           },
           "timestampHidden": false,
-          "type": "SingleValue",
+          "type": "Heatmap",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('kubernetes.deployment.desired', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace']).sum().publish(label='A')",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['host', 'kubernetes_cluster', 'kubernetes_node']).publish(label='A', enable=False)\nB = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['host']).publish(label='E', enable=False)\nC = (A/B).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -4682,26 +5608,26 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBnB8XAcAA",
+        "id": "D2SmR8XAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Net Pods Desired by Replication Controller",
+        "name": "Top Nodes by Memory",
         "options": {
           "colorBy": "Dimension",
           "colorScale2": null,
           "legendOptions": {
             "fields": [
               {
+                "enabled": true,
+                "property": "host"
+              },
+              {
                 "enabled": false,
                 "property": "kubernetes_cluster"
               },
               {
-                "enabled": true,
-                "property": "kubernetes_name"
-              },
-              {
                 "enabled": false,
-                "property": "kubernetes_namespace"
+                "property": "kubernetes_role"
               },
               {
                 "enabled": false,
@@ -4716,836 +5642,24 @@
                 "property": "sf_metric"
               },
               {
-                "enabled": false,
-                "property": "uid"
-              }
-            ]
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "available pods",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "desired pods",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "pods desired but not available",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('kubernetes.replication_controller.available').publish(label='A', enable=False)\nB = data('kubernetes.replication_controller.desired').publish(label='B', enable=False)\nC = (B-A).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnCYRAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Container Restarts",
-        "options": {
-          "colorBy": "Scale",
-          "colorScale": null,
-          "colorScale2": [
-            {
-              "gt": 1,
-              "gte": null,
-              "lt": null,
-              "lte": null,
-              "paletteIndex": 16
-            },
-            {
-              "gt": null,
-              "gte": null,
-              "lt": null,
-              "lte": 1,
-              "paletteIndex": 14
-            }
-          ],
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "kubernetes.container_restart_count - Sum by kubernetes_cluster",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": null,
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('kubernetes.container_restart_count', rollup='sum').sum(by=['kubernetes_cluster']).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "number of pods ready by deploments",
-        "id": "D4rhW0NAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Available Pods by Deployments",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": 0,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('kubernetes.deployment.available', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_name', 'kubernetes_uid']).sum().publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Based on Kubernetes resource limits.  If no limits, will be blank.",
-        "id": "DkBm2N8AgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "% Memory Used per Container",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "container",
-              "label": "A",
-              "paletteIndex": 1,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "limit",
-              "label": "B",
-              "paletteIndex": 6,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 1
-            },
-            {
-              "displayName": "",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 3600001,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).publish(label='A', enable=False)\nB = data('container_spec_memory_limit_bytes', filter=filter('metric_source', 'kubernetes')).sum(by=['container_name']).above(0, inclusive=True).publish(label='B', enable=False)\nC = (A/B*100).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnBFnAcAE",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Net Pods Desired by Replica Set",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": false,
-                "property": "kubernetes_cluster"
+                "enabled": true,
+                "property": "machine_id"
               },
               {
                 "enabled": true,
-                "property": "kubernetes_name"
-              },
-              {
-                "enabled": false,
-                "property": "kubernetes_namespace"
-              },
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": false,
-                "property": "metric_source"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              },
-              {
-                "enabled": false,
-                "property": "uid"
-              }
-            ]
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "available pods",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "desired pods",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "pods desired but not available",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('kubernetes.replica_set.available').publish(label='A', enable=False)\nB = data('kubernetes.replica_set.desired').publish(label='B', enable=False)\nC = (B-A).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "D2SlWkWAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Desired Pods by Deployments",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": true,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": true,
-                "property": "kubernetes_name"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_namespace"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_cluster"
-              },
-              {
-                "enabled": false,
-                "property": "deployment"
-              },
-              {
-                "enabled": false,
-                "property": "kubernetes_uid"
-              },
-              {
-                "enabled": false,
-                "property": "kubernetes_deployment_uid"
-              },
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              }
-            ]
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": "kubernetes_name",
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": 0,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "desired pods",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "pods",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": true,
-          "stacked": true,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('kubernetes.deployment.desired', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_name']).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "D2SmSX4AgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "# Nodes",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['host']).mean(over='1m').count().publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBm2CNAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Network Errors / sec",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Rx",
-              "label": "A",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Tx",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "+sf_metric",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_errors_total', filter=filter('metric_source', 'kubernetes')).sum().publish(label='A')\nB = data('pod_network_transmit_errors_total', filter=filter('metric_source', 'kubernetes')).sum().publish(label='B')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "of all phases",
-        "id": "D2SlXplAcAE",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Total of Pods",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": "",
-              "valueSuffix": "pods",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='latest').count().publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "per cluster",
-        "id": "DkBnaH0AgFc",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Network Transmit Errors",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Tx (Bytes)",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Byte",
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "B = data('pod_network_transmit_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_cluster']).publish(label='B')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Network receive and transmit errors from pods on this node",
-        "id": "DkBnHTDAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Pod Network Errors by Interface",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": null
-          },
-          "maximumPrecision": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Rx",
-              "label": "A",
-              "paletteIndex": 4,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Tx",
-              "label": "B",
-              "paletteIndex": 1,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
-          "time": null,
-          "type": "List",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['interface']).publish(label='A')\nB = data('pod_network_transmit_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['interface']).publish(label='B')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "D2SlUbdAcDo",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "CPU Usage per Pod",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "cpu %",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": true,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": true,
-                "property": "kubernetes_pod_name"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_namespace"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_cluster"
+                "property": "AWSUniqueId"
               },
               {
                 "enabled": true,
                 "property": "kubernetes_node"
               },
               {
-                "enabled": false,
-                "property": "host"
-              },
-              {
                 "enabled": true,
-                "property": "sf_metric"
+                "property": "gcp_id"
               }
             ]
           },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
+          "maximumPrecision": 4,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
@@ -5554,103 +5668,7 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "conatiner centi-core usage",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": "",
-              "valueSuffix": "",
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "num cores on host",
-              "label": "E",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": "",
-              "valueSuffix": "",
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "pod cpu usage",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": "",
-              "valueSuffix": "%",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": true,
-          "stacked": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['kubernetes_pod_name', 'host', 'kubernetes_pod_name', 'kubernetes_namespace', 'kubernetes_cluster', 'kubernetes_node']).publish(label='A', enable=False)\nB = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['kubernetes_node']).publish(label='E', enable=False)\nC = (A/B).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnI_OAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "CPU Use per Pod (%)",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "%",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": 0
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "CPU %",
+              "displayName": "",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -5660,17 +5678,125 @@
               "yAxis": 0
             }
           ],
-          "showEventLines": false,
-          "stacked": true,
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
           "time": {
-            "range": 3600001,
+            "range": 900000,
             "type": "relative"
           },
-          "type": "TimeSeriesChart",
+          "type": "List",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('machine_memory_bytes', filter=filter('kubernetes_cluster', '*', match_missing=True)).mean(over='1m').top(count=10).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "per node",
+        "id": "D2SmUhoAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top 10 Nodes by Memory Capacity Used",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale2": [
+            {
+              "gt": 80,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 60,
+              "gte": null,
+              "lt": null,
+              "lte": 80,
+              "paletteIndex": 17
+            },
+            {
+              "gt": 40,
+              "gte": null,
+              "lt": null,
+              "lte": 60,
+              "paletteIndex": 18
+            },
+            {
+              "gt": 20,
+              "gte": null,
+              "lt": null,
+              "lte": 40,
+              "paletteIndex": 19
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 20,
+              "paletteIndex": 20
+            }
+          ],
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": 3,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "memory usage per node",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "memory capacity per node",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "",
+              "label": "F",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_pod_name']).publish(label='A')",
+        "programText": "D = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'host']).mean(over='1m').publish(label='D', enable=False)\nE = data('machine_memory_bytes', filter=filter('kubernetes_cluster', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'host']).mean(over='1m').publish(label='E', enable=False)\nF = (D/E).scale(100).top(count=10).publish(label='F')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -5681,16 +5807,93 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "D2SlUMWAYAA",
+        "id": "DkBnJQ3AYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": ".",
+        "name": "Total # Pods",
         "options": {
-          "markdown": "<table width=\"100%\" height=\"50%\" rules=\"none\"><tr><td valign=\"middle\" align=\"center\" bgcolor=\"#59a200\">\n<font size=\"5\" color=\"white\">K8s Nodes</font>\n</td></tr></table>\n\n<p align=\"center\" ><br /><font>This dashboard is populated by the metrics emitted from the <a href=\"https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-cluster.html\" target=\"_blank\">kubernetes-cluster</a> monitor and  <a href=\"https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubelet-stats.html\" target=\"_blank\">kubelet-stats</a> . Charts below refer to the health of your Kubernetes Nodes. When filtered by Deployment or Service, charts below will be filtered by the selected pods running on the nodes.<br></p></font>",
-          "type": "Text"
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "container_cpu_utilization - Sum by kubernetes_pod_name - Mean(1m) - Count",
+              "label": "A",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "",
+        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes'), extrapolation='last_value').sum(by=['kubernetes_pod_name']).mean(over='1m').count().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "created by Deployments",
+        "id": "D2SlXg8AYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Available Pods",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kubernetes.deployment.available', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('deployment', '*', match_missing=True), rollup='latest').sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_name']).sum().publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -5808,78 +6011,16 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "",
-        "id": "D4rhZ6mAgCU",
+        "description": "This may include \"pause\" containers used internally by K8s",
+        "id": "D4rhZLXAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "CPU Usage per Pod",
+        "name": "# Active Pods",
         "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
           "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": true,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": true,
-                "property": "kubernetes_pod_name"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_namespace"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_cluster"
-              },
-              {
-                "enabled": true,
-                "property": "kubernetes_node"
-              },
-              {
-                "enabled": false,
-                "property": "host"
-              },
-              {
-                "enabled": true,
-                "property": "sf_metric"
-              }
-            ]
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
@@ -5888,47 +6029,29 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "conatiner centi-core usage",
+              "displayName": "number of pods",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
-              "valuePrefix": "",
-              "valueSuffix": "",
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "num cores on host",
-              "label": "E",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": "",
-              "valueSuffix": "",
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "pod cpu usage",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": "",
-              "valueSuffix": "%",
+              "valuePrefix": null,
+              "valueSuffix": null,
               "valueUnit": null,
               "yAxis": 0
             }
           ],
-          "showEventLines": true,
-          "stacked": false,
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
           "time": {
             "range": 900000,
             "type": "relative"
           },
-          "type": "TimeSeriesChart",
+          "timestampHidden": false,
+          "type": "SingleValue",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['kubernetes_pod_name', 'host', 'kubernetes_pod_name', 'kubernetes_namespace', 'kubernetes_cluster', 'kubernetes_node']).publish(label='A', enable=False)\nB = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['kubernetes_node']).publish(label='E', enable=False)\nC = (A/B).publish(label='C')",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'kubernetes_pod_uid']).count().publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -5939,10 +6062,10 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "D4rhWtQAgAA",
+        "id": "D2SlWE-AcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Network Errors / sec",
+        "name": "# of Pods by Phase",
         "options": {
           "colorBy": "Dimension",
           "colorScale2": null,
@@ -5958,9 +6081,98 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "Rx",
+              "displayName": "Running",
+              "label": "B",
+              "paletteIndex": 15,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Pending",
               "label": "A",
+              "paletteIndex": 6,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Succeeded",
+              "label": "C",
+              "paletteIndex": 2,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Failed",
+              "label": "D",
               "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Unknown",
+              "label": "E",
+              "paletteIndex": 11,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "pods",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "+sf_originatingMetric",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "B = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count().publish(label='B')\nA = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count().publish(label='A')\nC = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(2.5, 3.5, low_inclusive=True, high_inclusive=True).count().publish(label='C')\nD = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(3.5, 4.5, low_inclusive=True, high_inclusive=True).count().publish(label='D')\nE = data('kubernetes.pod_phase', filter=filter('kubernetes_namespace', '*') and filter('kubernetes_cluster', '*') and filter('deployment', '*', match_missing=True) and filter('kubernetes_node', '*') and filter('sf_tags', '*', match_missing=True), rollup='latest').between(4.5, 5.5, low_inclusive=True, high_inclusive=True).count().publish(label='E')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "DkBnJksAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Total Memory (bytes)",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": 4,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "machine_memory_bytes - Sum",
+              "label": "A",
+              "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -5968,9 +6180,131 @@
               "yAxis": 0
             },
             {
-              "displayName": "Tx",
+              "displayName": "A/1024/1024",
               "label": "B",
               "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": null,
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('machine_memory_bytes', filter=filter('metric_source', 'kubernetes')).sum().publish(label='A')\nB = (A/1024/1024).publish(label='B', enable=False)",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "per cluster",
+        "id": "D8I6YG3AYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Network Receieve Errors",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": null
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx (Bytes)",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "sortBy": "-value",
+          "time": null,
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_errors_total', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_cluster']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D2SmTISAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top Nodes by # Pods",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "host"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": true,
+                "property": "machine_id"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "# of Pods per Node",
+              "label": "A",
+              "paletteIndex": 1,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -5980,7 +6314,7 @@
           ],
           "refreshInterval": null,
           "secondaryVisualization": "Sparkline",
-          "sortBy": "+sf_metric",
+          "sortBy": "-value",
           "time": {
             "range": 900000,
             "type": "relative"
@@ -5989,112 +6323,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('pod_network_receive_errors_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True) ).sum().publish(label='A')\nB = data('pod_network_transmit_errors_total', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True) ).sum().publish(label='B')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Based on Kubernetes resource limits.  If no limits, will be blank.",
-        "id": "D4rhaiFAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "% Memory Used per Pod",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "% memory used",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": 110,
-              "min": null
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": true,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "container",
-              "label": "A",
-              "paletteIndex": 1,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "limit",
-              "label": "B",
-              "paletteIndex": 6,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 3600000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_memory_usage_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).publish(label='A', enable=False)\nB = data('container_spec_memory_limit_bytes', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_deployment_name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['kubernetes_pod_name']).above(0, inclusive=True).publish(label='B', enable=False)\nC = (A/B*100).publish(label='C')",
+        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*', match_missing=True), extrapolation='last_value').sum(by=['kubernetes_pod_name']).mean(over='1m').count(by=['kubernetes_node']).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -6105,233 +6334,10 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "DkBnHSwAcAA",
+        "id": "DkBnHTuAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Memory Use per Pod (bytes)",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "bytes",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "memory use (bytes)",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 3600000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Binary"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_memory_usage_bytes', filter=filter('metric_source', 'kubernetes')).sum(by=['kubernetes_pod_name']).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "grouped by namespace",
-        "id": "D2SlUA5AcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "CPU Usage per Pod",
-        "options": {
-          "colorBy": "Scale",
-          "colorRange": null,
-          "colorScale": null,
-          "colorScale2": [
-            {
-              "gt": 80,
-              "gte": null,
-              "lt": null,
-              "lte": null,
-              "paletteIndex": 16
-            },
-            {
-              "gt": 60,
-              "gte": null,
-              "lt": null,
-              "lte": 80,
-              "paletteIndex": 17
-            },
-            {
-              "gt": 40,
-              "gte": null,
-              "lt": null,
-              "lte": 60,
-              "paletteIndex": 18
-            },
-            {
-              "gt": 20,
-              "gte": null,
-              "lt": null,
-              "lte": 40,
-              "paletteIndex": 19
-            },
-            {
-              "gt": null,
-              "gte": null,
-              "lt": null,
-              "lte": 20,
-              "paletteIndex": 20
-            }
-          ],
-          "groupBy": [
-            "kubernetes_namespace"
-          ],
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "conatiner centi-core usage",
-              "label": "A",
-              "valuePrefix": "",
-              "valueSuffix": "",
-              "valueUnit": null
-            },
-            {
-              "displayName": "num cores on host",
-              "label": "E",
-              "valuePrefix": "",
-              "valueSuffix": "",
-              "valueUnit": null
-            },
-            {
-              "displayName": "pod cpu usage",
-              "label": "C",
-              "valuePrefix": "",
-              "valueSuffix": "%",
-              "valueUnit": null
-            }
-          ],
-          "refreshInterval": null,
-          "sortDirection": "Ascending",
-          "sortProperty": null,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "timestampHidden": false,
-          "type": "Heatmap",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_namespace', '*') and filter('kubernetes_node', '*') and filter('deployment', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['kubernetes_pod_name', 'host', 'kubernetes_pod_name', 'kubernetes_namespace', 'kubernetes_cluster', 'kubernetes_node']).publish(label='A', enable=False)\nB = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('kubernetes_node', '*')).sum(by=['host']).publish(label='E', enable=False)\nC = (A/B).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnaELAcAE",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "# Clusters",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": 3,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "",
-              "label": "D",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": null,
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "D = data('container_cpu_utilization').sum(by=['kubernetes_cluster']).mean(over='1m').count().publish(label='D')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "DkBnJQ3AYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Total # Pods",
+        "name": "Total # CPU Cores",
         "options": {
           "colorBy": "Dimension",
           "colorScale": null,
@@ -6345,9 +6351,9 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "container_cpu_utilization - Sum by kubernetes_pod_name - Mean(1m) - Count",
+              "displayName": "cpu cores",
               "label": "A",
-              "paletteIndex": 1,
+              "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -6364,7 +6370,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('container_cpu_utilization', filter=filter('metric_source', 'kubernetes'), extrapolation='last_value').sum(by=['kubernetes_pod_name']).mean(over='1m').count().publish(label='A')",
+        "programText": "A = data('machine_cpu_cores', filter=filter('metric_source', 'kubernetes')).sum().mean(over='1m').publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -6377,64 +6383,57 @@
         "chartDensity": "DEFAULT",
         "charts": [
           {
-            "chartId": "D2SmSX4AgAA",
-            "column": 0,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "D2SmSKEAYAA",
-            "column": 8,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "D2SmR8XAgAA",
+            "chartId": "D8I_-tTAcAA",
             "column": 4,
             "height": 1,
             "row": 0,
             "width": 4
           },
           {
-            "chartId": "D2SmUQbAgAA",
-            "column": 4,
+            "chartId": "D8I_-iEAgAA",
+            "column": 0,
             "height": 1,
-            "row": 1,
+            "row": 0,
             "width": 4
           },
           {
-            "chartId": "D2SmTISAcAA",
+            "chartId": "D8I_-rWAgAA",
+            "column": 8,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "D8I_-j7AcAA",
             "column": 0,
             "height": 1,
             "row": 1,
             "width": 4
           },
           {
-            "chartId": "D2SmUhoAYAA",
+            "chartId": "D8JAAiDAgAA",
+            "column": 4,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "D8I_-3UAYAA",
             "column": 8,
             "height": 1,
             "row": 1,
             "width": 4
           },
           {
-            "chartId": "D2SmSj3AYAA",
+            "chartId": "D8I_-n1AYAA",
             "column": 4,
             "height": 1,
             "row": 2,
             "width": 4
           },
           {
-            "chartId": "D2SmUtjAcAA",
+            "chartId": "D8I_-flAYAA",
             "column": 0,
-            "height": 1,
-            "row": 2,
-            "width": 4
-          },
-          {
-            "chartId": "D2SmSLNAcAA",
-            "column": 8,
             "height": 1,
             "row": 2,
             "width": 4
@@ -6443,9 +6442,218 @@
         "created": 0,
         "creator": null,
         "customProperties": null,
-        "description": "An overview of multiple Kubernetes nodes",
+        "description": "",
         "discoveryOptions": {
-          "query": "_exists_:kubernetes_cluster AND _exists_:host",
+          "query": "_exists_:kubernetes_pod_name AND _exists_:kubernetes_cluster",
+          "selectors": [
+            "_exists_:kubernetes_pod_name"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": [
+            {
+              "alias": "Pod",
+              "applyIfExists": false,
+              "description": "",
+              "preferredSuggestions": [],
+              "property": "kubernetes_pod_name",
+              "replaceOnly": false,
+              "required": true,
+              "restricted": false,
+              "value": [
+                "Choose a Pod"
+              ]
+            }
+          ]
+        },
+        "groupId": "DiVWf-iAgAA",
+        "id": "D8I_-P3AcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "maxDelayOverride": null,
+        "name": "K8s Pod",
+        "selectedEventOverlays": [],
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "D8I6ZUjAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "D8I6Zv0AcAA",
+            "column": 8,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "D8I6ZjWAgAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "D8I6ZNBAgAQ",
+            "column": 0,
+            "height": 2,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "D8I6Z29AYAA",
+            "column": 8,
+            "height": 2,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "D8I6ZZfAYAA",
+            "column": 4,
+            "height": 2,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "D8I6aRTAgAA",
+            "column": 6,
+            "height": 1,
+            "row": 3,
+            "width": 6
+          },
+          {
+            "chartId": "D8I6YG3AYAA",
+            "column": 0,
+            "height": 1,
+            "row": 3,
+            "width": 6
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "",
+        "discoveryOptions": {
+          "query": "sf_metric:cpu.utilization AND _exists_:kubernetes_cluster",
+          "selectors": [
+            "_exists_:kubernetes_cluster"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": null
+        },
+        "groupId": "DiVWf-iAgAA",
+        "id": "D8I6X2QAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "maxDelayOverride": null,
+        "name": "K8s Clusters",
+        "selectedEventOverlays": [],
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DkBnAvVAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnAW2AgAI",
+            "column": 8,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnCXLAgAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnCYRAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnCMpAgAA",
+            "column": 8,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnCUjAYAA",
+            "column": 4,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnCV1AcAA",
+            "column": 0,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnBZnAgAA",
+            "column": 4,
+            "height": 1,
+            "row": 2,
+            "width": 8
+          },
+          {
+            "chartId": "DkBnBhCAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnB8XAcAA",
+            "column": 8,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnBFnAcAE",
+            "column": 4,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "",
+        "discoveryOptions": {
+          "query": "metric_source:kubernetes",
           "selectors": [
             "sf_key:kubernetes_cluster"
           ]
@@ -6458,23 +6666,137 @@
             {
               "alias": "Cluster",
               "applyIfExists": false,
-              "description": "Kubernetes Cluster Name",
+              "description": "k8s cluster",
               "preferredSuggestions": [],
               "property": "kubernetes_cluster",
-              "replaceOnly": true,
-              "required": false,
+              "replaceOnly": false,
+              "required": true,
               "restricted": false,
               "value": ""
             }
           ]
         },
         "groupId": "DiVWf-iAgAA",
-        "id": "D2SmRRbAcAA",
+        "id": "DkBm_nVAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "locked": false,
         "maxDelayOverride": null,
-        "name": "K8s Nodes",
+        "name": "K8s Operations",
+        "selectedEventOverlays": [],
+        "tags": null
+      }
+    },
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "DkBnJQ3AYAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnHTuAcAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnJksAcAA",
+            "column": 8,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnHSwAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 6
+          },
+          {
+            "chartId": "DkBnI_OAcAA",
+            "column": 6,
+            "height": 1,
+            "row": 1,
+            "width": 6
+          },
+          {
+            "chartId": "DkBnHTDAYAA",
+            "column": 8,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnJmPAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnHS4AgAA",
+            "column": 4,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "DkBnJHhAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 3,
+            "width": 6
+          },
+          {
+            "chartId": "DkBnHZUAgAA",
+            "column": 6,
+            "height": 1,
+            "row": 3,
+            "width": 6
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": null,
+        "discoveryOptions": {
+          "query": "_exists_:kubernetes_cluster AND _exists_:host",
+          "selectors": [
+            "_exists_:host"
+          ]
+        },
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": [
+            {
+              "alias": "Node",
+              "applyIfExists": false,
+              "description": "K8s Node",
+              "preferredSuggestions": [],
+              "property": "host",
+              "replaceOnly": false,
+              "required": true,
+              "restricted": false,
+              "value": [
+                "Choose a Node"
+              ]
+            }
+          ]
+        },
+        "groupId": "DiVWf-iAgAA",
+        "id": "DkBnHSpAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "maxDelayOverride": null,
+        "name": "K8s Node",
         "selectedEventOverlays": [],
         "tags": null
       }
@@ -6686,7 +7008,6 @@
         "id": "D2SlSb5AgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "locked": false,
         "maxDelayOverride": null,
         "name": "K8s Overview",
         "selectedEventOverlays": [],
@@ -6698,303 +7019,75 @@
         "chartDensity": "DEFAULT",
         "charts": [
           {
-            "chartId": "DkBnJQ3AYAA",
+            "chartId": "D2SmSX4AgAA",
             "column": 0,
             "height": 1,
             "row": 0,
             "width": 4
           },
           {
-            "chartId": "DkBnHTuAcAA",
-            "column": 4,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnJksAcAA",
+            "chartId": "D2SmSKEAYAA",
             "column": 8,
             "height": 1,
             "row": 0,
             "width": 4
           },
           {
-            "chartId": "DkBnHSwAcAA",
+            "chartId": "D2SmR8XAgAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "D2SmUQbAgAA",
+            "column": 4,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "D2SmTISAcAA",
             "column": 0,
             "height": 1,
             "row": 1,
-            "width": 6
+            "width": 4
           },
           {
-            "chartId": "DkBnI_OAcAA",
-            "column": 6,
-            "height": 1,
-            "row": 1,
-            "width": 6
-          },
-          {
-            "chartId": "DkBnHTDAYAA",
+            "chartId": "D2SmUhoAYAA",
             "column": 8,
             "height": 1,
-            "row": 2,
+            "row": 1,
             "width": 4
           },
           {
-            "chartId": "DkBnJmPAgAA",
-            "column": 0,
-            "height": 1,
-            "row": 2,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnHS4AgAA",
+            "chartId": "D2SmSj3AYAA",
             "column": 4,
             "height": 1,
             "row": 2,
             "width": 4
           },
           {
-            "chartId": "DkBnJHhAgAA",
+            "chartId": "D2SmUtjAcAA",
             "column": 0,
             "height": 1,
-            "row": 3,
-            "width": 6
+            "row": 2,
+            "width": 4
           },
           {
-            "chartId": "DkBnHZUAgAA",
-            "column": 6,
+            "chartId": "D2SmSLNAcAA",
+            "column": 8,
             "height": 1,
-            "row": 3,
-            "width": 6
+            "row": 2,
+            "width": 4
           }
         ],
         "created": 0,
         "creator": null,
         "customProperties": null,
-        "description": null,
+        "description": "An overview of multiple Kubernetes nodes",
         "discoveryOptions": {
           "query": "_exists_:kubernetes_cluster AND _exists_:host",
-          "selectors": [
-            "_exists_:host"
-          ]
-        },
-        "eventOverlays": null,
-        "filters": {
-          "sources": null,
-          "time": null,
-          "variables": [
-            {
-              "alias": "host",
-              "applyIfExists": false,
-              "description": "K8s node",
-              "preferredSuggestions": [],
-              "property": "host",
-              "replaceOnly": false,
-              "required": true,
-              "restricted": false,
-              "value": ""
-            }
-          ]
-        },
-        "groupId": "DiVWf-iAgAA",
-        "id": "DkBnHSpAYAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "locked": false,
-        "maxDelayOverride": null,
-        "name": "K8s Node",
-        "selectedEventOverlays": [],
-        "tags": null
-      }
-    },
-    {
-      "dashboard": {
-        "chartDensity": "DEFAULT",
-        "charts": [
-          {
-            "chartId": "DkBm18SAgAA",
-            "column": 4,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBm2ftAYCM",
-            "column": 0,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBm2CNAYAA",
-            "column": 8,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBm2N8AgAA",
-            "column": 0,
-            "height": 1,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBm16iAcAA",
-            "column": 4,
-            "height": 1,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBm2FzAcAA",
-            "column": 8,
-            "height": 1,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBm2jfAcDo",
-            "column": 4,
-            "height": 1,
-            "row": 2,
-            "width": 4
-          },
-          {
-            "chartId": "DkBm1ulAYAA",
-            "column": 0,
-            "height": 1,
-            "row": 2,
-            "width": 4
-          }
-        ],
-        "created": 0,
-        "creator": null,
-        "customProperties": null,
-        "description": null,
-        "discoveryOptions": {
-          "query": "_exists_:kubernetes_pod_name AND _exists_:kubernetes_cluster",
-          "selectors": [
-            "_exists_:kubernetes_pod_name"
-          ]
-        },
-        "eventOverlays": null,
-        "filters": {
-          "sources": null,
-          "time": null,
-          "variables": [
-            {
-              "alias": "pod",
-              "applyIfExists": false,
-              "description": "K8s pod",
-              "preferredSuggestions": [],
-              "property": "kubernetes_pod_name",
-              "replaceOnly": false,
-              "required": true,
-              "restricted": false,
-              "value": null
-            }
-          ]
-        },
-        "groupId": "DiVWf-iAgAA",
-        "id": "DkBm1lEAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "locked": false,
-        "maxDelayOverride": null,
-        "name": "K8s Pod",
-        "selectedEventOverlays": [],
-        "tags": null
-      }
-    },
-    {
-      "dashboard": {
-        "chartDensity": "DEFAULT",
-        "charts": [
-          {
-            "chartId": "DkBnAvVAYAA",
-            "column": 0,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnAW2AgAI",
-            "column": 8,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnCXLAgAA",
-            "column": 4,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnCYRAYAA",
-            "column": 0,
-            "height": 1,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnCMpAgAA",
-            "column": 8,
-            "height": 1,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnCUjAYAA",
-            "column": 4,
-            "height": 1,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnCV1AcAA",
-            "column": 0,
-            "height": 1,
-            "row": 2,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnBZnAgAA",
-            "column": 4,
-            "height": 1,
-            "row": 2,
-            "width": 8
-          },
-          {
-            "chartId": "DkBnBhCAYAA",
-            "column": 0,
-            "height": 1,
-            "row": 3,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnB8XAcAA",
-            "column": 8,
-            "height": 1,
-            "row": 3,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnBFnAcAE",
-            "column": 4,
-            "height": 1,
-            "row": 3,
-            "width": 4
-          }
-        ],
-        "created": 0,
-        "creator": null,
-        "customProperties": null,
-        "description": "",
-        "discoveryOptions": {
-          "query": "metric_source:kubernetes",
           "selectors": [
             "sf_key:kubernetes_cluster"
           ]
@@ -7007,111 +7100,22 @@
             {
               "alias": "Cluster",
               "applyIfExists": false,
-              "description": "k8s cluster",
+              "description": "Kubernetes Cluster Name",
               "preferredSuggestions": [],
               "property": "kubernetes_cluster",
-              "replaceOnly": false,
-              "required": true,
+              "replaceOnly": true,
+              "required": false,
               "restricted": false,
               "value": ""
             }
           ]
         },
         "groupId": "DiVWf-iAgAA",
-        "id": "DkBm_nVAcAA",
+        "id": "D2SmRRbAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "locked": false,
         "maxDelayOverride": null,
-        "name": "K8s Operations",
-        "selectedEventOverlays": [],
-        "tags": null
-      }
-    },
-    {
-      "dashboard": {
-        "chartDensity": "DEFAULT",
-        "charts": [
-          {
-            "chartId": "DkBnaELAcAE",
-            "column": 0,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBncFkAYAI",
-            "column": 8,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnaDJAYAA",
-            "column": 4,
-            "height": 1,
-            "row": 0,
-            "width": 4
-          },
-          {
-            "chartId": "DkBncDiAgAI",
-            "column": 0,
-            "height": 2,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnb24AYAA",
-            "column": 8,
-            "height": 2,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnaCuAgDg",
-            "column": 4,
-            "height": 2,
-            "row": 1,
-            "width": 4
-          },
-          {
-            "chartId": "DkBnaH0AgFc",
-            "column": 6,
-            "height": 1,
-            "row": 3,
-            "width": 6
-          },
-          {
-            "chartId": "DkBnb_OAcAE",
-            "column": 0,
-            "height": 1,
-            "row": 3,
-            "width": 6
-          }
-        ],
-        "created": 0,
-        "creator": null,
-        "customProperties": null,
-        "description": null,
-        "discoveryOptions": {
-          "query": "sf_metric:cpu.utilization AND _exists_:kubernetes_cluster",
-          "selectors": [
-            "_exists_:kubernetes_cluster"
-          ]
-        },
-        "eventOverlays": null,
-        "filters": {
-          "sources": null,
-          "time": null,
-          "variables": null
-        },
-        "groupId": "DiVWf-iAgAA",
-        "id": "DkBnZ_qAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "locked": false,
-        "maxDelayOverride": null,
-        "name": "K8s Clusters",
+        "name": "K8s Nodes",
         "selectedEventOverlays": [],
         "tags": null
       }
@@ -7272,7 +7276,6 @@
         "id": "D4rhV71AcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "locked": false,
         "maxDelayOverride": null,
         "name": "K8s Pods",
         "selectedEventOverlays": [],
@@ -7286,12 +7289,12 @@
       "creator": null,
       "dashboards": [
         "D2SlSb5AgAA",
-        "DkBnZ_qAcAA",
+        "D8I6X2QAcAA",
         "DkBnHSpAYAA",
         "D2SmRRbAcAA",
         "DkBm_nVAcAA",
-        "DkBm1lEAgAA",
-        "D4rhV71AcAA"
+        "D4rhV71AcAA",
+        "D8I_-P3AcAA"
       ],
       "description": "Dashboards about Kubernetes clusters, nodes and pods.",
       "email": null,
@@ -7316,7 +7319,7 @@
       "teams": null
     }
   },
-  "hashCode": 157101201,
+  "hashCode": -1709408311,
   "id": "DiVWf-iAgAA",
   "modelVersion": 1,
   "packageType": "GROUP"


### PR DESCRIPTION
Count by `kubernetes.node_ready` instead of `container_cpu_utilization` because users with large clusters may return over 10k MTSs for container_cpu_utilization, causing us to show lower value than the actual count. 