### PR TITLE
AWS Overview nav: change elb query

### DIFF
--- a/navigators/AWS/aws architecture.json
+++ b/navigators/AWS/aws architecture.json
@@ -1,119 +1,6 @@
 {
-  "hashCode" : -392695114,
+  "hashCode" : -926133045,
   "id" : "DiVVFONAYAA",
-  "importQualifiers" : [ {
-    "filters" : [ {
-      "not" : false,
-      "property" : "namespace",
-      "values" : [ "AWS/SQS" ]
-    } ],
-    "metric" : "ApproximateNumberOfMessagesVisible"
-  }, {
-    "filters" : [ {
-      "not" : false,
-      "property" : "namespace",
-      "values" : [ "AWS/SQS" ]
-    } ],
-    "metric" : "ApproximateNumberOfMessagesNotVisible"
-  }, {
-    "filters" : [ {
-      "not" : false,
-      "property" : "namespace",
-      "values" : [ "AWS/SQS" ]
-    } ],
-    "metric" : "ApproximateNumberOfMessagesDelayed"
-  }, {
-    "filters" : [ {
-      "not" : false,
-      "property" : "namespace",
-      "values" : [ "AWS/RDS" ]
-    } ],
-    "metric" : "DatabaseConnections"
-  }, {
-    "filters" : [ {
-      "not" : false,
-      "property" : "namespace",
-      "values" : [ "AWS/EC2" ]
-    } ],
-    "metric" : "CPUUtilization"
-  }, {
-    "filters" : [ {
-      "not" : false,
-      "property" : "namespace",
-      "values" : [ "AWS/SNS" ]
-    } ],
-    "metric" : "NumberOfNotificationsDelivered"
-  }, {
-    "filters" : [ {
-      "not" : false,
-      "property" : "namespace",
-      "values" : [ "AWS/SNS" ]
-    } ],
-    "metric" : "NumberOfNotificationsFailed"
-  }, {
-    "filters" : [ {
-      "not" : false,
-      "property" : "namespace",
-      "values" : [ "AWS/ElastiCache" ]
-    } ],
-    "metric" : "CurrConnections"
-  }, {
-    "filters" : [ {
-      "not" : false,
-      "property" : "namespace",
-      "values" : [ "AWS/CloudFront" ]
-    } ],
-    "metric" : "TotalErrorRate"
-  }, {
-    "filters" : [ {
-      "not" : false,
-      "property" : "namespace",
-      "values" : [ "AWS/ELB" ]
-    } ],
-    "metric" : "RequestCount"
-  }, {
-    "filters" : [ {
-      "not" : false,
-      "property" : "namespace",
-      "values" : [ "AWS/EBS" ]
-    } ],
-    "metric" : "VolumeReadOps"
-  }, {
-    "filters" : [ {
-      "not" : false,
-      "property" : "namespace",
-      "values" : [ "AWS/EBS" ]
-    } ],
-    "metric" : "VolumeWriteOps"
-  }, {
-    "filters" : [ {
-      "not" : false,
-      "property" : "namespace",
-      "values" : [ "AWS/ECS" ]
-    } ],
-    "metric" : "CPUReservation"
-  }, {
-    "filters" : [ {
-      "not" : false,
-      "property" : "namespace",
-      "values" : [ "AWS/DynamoDB" ]
-    } ],
-    "metric" : "ThrottledRequests"
-  }, {
-    "filters" : [ {
-      "not" : false,
-      "property" : "sf_key",
-      "values" : [ "FunctionName" ]
-    } ],
-    "metric" : "Invocations"
-  }, {
-    "filters" : [ {
-      "not" : false,
-      "property" : "sf_key",
-      "values" : [ "aws_function_name" ]
-    } ],
-    "metric" : "function.invocations"
-  } ],
   "modelVersion" : 1,
   "navigatorExport" : {
     "navigator" : {
@@ -267,7 +154,7 @@
           "job" : {
             "filters" : [ ],
             "resolution" : 60000,
-            "template" : "APPROX_VISIBLE_MSGS = data(\"ApproximateNumberOfMessagesVisible\", filter=filter(\"namespace\", \"AWS/SQS\") and filter(\"stat\", \"mean\") and filter(\"QueueName\", \"*\") and filter(\"aws_region\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"QueueName\", \"aws_region\"])\nAPPROX_NOT_VISIBLE_MSGS = data(\"ApproximateNumberOfMessagesNotVisible\", filter=filter(\"namespace\", \"AWS/SQS\") and filter(\"stat\", \"mean\") and filter(\"QueueName\", \"*\") and filter(\"aws_region\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"QueueName\", \"aws_region\"])\nAPPROX_MESSAGES_DELAYED= data(\"ApproximateNumberOfMessagesDelayed\", filter=filter(\"namespace\", \"AWS/SQS\") and filter(\"stat\", \"mean\") and filter(\"QueueName\", \"*\") and filter(\"aws_region\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"QueueName\", \"aws_region\"])\nCURRENT_QUEUE_SIZE = (APPROX_VISIBLE_MSGS + APPROX_NOT_VISIBLE_MSGS + APPROX_MESSAGES_DELAYED).mean(by=[\"QueueName\",\"aws_region\"])\nRDS = data(\"DatabaseConnections\", filter=filter(\"namespace\", \"AWS/RDS\") and filter(\"stat\", \"mean\") and filter(\"DBInstanceIdentifier\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"DBInstanceIdentifier\"])\nEC2 = data(\"CPUUtilization\", filter=filter(\"stat\", \"mean\") and filter(\"namespace\", \"AWS/EC2\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"InstanceId\"])\nNOTIFICATIONS_DELIVERED1 = data(\"NumberOfNotificationsDelivered\", filter=filter(\"namespace\", \"AWS/SNS\") and filter(\"stat\", \"sum\") and filter(\"TopicName\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"TopicName\"])\nNOTIFICATIONS_FAILED1 = data(\"NumberOfNotificationsFailed\", filter=filter(\"namespace\", \"AWS/SNS\") and filter(\"stat\", \"sum\") and filter(\"TopicName\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"TopicName\"])\nDELIVERY_SUCCESS = ((NOTIFICATIONS_DELIVERED1 / (NOTIFICATIONS_DELIVERED1 + NOTIFICATIONS_FAILED1)) * 100)\nELASTICACHE_CONNECTIONS = data(\"CurrConnections\", filter=filter(\"stat\", \"mean\") and filter(\"namespace\", \"AWS/ElastiCache\") and filter(\"CacheNodeId\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"CacheClusterId\", \"CacheNodeId\", \"aws_region\"])\nCDN = data(\"TotalErrorRate\", filter=filter(\"namespace\", \"AWS/CloudFront\") and filter(\"stat\", \"mean\") and filter(\"DistributionId\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"DistributionId\"])\nELB = data(\"RequestCount\", filter=filter(\"namespace\", \"AWS/ELB\") and filter(\"stat\", \"sum\") and filter(\"AvailabilityZone\", \"*\") and filter(\"LoadBalancerName\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).scale(60).sum(by=[\"LoadBalancerName\"])\nEBS_READOPS1 = data(\"VolumeReadOps\", filter=filter(\"namespace\", \"AWS/EBS\") and filter(\"stat\", \"sum\") and filter(\"VolumeId\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"VolumeId\"]).scale(60)\nEBS_WRITEOPS1 = data(\"VolumeWriteOps\", filter=filter(\"namespace\", \"AWS/EBS\") and filter(\"stat\", \"sum\") and filter(\"VolumeId\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"VolumeId\"]).scale(60)\nTOTAL_IOPS = (EBS_READOPS1 + EBS_WRITEOPS1)\nECS_CPU_RESERVATION = data(\"CPUReservation\", filter=filter(\"namespace\", \"AWS/ECS\") and filter(\"stat\", \"mean\") and filter(\"ClusterName\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"ClusterName\"])\nTHROTTLED_REQUESTS = data(\"ThrottledRequests\", filter=filter(\"namespace\", \"AWS/DynamoDB\") and filter(\"stat\", \"sum\") and filter(\"TableName\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"TableName\"]).scale(60)\ninvocations_from_cw = data(\"Invocations\", filter=filter(\"FunctionName\", \"*\") and filter(\"stat\", \"sum\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\ninvocations_from_wrapper = data(\"function.invocations\", filter=filter(\"lambda_arn\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\nINVOCATIONS = union(invocations_from_cw, invocations_from_wrapper)",
+            "template" : "APPROX_VISIBLE_MSGS = data(\"ApproximateNumberOfMessagesVisible\", filter=filter(\"namespace\", \"AWS/SQS\") and filter(\"stat\", \"mean\") and filter(\"QueueName\", \"*\") and filter(\"aws_region\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"QueueName\", \"aws_region\"])\nAPPROX_NOT_VISIBLE_MSGS = data(\"ApproximateNumberOfMessagesNotVisible\", filter=filter(\"namespace\", \"AWS/SQS\") and filter(\"stat\", \"mean\") and filter(\"QueueName\", \"*\") and filter(\"aws_region\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"QueueName\", \"aws_region\"])\nAPPROX_MESSAGES_DELAYED= data(\"ApproximateNumberOfMessagesDelayed\", filter=filter(\"namespace\", \"AWS/SQS\") and filter(\"stat\", \"mean\") and filter(\"QueueName\", \"*\") and filter(\"aws_region\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"QueueName\", \"aws_region\"])\nCURRENT_QUEUE_SIZE = (APPROX_VISIBLE_MSGS + APPROX_NOT_VISIBLE_MSGS + APPROX_MESSAGES_DELAYED).mean(by=[\"QueueName\",\"aws_region\"])\nRDS = data(\"DatabaseConnections\", filter=filter(\"namespace\", \"AWS/RDS\") and filter(\"stat\", \"mean\") and filter(\"DBInstanceIdentifier\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"DBInstanceIdentifier\"])\nEC2 = data(\"CPUUtilization\", filter=filter(\"stat\", \"mean\") and filter(\"namespace\", \"AWS/EC2\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"InstanceId\"])\nNOTIFICATIONS_DELIVERED1 = data(\"NumberOfNotificationsDelivered\", filter=filter(\"namespace\", \"AWS/SNS\") and filter(\"stat\", \"sum\") and filter(\"TopicName\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"TopicName\"])\nNOTIFICATIONS_FAILED1 = data(\"NumberOfNotificationsFailed\", filter=filter(\"namespace\", \"AWS/SNS\") and filter(\"stat\", \"sum\") and filter(\"TopicName\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"TopicName\"])\nDELIVERY_SUCCESS = ((NOTIFICATIONS_DELIVERED1 / (NOTIFICATIONS_DELIVERED1 + NOTIFICATIONS_FAILED1)) * 100)\nELASTICACHE_CONNECTIONS = data(\"CurrConnections\", filter=filter(\"stat\", \"mean\") and filter(\"namespace\", \"AWS/ElastiCache\") and filter(\"CacheNodeId\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"CacheClusterId\", \"CacheNodeId\", \"aws_region\"])\nCDN = data(\"TotalErrorRate\", filter=filter(\"namespace\", \"AWS/CloudFront\") and filter(\"stat\", \"mean\") and filter(\"DistributionId\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"DistributionId\"])\nELB = data(\"RequestCount\", filter=filter(\"namespace\", \"AWS/ELB\") and filter(\"stat\", \"sum\") and not filter(\"AvailabilityZone\", \"*\") and filter(\"LoadBalancerName\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).scale(60).sum(by=[\"LoadBalancerName\"])\nEBS_READOPS1 = data(\"VolumeReadOps\", filter=filter(\"namespace\", \"AWS/EBS\") and filter(\"stat\", \"sum\") and filter(\"VolumeId\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"VolumeId\"]).scale(60)\nEBS_WRITEOPS1 = data(\"VolumeWriteOps\", filter=filter(\"namespace\", \"AWS/EBS\") and filter(\"stat\", \"sum\") and filter(\"VolumeId\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"VolumeId\"]).scale(60)\nTOTAL_IOPS = (EBS_READOPS1 + EBS_WRITEOPS1)\nECS_CPU_RESERVATION = data(\"CPUReservation\", filter=filter(\"namespace\", \"AWS/ECS\") and filter(\"stat\", \"mean\") and filter(\"ClusterName\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"ClusterName\"])\nTHROTTLED_REQUESTS = data(\"ThrottledRequests\", filter=filter(\"namespace\", \"AWS/DynamoDB\") and filter(\"stat\", \"sum\") and filter(\"TableName\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"TableName\"]).scale(60)\ninvocations_from_cw = data(\"Invocations\", filter=filter(\"FunctionName\", \"*\") and filter(\"stat\", \"sum\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\ninvocations_from_wrapper = data(\"function.invocations\", filter=filter(\"lambda_arn\", \"*\"){{#filter}} and {{{filter}}}{{/filter}}, rollup=\"sum\", extrapolation=\"null\", maxExtrapolations=-1).sum(by=[\"aws_function_name\", \"aws_function_version\", \"aws_region\", \"aws_account_id\"]).sum(over=\"{{{timeRange}}}\")\nINVOCATIONS = union(invocations_from_cw, invocations_from_wrapper)",
             "varName" : null
           },
           "metrics" : [ {


### PR DESCRIPTION
added a `not` AvailabilityZone:* so that the load balancer properties will appear, as this should only match 1 mts.

before, there was AvailabilityZone:* and sum by LoadBalancerName, so the properties were dropped. The MTS missing the AZ is an aggregate of the AZs already, so this value is the same.