### PR TITLE
Hosts: resync nav and remove invalid property

### DIFF
--- a/navigators/Hosts/collectd hosts.json
+++ b/navigators/Hosts/collectd hosts.json
@@ -1,18 +1,6 @@
 {
-  "hashCode" : -2048141695,
+  "hashCode" : 1706103380,
   "id" : "DiVVQHAAcAA",
-  "importQualifiers" : [ {
-    "filters" : [ {
-      "not" : false,
-      "property" : "sf_key",
-      "values" : [ "host" ]
-    }, {
-      "not" : true,
-      "property" : "sf_key",
-      "values" : [ "agent" ]
-    } ],
-    "metric" : "cpu.utilization"
-  } ],
   "modelVersion" : 1,
   "navigatorExport" : {
     "navigator" : {
@@ -96,12 +84,18 @@
           "id" : "collectd.cpu.utilization",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "host",
               "type" : "property"
+            }, {
+              "not" : false,
+              "property" : "_missing_",
+              "propertyValue" : "agent",
+              "type" : "property"
             } ],
             "resolution" : 60000,
-            "template" : "CPU_UTILIZATION = data(\"cpu.utilization\"{{#filter}}, filter={{{filter}}}{{/filter}} and (not filter('_exists_', 'agent')), extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
+            "template" : "CPU_UTILIZATION = data(\"cpu.utilization\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
             "varName" : "CPU_UTILIZATION"
           },
           "metricSelectors" : [ "cpu.utilization" ],
@@ -122,12 +116,18 @@
           "id" : "collectd.memory.utilization",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "host",
               "type" : "property"
+            }, {
+              "not" : false,
+              "property" : "_missing_",
+              "propertyValue" : "agent",
+              "type" : "property"
             } ],
             "resolution" : 60000,
-            "template" : "MEMORY_UTILIZATION = data(\"memory.utilization\"{{#filter}}, filter={{{filter}}}{{/filter}} and (not filter('_exists_', 'agent')), extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
+            "template" : "MEMORY_UTILIZATION = data(\"memory.utilization\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
             "varName" : "MEMORY_UTILIZATION"
           },
           "metricSelectors" : [ "memory.utilization" ],
@@ -148,12 +148,18 @@
           "id" : "collectd.disk.summary_utilization",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "host",
               "type" : "property"
+            }, {
+              "not" : false,
+              "property" : "_missing_",
+              "propertyValue" : "agent",
+              "type" : "property"
             } ],
             "resolution" : 60000,
-            "template" : "DISK_UTILIZATION = data(\"disk.summary_utilization\"{{#filter}}, filter={{{filter}}}{{/filter}} and (not filter('_exists_', 'agent')), extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
+            "template" : "DISK_UTILIZATION = data(\"disk.summary_utilization\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
             "varName" : "DISK_UTILIZATION"
           },
           "metricSelectors" : [ "disk.summary_utilization" ],
@@ -174,12 +180,18 @@
           "id" : "collectd.network.total",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "host",
               "type" : "property"
+            }, {
+              "not" : false,
+              "property" : "_missing_",
+              "propertyValue" : "agent",
+              "type" : "property"
             } ],
             "resolution" : 60000,
-            "template" : "NETWORK_TOTAL = data(\"network.total\"{{#filter}}, filter={{{filter}}}{{/filter}} and (not filter('_exists_', 'agent')), extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
+            "template" : "NETWORK_TOTAL = data(\"network.total\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
             "varName" : "NETWORK_TOTAL"
           },
           "metricSelectors" : [ "network.total" ],
@@ -200,12 +212,18 @@
           "id" : "collectd.disk_ops.total",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "host",
               "type" : "property"
+            }, {
+              "not" : false,
+              "property" : "_missing_",
+              "propertyValue" : "agent",
+              "type" : "property"
             } ],
             "resolution" : 60000,
-            "template" : "DISK_OPS_TOTAL = data(\"disk_ops.total\"{{#filter}}, filter={{{filter}}}{{/filter}} and (not filter('_exists_', 'agent')), extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
+            "template" : "DISK_OPS_TOTAL = data(\"disk_ops.total\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
             "varName" : "DISK_OPS_TOTAL"
           },
           "metricSelectors" : [ "disk_ops.total" ],
@@ -228,12 +246,18 @@
           "id" : "___SF_ALERT_COLLECTD",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "host",
               "type" : "property"
+            }, {
+              "not" : false,
+              "property" : "_missing_",
+              "propertyValue" : "agent",
+              "type" : "property"
             } ],
             "resolution" : 60000,
-            "template" : "CPU_UTILIZATION = data(\"cpu.utilization\"{{#filter}}, filter={{{filter}}}{{/filter}} and (not filter('_exists_', 'agent')), extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
+            "template" : "CPU_UTILIZATION = data(\"cpu.utilization\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
             "varName" : "CPU_UTILIZATION"
           },
           "metricSelectors" : [ ],
@@ -241,13 +265,13 @@
           "valueFormat" : "AlertSeverity",
           "valueLabel" : "Most severe alert"
         } ],
-        "mtsQuery" : "sf_metric:cpu.utilization AND _exists_:host AND NOT _exists_:agent",
+        "mtsQuery" : "sf_metric:cpu.utilization AND _exists_:host AND _missing_:agent",
         "propertyColumns" : [ [ {
           "header" : "Memory",
           "properties" : [ "host_mem_total" ]
         }, {
           "header" : "Processor",
-          "properties" : [ "host_processor", "host_cpu_cores", "host_cpu_model", "host_logical_cpus", "host_physical_cpus" ]
+          "properties" : [ "host_processor", "host_cpu_model", "host_logical_cpus", "host_physical_cpus" ]
         }, {
           "header" : "OS",
           "properties" : [ "host_kernel_name", "host_kernel_release", "host_kernel_version" ]


### PR DESCRIPTION
`host_cpu_cores` is reporting logical num of processors. we already report this as `host_logical_cpus`, and it's confusing people. Removing it for now.