### PR TITLE
Update µAPM dashboards

### DIFF
--- a/group/APM.json
+++ b/group/APM.json
@@ -5,143 +5,16 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "Saturation of the service hosts (max of CPU, memory and disk utilization)",
-        "id": "D7F9AxgAgAA",
+        "description": "Requests/sec processed by the endpoint",
+        "id": "EKWuLwZAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Service hosts saturation",
+        "name": "Request rate",
         "options": {
-          "colorBy": "Scale",
-          "colorRange": null,
+          "colorBy": "Dimension",
           "colorScale": null,
-          "colorScale2": [
-            {
-              "gt": 90,
-              "gte": null,
-              "lt": null,
-              "lte": null,
-              "paletteIndex": 16
-            },
-            {
-              "gt": 75,
-              "gte": null,
-              "lt": null,
-              "lte": 90,
-              "paletteIndex": 17
-            },
-            {
-              "gt": 50,
-              "gte": null,
-              "lt": null,
-              "lte": 75,
-              "paletteIndex": 18
-            },
-            {
-              "gt": null,
-              "gte": null,
-              "lt": null,
-              "lte": 50,
-              "paletteIndex": 20
-            }
-          ],
-          "groupBy": [],
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": 0,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "cpu.utilization",
-              "label": "A",
-              "valuePrefix": "",
-              "valueSuffix": "",
-              "valueUnit": null
-            },
-            {
-              "displayName": "disk.summary_utilization",
-              "label": "B",
-              "valuePrefix": "",
-              "valueSuffix": "",
-              "valueUnit": null
-            },
-            {
-              "displayName": "memory.utilization",
-              "label": "C",
-              "valuePrefix": "",
-              "valueSuffix": "",
-              "valueUnit": null
-            },
-            {
-              "displayName": "Saturation",
-              "label": "D",
-              "valuePrefix": "",
-              "valueSuffix": "%",
-              "valueUnit": null
-            }
-          ],
-          "refreshInterval": null,
-          "sortDirection": "Ascending",
-          "sortProperty": null,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "timestampHidden": false,
-          "type": "Heatmap",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "f = filter('sf_hasService', '*') and filter('cluster', '*')\nA = data('cpu.utilization', filter=f).publish(label='A',enable=False)\nB = data('disk.summary_utilization', filter=f).publish(label='B',enable=False)\nC = data('memory.utilization', filter=f).publish(label='C',enable=False)\nD = max(A, B, C).sum(by='host').publish(label='D')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Error rate on requests made to the service",
-        "id": "D7x6v1cAgAY",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Error rate",
-        "options": {
-          "colorBy": "Scale",
-          "colorScale": null,
-          "colorScale2": [
-            {
-              "gt": 5,
-              "gte": null,
-              "lt": null,
-              "lte": null,
-              "paletteIndex": 16
-            },
-            {
-              "gt": 1,
-              "gte": null,
-              "lt": null,
-              "lte": 5,
-              "paletteIndex": 17
-            },
-            {
-              "gt": 0,
-              "gte": null,
-              "lt": null,
-              "lte": 1,
-              "paletteIndex": 18
-            },
-            {
-              "gt": null,
-              "gte": null,
-              "lt": null,
-              "lte": 0,
-              "paletteIndex": 20
-            }
-          ],
-          "maximumPrecision": null,
+          "colorScale2": null,
+          "maximumPrecision": 4,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": null,
@@ -150,32 +23,22 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "Successful requests",
+              "displayName": "Requests/sec",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
-              "valueSuffix": null,
+              "valueSuffix": "requests/sec",
               "valueUnit": null,
               "yAxis": 0
             },
             {
-              "displayName": "All requests",
+              "displayName": "Requests/sec",
               "label": "B",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Error rate",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "%",
+              "valueSuffix": "request/sec",
               "valueUnit": null,
               "yAxis": 0
             }
@@ -192,7 +55,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('error', 'false') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['service']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['service']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "programText": "f = filter('kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('service', '*') and filter('operation', '*') and filter('cluster', '*')\nA = data('spans.count', filter=f and filter('httpMethod', '*'), rollup='rate').sum(by=['service', 'operation', 'httpMethod']).publish(label='A')\nB = data('spans.count', filter=f and (not filter('httpMethod', '*')), rollup='rate').sum(by=['service', 'operation']).publish(label='B')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -202,47 +65,17 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "99th percentile response time",
-        "id": "D7F9CB6AgAA",
+        "description": "",
+        "id": "EKWuOTVAYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Request latency (p99)",
+        "name": ".",
         "options": {
-          "colorBy": "Metric",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": 6,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "p99 latency",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Nanosecond",
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "showSparkLine": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
+          "markdown": "<table width=\"100%\" height=\"50%\" rules=\"none\">\n<tr><td valign=\"middle\" align=\"center\" bgcolor=\"#4682B4\">\n<font size=\"5\" color=\"white\">Host Metrics</font>\n</td></tr>\n</table>\n<p align=\"center\" ><br />\nKey system-level metrics for the host(s) that power this service\n</p>",
+          "type": "Text"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.duration.ns.p99', filter=filter('kind', 'CONSUMER', 'SERVER') and filter('service', '*') and filter('operation', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))).mean(by=['service', 'operation']).publish(label='A')",
+        "programText": "",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -252,11 +85,11 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "Distribution of request latency with median (50th), 90th and 99th percentiles",
-        "id": "D7F9CCBAYAA",
+        "description": "Storage utilization, in bytes, of the Kubernetes pods for this service",
+        "id": "EKWuMPkAYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Request latency distribution",
+        "name": "Pod disk usage",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -282,7 +115,7 @@
             }
           ],
           "axisPrecision": null,
-          "colorBy": "Metric",
+          "colorBy": "Dimension",
           "defaultPlotType": "LineChart",
           "eventPublishLabelOptions": [],
           "histogramChartOptions": {
@@ -290,7 +123,36 @@
           },
           "includeZero": false,
           "legendOptions": {
-            "fields": null
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              }
+            ]
           },
           "lineChartOptions": {
             "showDataMarkers": false
@@ -307,33 +169,13 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "p50 latency",
+              "displayName": "Disk utilization",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
-              "valueUnit": "Nanosecond",
-              "yAxis": 0
-            },
-            {
-              "displayName": "p90 latency",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Nanosecond",
-              "yAxis": 0
-            },
-            {
-              "displayName": "p99 latency",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Nanosecond",
+              "valueUnit": "Byte",
               "yAxis": 0
             }
           ],
@@ -344,10 +186,10 @@
             "type": "relative"
           },
           "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
+          "unitPrefix": "Binary"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.duration.ns.median', filter=filter('kind', 'CONSUMER', 'SERVER') and filter('service', '*') and filter('operation', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))).mean(by=['service', 'operation']).publish(label='A')\nB = data('spans.duration.ns.p90', filter=filter('kind', 'CONSUMER', 'SERVER') and filter('service', '*') and filter('operation', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))).mean(by=['service', 'operation']).publish(label='B')\nC = data('spans.duration.ns.p99', filter=filter('kind', 'CONSUMER', 'SERVER') and filter('service', '*') and filter('operation', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))).mean(by=['service', 'operation']).publish(label='C')",
+        "programText": "A = data('container_fs_usage_bytes', filter=filter('cluster', '*') and filter('service', '*')).sum(by=['kubernetes_pod_uid', 'container_id']).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -357,11 +199,61 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "Cumulative network utilization of the service hosts",
-        "id": "D7x6v1cAgAI",
+        "description": "Requests/sec processed by the service",
+        "id": "EKWt8VZAYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Host network utilization",
+        "name": "Request rate",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": 4,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Requests/sec",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "requests/sec",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['service']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Requests/sec processed by the endpoint",
+        "id": "EKWuQD0AYAI",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Request rate",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -374,7 +266,7 @@
               "lowWatermark": null,
               "lowWatermarkLabel": null,
               "max": null,
-              "min": 0
+              "min": null
             },
             {
               "highWatermark": null,
@@ -406,19 +298,29 @@
           },
           "programOptions": {
             "disableSampling": false,
-            "maxDelay": 0,
+            "maxDelay": null,
             "minimumResolution": 0,
             "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "Network utilization",
+              "displayName": "Requests/sec",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Byte",
+              "valueSuffix": "requests/sec",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Requests/sec",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "request/sec",
+              "valueUnit": null,
               "yAxis": 0
             }
           ],
@@ -432,7 +334,102 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('network.total', filter=filter('sf_hasService', '*') and filter('cluster', '*'), rollup='rate').publish(label='A')",
+        "programText": "f = filter('kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('service', '*') and filter('operation', '*') and filter('cluster', '*')\nA = data('spans.count', filter=f and filter('httpMethod', '*'), rollup='rate').sum(by=['service', 'operation', 'httpMethod']).publish(label='A')\nB = data('spans.count', filter=f and (not filter('httpMethod', '*')), rollup='rate').sum(by=['service', 'operation']).publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Network utilization in bytes (in and out) of the Kubernetes pods for this service",
+        "id": "EKWuP6tAcAE",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod network utilization (bytes/sec)",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Rx Bytes /sec (RED)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Tx Bytes /sec (BLUE)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx (bytes/sec)",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx (bytes/sec)",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 1
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('cluster', '*') and filter('service', '*'), extrapolation='zero').sum(by=['kubernetes_pod_uid', 'container_id']).publish(label='A')\nB = data('pod_network_transmit_bytes_total', filter=filter('cluster', '*') and filter('service', '*'), extrapolation='zero').sum(by=['kubernetes_pod_uid', 'container_id']).publish(label='B')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -443,7 +440,7 @@
         "creator": null,
         "customProperties": {},
         "description": "Memory utilization of the service hosts",
-        "id": "D7x6v1bAgEA",
+        "id": "EKWt-bVAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "name": "Host memory usage",
@@ -527,44 +524,168 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "Error rate on requests made to the endpoint",
-        "id": "D7F9AnUAcAA",
+        "description": "",
+        "id": "EKWuPhVAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Error rate",
+        "name": ".",
         "options": {
-          "colorBy": "Scale",
-          "colorScale": null,
-          "colorScale2": [
+          "markdown": "<table width=\"100%\" height=\"50%\" rules=\"none\">\n<tr><td valign=\"middle\" align=\"center\" bgcolor=\"#4682B4\">\n<font size=\"5\" color=\"white\">Kubernetes Pod Metrics</font>\n</td></tr>\n</table>\n<p align=\"center\" ><br />\nKey metrics from the Kubernetes pod(s) that power this service.<br />\n<i>Metrics will only populate these charts if your service is running in Kubernetes and your <a href=\"https://docs.signalfx.com/en/latest/integrations/kubernetes/index.html\">SignalFx Smart Agent is configured to monitor your Kubernetes environment</a>.</i>\n</p>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Storage utilization, in bytes, of the Kubernetes pods for this service",
+        "id": "EKWt8OIAgC4",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod disk usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
             {
-              "gt": 5,
-              "gte": null,
-              "lt": null,
-              "lte": null,
-              "paletteIndex": 16
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
             },
             {
-              "gt": 1,
-              "gte": null,
-              "lt": null,
-              "lte": 5,
-              "paletteIndex": 17
-            },
-            {
-              "gt": 0,
-              "gte": null,
-              "lt": null,
-              "lte": 1,
-              "paletteIndex": 18
-            },
-            {
-              "gt": null,
-              "gte": null,
-              "lt": null,
-              "lte": 0,
-              "paletteIndex": 20
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
             }
           ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Disk utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_fs_usage_bytes', filter=filter('cluster', '*') and filter('service', '*')).sum(by=['kubernetes_pod_uid', 'container_id']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Most active service endpoints (1min requests/sec average)",
+        "id": "EKWt-eoAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Top endpoints",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": true,
+                "property": "operation"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "service"
+              }
+            ]
+          },
           "maximumPrecision": null,
           "programOptions": {
             "disableSampling": false,
@@ -574,49 +695,28 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "Successful requests",
+              "displayName": "Requests/sec",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "All requests",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Error rate",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "%",
+              "valueSuffix": "requests/sec",
               "valueUnit": null,
               "yAxis": 0
             }
           ],
           "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
           "time": {
             "range": 900000,
             "type": "relative"
           },
-          "timestampHidden": false,
-          "type": "SingleValue",
+          "type": "List",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('error', 'false') and filter('service', '*') and filter('operation', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['service', 'operation']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('operation', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['service', 'operation']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['operation', 'service']).mean(over='1m').publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -626,109 +726,11 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "Saturation of the service hosts (max of CPU, memory and disk utilization)",
-        "id": "D7x6v1cAgAQ",
+        "description": "99th percentile request latency by endpoint",
+        "id": "EKWt-riAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Service hosts saturation",
-        "options": {
-          "colorBy": "Scale",
-          "colorRange": null,
-          "colorScale": null,
-          "colorScale2": [
-            {
-              "gt": 90,
-              "gte": null,
-              "lt": null,
-              "lte": null,
-              "paletteIndex": 16
-            },
-            {
-              "gt": 75,
-              "gte": null,
-              "lt": null,
-              "lte": 90,
-              "paletteIndex": 17
-            },
-            {
-              "gt": 50,
-              "gte": null,
-              "lt": null,
-              "lte": 75,
-              "paletteIndex": 18
-            },
-            {
-              "gt": null,
-              "gte": null,
-              "lt": null,
-              "lte": 50,
-              "paletteIndex": 20
-            }
-          ],
-          "groupBy": [],
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": 0,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "cpu.utilization",
-              "label": "A",
-              "valuePrefix": "",
-              "valueSuffix": "%",
-              "valueUnit": null
-            },
-            {
-              "displayName": "memory.utilization",
-              "label": "B",
-              "valuePrefix": "",
-              "valueSuffix": "%",
-              "valueUnit": null
-            },
-            {
-              "displayName": "disk.summary_utilization",
-              "label": "C",
-              "valuePrefix": "",
-              "valueSuffix": "%",
-              "valueUnit": null
-            },
-            {
-              "displayName": "Saturation",
-              "label": "D",
-              "valuePrefix": "",
-              "valueSuffix": "%",
-              "valueUnit": null
-            }
-          ],
-          "refreshInterval": null,
-          "sortDirection": "Ascending",
-          "sortProperty": null,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "timestampHidden": false,
-          "type": "Heatmap",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "f = filter('sf_hasService', '*') and filter('cluster', '*')\nA = data('cpu.utilization', filter=f).publish(label='A', enable=False)\nB = data('memory.utilization', filter=f).publish(label='B', enable=False)\nC = data('disk.summary_utilization', filter=f).publish(label='C', enable=False)\nD = max(A, B, C).sum(by='host').publish(label='D')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Error rate on requests made to the service",
-        "id": "D7x6v1bAgD4",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Error rate",
+        "name": "Request latency (p99) by endpoint",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -742,111 +744,6 @@
               "lowWatermarkLabel": null,
               "max": null,
               "min": null
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Successful requests",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "All requests",
-              "label": "B",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "yAxis": 0
-            },
-            {
-              "displayName": "Error rate",
-              "label": "C",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "%",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('error', 'false') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['service']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['service']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Memory utilization of the service hosts",
-        "id": "D7F9BagAYEQ",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Host memory usage",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "%",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": 100,
-              "min": 0
             },
             {
               "highWatermark": null,
@@ -878,19 +775,19 @@
           },
           "programOptions": {
             "disableSampling": false,
-            "maxDelay": 0,
+            "maxDelay": null,
             "minimumResolution": 0,
             "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "memory.utilization",
+              "displayName": "Request latency (p99)",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
-              "valuePrefix": "",
-              "valueSuffix": "",
-              "valueUnit": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Nanosecond",
               "yAxis": 0
             }
           ],
@@ -904,227 +801,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('memory.utilization', filter=filter('sf_hasService', '*') and filter('cluster', '*')).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "CPU Utilization of the service hosts",
-        "id": "D7F9CCvAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Host CPU",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "%",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": 100,
-              "min": 0
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": 0,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "cpu.utilization",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": "",
-              "valueSuffix": "",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('cpu.utilization', filter=filter('sf_hasService', '*') and filter('cluster', '*')).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Requests/sec by service endpoint",
-        "id": "D7x6v1bAgEE",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Request rate by endpoint",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Requests/sec",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "requests/sec",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": true,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['operation', 'service']).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Requests/sec processed by the service",
-        "id": "D7x6v1bAgD8",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Request rate",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": 4,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Requests/sec",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "requests/sec",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['service']).publish(label='A')",
+        "programText": "A = data('spans.duration.ns.p99', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))).max(by=['operation', 'service']).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1135,104 +812,7 @@
         "creator": null,
         "customProperties": {},
         "description": "",
-        "id": "D7x6v1cAgAk",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Service map",
-        "options": {
-          "colorBy": "Scale",
-          "colorRange": null,
-          "colorScale2": [
-            {
-              "gt": 5,
-              "gte": null,
-              "lt": null,
-              "lte": null,
-              "paletteIndex": 16
-            },
-            {
-              "gt": 1,
-              "gte": null,
-              "lt": null,
-              "lte": 5,
-              "paletteIndex": 17
-            },
-            {
-              "gt": 0,
-              "gte": null,
-              "lt": null,
-              "lte": 1,
-              "paletteIndex": 18
-            },
-            {
-              "gt": null,
-              "gte": null,
-              "lt": null,
-              "lte": 0,
-              "paletteIndex": 3
-            }
-          ],
-          "defaultColorBy": null,
-          "defaultSizeBy": null,
-          "mapRange": null,
-          "operationFilter": null,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": 0,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "serviceFilter": [],
-          "systemMapLabelOptions": [
-            {
-              "displayName": "Requests/sec",
-              "label": "B",
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "viewMenu": "SizeBy"
-            },
-            {
-              "displayName": "Successful requests",
-              "label": "C",
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "viewMenu": "SizeBy"
-            },
-            {
-              "displayName": "All requests",
-              "label": "D",
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "viewMenu": "SizeBy"
-            },
-            {
-              "displayName": "Error rate",
-              "label": "E",
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": null,
-              "viewMenu": "ColorBy"
-            }
-          ],
-          "tagFilters": null,
-          "type": "SystemMap"
-        },
-        "packageSpecifications": "",
-        "programText": "B = data('spans.count', filter=filter('kind', 'CONSUMER', 'SERVER') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['service']).publish(label='B')\nC = data('spans.count', filter=filter('kind', 'CONSUMER', 'SERVER') and filter('cluster', '*') and filter('error', 'false') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['service']).publish(label='C', enable=False)\nD = data('spans.count', filter=filter('kind', 'CONSUMER', 'SERVER') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['service']).publish(label='D', enable=False)\nE = (100*(D-C)/D).sum(by=['service']).publish(label='E')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "",
-        "id": "D7F9A0cAcAA",
+        "id": "EKWuOWsAgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "name": "Service map",
@@ -1328,178 +908,8 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "Disk utilization of the service hosts",
-        "id": "D7x6v1cAgAg",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Host disk usage",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "%",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": 100,
-              "min": 0
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": 0,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "disk.summary_utilization",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": "",
-              "valueSuffix": "%",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('disk.summary_utilization', filter=filter('sf_hasService', '*') and filter('cluster', '*')).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Requests/sec processed by the service",
-        "id": "D7x6v1bAgEM",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Request rate",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": null,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Requests/sec",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "requests/sec",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['service']).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Error rate on requests made to the endpoint",
-        "id": "D7F9CCmAgAA",
+        "description": "Error rate on requests made to the service",
+        "id": "EKWt-S6AYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "name": "Error rate",
@@ -1529,7 +939,7 @@
           ],
           "axisPrecision": null,
           "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
+          "defaultPlotType": "AreaChart",
           "eventPublishLabelOptions": [],
           "histogramChartOptions": {
             "colorThemeIndex": 16
@@ -1593,7 +1003,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('error', 'false') and filter('service', '*') and filter('operation', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['service', 'operation']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('operation', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['service', 'operation']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('error', 'false') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta', extrapolation='zero').sum(by=['service']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta', extrapolation='zero').sum(by=['service']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1603,11 +1013,31 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "Requests/sec processed by the endpoint",
-        "id": "D7F9BNAAcAA",
+        "description": "",
+        "id": "EKWuAj_AcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Request rate",
+        "name": ".",
+        "options": {
+          "markdown": "<table width=\"100%\" height=\"50%\" rules=\"none\">\n<tr><td valign=\"middle\" align=\"center\" bgcolor=\"#4682B4\">\n<font size=\"5\" color=\"white\">Host Metrics</font>\n</td></tr>\n</table>\n<p align=\"center\" ><br />\nKey system-level metrics for the host(s) that power this service\n</p>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Memory usage in bytes of the containers in the Kubernetes pods of this service, and their utilization (if a memory limit is set for the pod)",
+        "id": "EKWt_NTAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod memory usage",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -1625,11 +1055,11 @@
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "",
+              "label": "%",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
+              "max": 100,
+              "min": 0
             }
           ],
           "axisPrecision": null,
@@ -1641,7 +1071,36 @@
           },
           "includeZero": false,
           "legendOptions": {
-            "fields": null
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              }
+            ]
           },
           "lineChartOptions": {
             "showDataMarkers": false
@@ -1658,99 +1117,34 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "Requests/sec",
+              "displayName": "Memory usage in bytes",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
-              "valueSuffix": "requests/sec",
-              "valueUnit": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
               "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('operation', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['service', 'operation']).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Disk utilization of the service hosts",
-        "id": "D7F9CB-AcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Host disk usage",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "%",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": 100,
-              "min": 0
             },
             {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": 0,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "disk.summary_utilization",
-              "label": "A",
+              "displayName": "container_spec_memory_limit_bytes - Maximum by kubernetes_pod_uid,container_id - Exclude x < 0",
+              "label": "B",
               "paletteIndex": null,
               "plotType": null,
-              "valuePrefix": "",
-              "valueSuffix": "",
-              "valueUnit": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
               "yAxis": 0
+            },
+            {
+              "displayName": "Memory utilization (out of limit)",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
             }
           ],
           "showEventLines": false,
@@ -1760,10 +1154,10 @@
             "type": "relative"
           },
           "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
+          "unitPrefix": "Binary"
         },
         "packageSpecifications": "",
-        "programText": "A = data('disk.summary_utilization', filter=filter('sf_hasService', '*') and filter('cluster', '*')).publish(label='A')",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('cluster', '*') and filter('service', '*')).mean(by=['kubernetes_pod_uid', 'container_id']).publish(label='A')\nB = data('container_spec_memory_limit_bytes', filter=filter('cluster', '*') and filter('service', '*')).max(by=['kubernetes_pod_uid', 'container_id']).above(0, inclusive=True).publish(label='B', enable=False)\nC = (100*A/B).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1773,34 +1167,44 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "Most active service endpoints (1min requests/sec average)",
-        "id": "D7x6v1cAgAU",
+        "description": "Error rate on requests made to the endpoint",
+        "id": "EKWuOaXAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Top endpoints",
+        "name": "Error rate",
         "options": {
-          "colorBy": "Dimension",
-          "colorScale2": null,
-          "legendOptions": {
-            "fields": [
-              {
-                "enabled": false,
-                "property": "sf_originatingMetric"
-              },
-              {
-                "enabled": true,
-                "property": "operation"
-              },
-              {
-                "enabled": false,
-                "property": "sf_metric"
-              },
-              {
-                "enabled": false,
-                "property": "service"
-              }
-            ]
-          },
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 5,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 1,
+              "gte": null,
+              "lt": null,
+              "lte": 5,
+              "paletteIndex": 17
+            },
+            {
+              "gt": 0,
+              "gte": null,
+              "lt": null,
+              "lte": 1,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 0,
+              "paletteIndex": 20
+            }
+          ],
           "maximumPrecision": null,
           "programOptions": {
             "disableSampling": false,
@@ -1810,28 +1214,59 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "Requests/sec",
+              "displayName": "Successful requests",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
               "valuePrefix": null,
-              "valueSuffix": "requests/sec",
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "All requests",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Error rate",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "F",
+              "label": "F",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
               "valueUnit": null,
               "yAxis": 0
             }
           ],
           "refreshInterval": null,
-          "secondaryVisualization": "Sparkline",
-          "sortBy": "-value",
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
           "time": {
             "range": 900000,
             "type": "relative"
           },
-          "type": "List",
+          "timestampHidden": false,
+          "type": "SingleValue",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['operation', 'service']).mean(over='1m').publish(label='A')",
+        "programText": "f = filter('kind', 'SERVER', 'CONSUMER') and filter('error', 'false') and filter('service', '*') and filter('operation', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))\nA = data('spans.count', filter=f and filter('httpMethod', '*'), rollup='delta', extrapolation='zero').sum(by=['service', 'operation', 'httpMethod']).publish(label='A', enable=False)\nB = data('spans.count', filter=f and filter('httpMethod', '*'), rollup='delta', extrapolation='zero').sum(by=['service', 'operation', 'httpMethod']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')\nD = data('spans.count', filter=f and (not filter('httpMethod', '*')), rollup='delta', extrapolation='zero').sum(by=['service', 'operation']).publish(label='A', enable=False)\nE = data('spans.count', filter=f and (not filter('httpMethod', '*')), rollup='delta', extrapolation='zero').sum(by=['service', 'operation']).publish(label='B', enable=False)\nF = (100*(E-D)/E).publish(label='F')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1841,82 +1276,47 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "CPU Utilization of the service hosts",
-        "id": "D7x6v1cAgAc",
+        "description": "99th percentile response time",
+        "id": "EKWt_AVAYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Host CPU",
+        "name": "Request latency (p99)",
         "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "%",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": 100,
-              "min": 0
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
+          "colorBy": "Metric",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": 6,
           "programOptions": {
             "disableSampling": false,
-            "maxDelay": 0,
+            "maxDelay": null,
             "minimumResolution": 0,
             "timezone": null
           },
           "publishLabelOptions": [
             {
-              "displayName": "cpu.utilization",
+              "displayName": "p99 latency",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
-              "valuePrefix": "",
-              "valueSuffix": "%",
-              "valueUnit": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Nanosecond",
               "yAxis": 0
             }
           ],
-          "showEventLines": false,
-          "stacked": false,
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "showSparkLine": false,
           "time": {
             "range": 900000,
             "type": "relative"
           },
-          "type": "TimeSeriesChart",
+          "timestampHidden": false,
+          "type": "SingleValue",
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('cpu.utilization', filter=filter('sf_hasService', '*') and filter('cluster', '*')).publish(label='A')",
+        "programText": "A = data('spans.duration.ns.p99', filter=filter('kind', 'CONSUMER', 'SERVER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))).mean(by=['service']).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1927,7 +1327,7 @@
         "creator": null,
         "customProperties": {},
         "description": "Distribution of request latency with median (50th), 90th and 99th percentiles",
-        "id": "D7x6v1cAgAA",
+        "id": "EKWt__8AgAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "name": "Request latency distribution",
@@ -2031,11 +1431,11 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "Cumulative network utilization of the service hosts",
-        "id": "D7F9A7jAYAE",
+        "description": "Disk utilization of the service hosts",
+        "id": "EKWt8VCAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Host network utilization",
+        "name": "Host disk usage",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -2044,10 +1444,10 @@
             {
               "highWatermark": null,
               "highWatermarkLabel": null,
-              "label": "",
+              "label": "%",
               "lowWatermark": null,
               "lowWatermarkLabel": null,
-              "max": null,
+              "max": 100,
               "min": 0
             },
             {
@@ -2086,151 +1486,16 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "Network utilization",
+              "displayName": "disk.summary_utilization",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Byte",
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": false,
-          "stacked": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('network.total', filter=filter('sf_hasService', '*') and filter('cluster', '*'), rollup='rate').publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Requests/sec processed by the endpoint",
-        "id": "D7F9BFrAgAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Request rate",
-        "options": {
-          "colorBy": "Dimension",
-          "colorScale": null,
-          "colorScale2": null,
-          "maximumPrecision": 4,
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Requests/sec",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "requests/sec",
+              "valuePrefix": "",
+              "valueSuffix": "%",
               "valueUnit": null,
               "yAxis": 0
             }
           ],
-          "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "showSparkLine": false,
-          "time": {
-            "range": 900000,
-            "type": "relative"
-          },
-          "timestampHidden": false,
-          "type": "SingleValue",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('operation', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['service', 'operation']).publish(label='A')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "99th percentile request latency by endpoint",
-        "id": "D7x6v1bAgEI",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Request latency (p99) by endpoint",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": false
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": false
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": null,
-            "showLegend": false
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": null,
-            "minimumResolution": 0,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Request latency (p99)",
-              "label": "A",
-              "paletteIndex": null,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": null,
-              "valueUnit": "Nanosecond",
-              "yAxis": 0
-            }
-          ],
           "showEventLines": false,
           "stacked": false,
           "time": {
@@ -2241,7 +1506,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.duration.ns.p99', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))).max(by=['operation', 'service']).publish(label='A')",
+        "programText": "A = data('disk.summary_utilization', filter=filter('sf_hasService', '*') and filter('cluster', '*')).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -2252,7 +1517,7 @@
         "creator": null,
         "customProperties": {},
         "description": "Error rate on requests made to the service, by endpoint",
-        "id": "D7x6v1cAgAE",
+        "id": "EKWt_euAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "name": "Error rate by endpoint",
@@ -2356,8 +1621,1466 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
+        "description": "Cumulative network utilization of the service hosts",
+        "id": "EKWuLsFAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host network utilization",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Network utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('network.total', filter=filter('sf_hasService', '*') and filter('cluster', '*'), rollup='rate').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Distribution of request latency with median (50th), 90th and 99th percentiles",
+        "id": "EKWuL_6AcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Request latency distribution",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Metric",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "p50 latency",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Nanosecond",
+              "yAxis": 0
+            },
+            {
+              "displayName": "p90 latency",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Nanosecond",
+              "yAxis": 0
+            },
+            {
+              "displayName": "p99 latency",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Nanosecond",
+              "yAxis": 0
+            },
+            {
+              "displayName": "p50 latency",
+              "label": "D",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "p90 latency",
+              "label": "E",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "p99 latency",
+              "label": "F",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "f = filter('kind', 'CONSUMER', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('service', '*') and filter('operation', '*') and filter('cluster', '*')\nA = data('spans.duration.ns.median', filter=f and filter('httpMethod', '*')).mean(by=['service', 'operation', 'httpMethod']).publish(label='A')\nB = data('spans.duration.ns.p90', filter=f and filter('httpMethod', '*')).mean(by=['service', 'operation', 'httpMethod']).publish(label='B')\nC = data('spans.duration.ns.p99', filter=f and filter('httpMethod', '*')).mean(by=['service', 'operation', 'httpMethod']).publish(label='C')\nD = data('spans.duration.ns.median', filter=f and (not filter('httpMethod', '*'))).mean(by=['service', 'operation']).publish(label='D')\nE = data('spans.duration.ns.p90', filter=f and (not filter('httpMethod', '*'))).mean(by=['service', 'operation']).publish(label='E')\nF = data('spans.duration.ns.p99', filter=f and (not filter('httpMethod', '*'))).mean(by=['service', 'operation']).publish(label='F')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "EKWt-UeAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": ".",
+        "options": {
+          "markdown": "<table width=\"100%\" height=\"50%\" rules=\"none\">\n<tr><td valign=\"middle\" align=\"center\" bgcolor=\"#4682B4\">\n<font size=\"5\" color=\"white\">Kubernetes Pod Metrics</font>\n</td></tr>\n</table>\n<p align=\"center\" ><br />\nKey metrics from the Kubernetes pod(s) that power this service.<br />\n<i>Metrics will only populate these charts if your service is running in Kubernetes and your <a href=\"https://docs.signalfx.com/en/latest/integrations/kubernetes/index.html\">SignalFx Smart Agent is configured to monitor your Kubernetes environment</a>.</i>\n</p>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "EKWt-3JAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Service map",
+        "options": {
+          "colorBy": "Scale",
+          "colorRange": null,
+          "colorScale2": [
+            {
+              "gt": 5,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 1,
+              "gte": null,
+              "lt": null,
+              "lte": 5,
+              "paletteIndex": 17
+            },
+            {
+              "gt": 0,
+              "gte": null,
+              "lt": null,
+              "lte": 1,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 0,
+              "paletteIndex": 3
+            }
+          ],
+          "defaultColorBy": null,
+          "defaultSizeBy": null,
+          "mapRange": null,
+          "operationFilter": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "serviceFilter": [],
+          "systemMapLabelOptions": [
+            {
+              "displayName": "Requests/sec",
+              "label": "B",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "viewMenu": "SizeBy"
+            },
+            {
+              "displayName": "Successful requests",
+              "label": "C",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "viewMenu": "SizeBy"
+            },
+            {
+              "displayName": "All requests",
+              "label": "D",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "viewMenu": "SizeBy"
+            },
+            {
+              "displayName": "Error rate",
+              "label": "E",
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "viewMenu": "ColorBy"
+            }
+          ],
+          "tagFilters": null,
+          "type": "SystemMap"
+        },
+        "packageSpecifications": "",
+        "programText": "B = data('spans.count', filter=filter('kind', 'CONSUMER', 'SERVER') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['service']).publish(label='B')\nC = data('spans.count', filter=filter('kind', 'CONSUMER', 'SERVER') and filter('cluster', '*') and filter('error', 'false') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['service']).publish(label='C', enable=False)\nD = data('spans.count', filter=filter('kind', 'CONSUMER', 'SERVER') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['service']).publish(label='D', enable=False)\nE = (100*(D-C)/D).sum(by=['service']).publish(label='E')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "CPU Utilization of the service hosts",
+        "id": "EKWt_CeAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host CPU usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "%",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "cpu.utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('cpu.utilization', filter=filter('sf_hasService', '*') and filter('cluster', '*')).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Disk utilization of the service hosts",
+        "id": "EKWuLXdAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host disk usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "%",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "disk.summary_utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('disk.summary_utilization', filter=filter('sf_hasService', '*') and filter('cluster', '*')).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Error rate on requests made to the service, by endpoint",
+        "id": "EKWuA0EAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Most erroneous endpoints",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": true,
+                "property": "operation"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "service"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Successful requests",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "All requests",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Error rate",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('error', 'false') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['service', 'operation']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['service', 'operation']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Cumulative network utilization of the service hosts",
+        "id": "EKWt_VSAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host network usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Network utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('network.total', filter=filter('sf_hasService', '*') and filter('cluster', '*'), rollup='rate').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Memory utilization of the service hosts",
+        "id": "EKWuMwIAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host memory usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "%",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "memory.utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('memory.utilization', filter=filter('sf_hasService', '*') and filter('cluster', '*')).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Error rate on requests made to the endpoint",
+        "id": "EKWuLxWAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Error rate",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Successful requests",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "All requests",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Error rate",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "F",
+              "label": "F",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "f = filter('kind', 'SERVER', 'CONSUMER') and filter('error', 'false') and filter('service', '*') and filter('operation', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))\nA = data('spans.count', filter=f and filter('httpMethod', '*'), rollup='delta', extrapolation='zero').sum(by=['service', 'operation', 'httpMethod']).publish(label='A', enable=False)\nB = data('spans.count', filter=f and filter('httpMethod', '*'), rollup='delta', extrapolation='zero').sum(by=['service', 'operation', 'httpMethod']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')\nD = data('spans.count', filter=f and (not filter('httpMethod', '*')), rollup='delta', extrapolation='zero').sum(by=['service', 'operation']).publish(label='A', enable=False)\nE = data('spans.count', filter=f and (not filter('httpMethod', '*')), rollup='delta', extrapolation='zero').sum(by=['service', 'operation']).publish(label='B', enable=False)\nF = (100*(E-D)/E).publish(label='F')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "CPU utilization of the containers in the Kubernetes pods of this service",
+        "id": "EKWuLWMAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod CPU usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": true,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "metric_source"
+              },
+              {
+                "enabled": true,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Container CPU utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": true,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_percent', filter=filter('cluster', '*') and filter('service', '*')).sum(by=['kubernetes_pod_uid', 'container_id']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Requests/sec processed by the service",
+        "id": "EKWuAsKAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Request rate",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": null,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Requests/sec",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "requests/sec",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['service']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Requests/sec by service endpoint",
+        "id": "EKWt9R3AgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Request rate by endpoint",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "AreaChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Requests/sec",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "requests/sec",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": true,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['operation', 'service']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "CPU Utilization of the service hosts",
+        "id": "EKWuPOrAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host CPU",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "%",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "cpu.utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('cpu.utilization', filter=filter('sf_hasService', '*') and filter('cluster', '*')).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Saturation of the service hosts (max of CPU, memory and disk utilization)",
+        "id": "EKWt_DVAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host saturation",
+        "options": {
+          "colorBy": "Scale",
+          "colorRange": null,
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 90,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 75,
+              "gte": null,
+              "lt": null,
+              "lte": 90,
+              "paletteIndex": 17
+            },
+            {
+              "gt": 50,
+              "gte": null,
+              "lt": null,
+              "lte": 75,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 50,
+              "paletteIndex": 20
+            }
+          ],
+          "groupBy": [],
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "cpu.utilization",
+              "label": "A",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
+            },
+            {
+              "displayName": "memory.utilization",
+              "label": "B",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
+            },
+            {
+              "displayName": "disk.summary_utilization",
+              "label": "C",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
+            },
+            {
+              "displayName": "Saturation",
+              "label": "D",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
+            }
+          ],
+          "refreshInterval": null,
+          "sortDirection": "Ascending",
+          "sortProperty": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "Heatmap",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "f = filter('sf_hasService', '*') and filter('cluster', '*')\nA = data('cpu.utilization', filter=f).publish(label='A', enable=False)\nB = data('memory.utilization', filter=f).publish(label='B', enable=False)\nC = data('disk.summary_utilization', filter=f).publish(label='C', enable=False)\nD = max(A, B, C).sum(by='host').publish(label='D')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Error rate on requests made to the service",
+        "id": "EKWt-RJAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Error rate",
+        "options": {
+          "colorBy": "Scale",
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 5,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 1,
+              "gte": null,
+              "lt": null,
+              "lte": 5,
+              "paletteIndex": 17
+            },
+            {
+              "gt": 0,
+              "gte": null,
+              "lt": null,
+              "lte": 1,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 0,
+              "paletteIndex": 20
+            }
+          ],
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Successful requests",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "All requests",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Error rate",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('error', 'false') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta', extrapolation='zero').sum(by=['service']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('kind', 'SERVER', 'CONSUMER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta', extrapolation='zero').sum(by=['service']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
         "description": "99th percentile response time",
-        "id": "D7x6v1cAgAM",
+        "id": "EKWuNKrAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "name": "Request latency (p99)",
@@ -2382,6 +3105,16 @@
               "valueSuffix": null,
               "valueUnit": "Nanosecond",
               "yAxis": 0
+            },
+            {
+              "displayName": "p99 latency",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
             }
           ],
           "refreshInterval": null,
@@ -2396,7 +3129,460 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.duration.ns.p99', filter=filter('kind', 'CONSUMER', 'SERVER') and filter('service', '*') and filter('cluster', '*') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))).mean(by=['service']).publish(label='A')",
+        "programText": "f = filter('kind', 'CONSUMER', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('cluster', '*') and filter('service', '*') and filter('operation', '*')\nA = data('spans.duration.ns.p99', filter=f and filter('httpMethod', '*')).mean(by=['service', 'operation', 'httpMethod']).publish(label='A')\nB = data('spans.duration.ns.p99', filter=f and (not filter('httpMethod', '*'))).mean(by=['service', 'operation']).publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Saturation of the service hosts (max of CPU, memory and disk utilization)",
+        "id": "EKWuLTBAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Hosts saturation",
+        "options": {
+          "colorBy": "Scale",
+          "colorRange": null,
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 90,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 75,
+              "gte": null,
+              "lt": null,
+              "lte": 90,
+              "paletteIndex": 17
+            },
+            {
+              "gt": 50,
+              "gte": null,
+              "lt": null,
+              "lte": 75,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 50,
+              "paletteIndex": 20
+            }
+          ],
+          "groupBy": [],
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "cpu.utilization",
+              "label": "A",
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null
+            },
+            {
+              "displayName": "disk.summary_utilization",
+              "label": "B",
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null
+            },
+            {
+              "displayName": "memory.utilization",
+              "label": "C",
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null
+            },
+            {
+              "displayName": "Saturation",
+              "label": "D",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
+            }
+          ],
+          "refreshInterval": null,
+          "sortDirection": "Ascending",
+          "sortProperty": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "Heatmap",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "f = filter('sf_hasService', '*') and filter('cluster', '*')\nA = data('cpu.utilization', filter=f).publish(label='A',enable=False)\nB = data('disk.summary_utilization', filter=f).publish(label='B',enable=False)\nC = data('memory.utilization', filter=f).publish(label='C',enable=False)\nD = max(A, B, C).sum(by='host').publish(label='D')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Memory usage in bytes of the containers in the Kubernetes pods of this service, and their utilization (if a memory limit is set for the pod)",
+        "id": "EKWuL5aAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod memory usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "%",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Memory usage in bytes",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            },
+            {
+              "displayName": "container_spec_memory_limit_bytes - Maximum by kubernetes_pod_uid,container_id - Exclude x < 0",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            },
+            {
+              "displayName": "Memory utilization (out of limit)",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('cluster', '*') and filter('service', '*')).mean(by=['kubernetes_pod_uid', 'container_id']).publish(label='A')\nB = data('container_spec_memory_limit_bytes', filter=filter('cluster', '*') and filter('service', '*')).max(by=['kubernetes_pod_uid', 'container_id']).above(0, inclusive=True).publish(label='B', enable=False)\nC = (100*A/B).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Network utilization in bytes (in and out) of the Kubernetes pods for this service",
+        "id": "EKWt_qFAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod network utilization (bytes/sec)",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Rx Bytes /sec (RED)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Tx Bytes /sec (BLUE)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx (bytes/sec)",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx (bytes/sec)",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 1
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('cluster', '*') and filter('service', '*'), extrapolation='zero').sum(by=['kubernetes_pod_uid', 'container_id']).publish(label='A')\nB = data('pod_network_transmit_bytes_total', filter=filter('cluster', '*') and filter('service', '*'), extrapolation='zero').sum(by=['kubernetes_pod_uid', 'container_id']).publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "CPU utilization of the containers in the Kubernetes pods of this service",
+        "id": "EKWt8CmAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod CPU usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": true,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "metric_source"
+              },
+              {
+                "enabled": true,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Container CPU utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": true,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_percent', filter=filter('cluster', '*') and filter('service', '*')).sum(by=['kubernetes_pod_uid', 'container_id']).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -2407,15 +3593,14 @@
       "crossLink": {
         "created": 0,
         "creator": null,
-        "id": "DsK5uFfAcIk",
+        "id": "EKWu-JXAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "propertyName": "service",
-        "propertyValue": "",
         "targets": [
           {
             "dashboardGroupId": "DsK5nuJAcAA",
-            "dashboardId": "DsK5tQFAcEo",
+            "dashboardId": "EKWt7miAcAA",
             "isDefault": true,
             "name": "APM Service",
             "type": "INTERNAL_LINK"
@@ -2430,87 +3615,129 @@
         "chartDensity": "HIGH",
         "charts": [
           {
-            "chartId": "D7F9A0cAcAA",
+            "chartId": "EKWuOWsAgAA",
             "column": 0,
-            "height": 2,
+            "height": 3,
             "row": 0,
             "width": 5
           },
           {
-            "chartId": "D7F9BFrAgAA",
+            "chartId": "EKWuLwZAcAA",
             "column": 5,
             "height": 1,
             "row": 0,
             "width": 3
           },
           {
-            "chartId": "D7F9BNAAcAA",
+            "chartId": "EKWuQD0AYAI",
             "column": 8,
             "height": 1,
             "row": 0,
             "width": 4
           },
           {
-            "chartId": "D7F9CB6AgAA",
+            "chartId": "EKWuNKrAcAA",
             "column": 5,
             "height": 1,
             "row": 1,
             "width": 3
           },
           {
-            "chartId": "D7F9CCBAYAA",
+            "chartId": "EKWuL_6AcAA",
             "column": 8,
             "height": 1,
             "row": 1,
             "width": 4
           },
           {
-            "chartId": "D7F9AnUAcAA",
+            "chartId": "EKWuOaXAcAA",
             "column": 5,
             "height": 1,
             "row": 2,
             "width": 3
           },
           {
-            "chartId": "D7F9CCmAgAA",
+            "chartId": "EKWuLxWAYAA",
             "column": 8,
             "height": 1,
             "row": 2,
             "width": 4
           },
           {
-            "chartId": "D7F9AxgAgAA",
-            "column": 0,
-            "height": 1,
-            "row": 2,
-            "width": 5
-          },
-          {
-            "chartId": "D7F9CCvAcAA",
+            "chartId": "EKWuOTVAYAA",
             "column": 0,
             "height": 1,
             "row": 3,
-            "width": 6
+            "width": 12
           },
           {
-            "chartId": "D7F9BagAYEQ",
-            "column": 6,
-            "height": 1,
-            "row": 3,
-            "width": 6
-          },
-          {
-            "chartId": "D7F9A7jAYAE",
+            "chartId": "EKWuMwIAgAA",
             "column": 6,
             "height": 1,
             "row": 4,
             "width": 6
           },
           {
-            "chartId": "D7F9CB-AcAA",
+            "chartId": "EKWuPOrAYAA",
             "column": 0,
             "height": 1,
             "row": 4,
+            "width": 6
+          },
+          {
+            "chartId": "EKWuLsFAgAA",
+            "column": 6,
+            "height": 1,
+            "row": 5,
+            "width": 6
+          },
+          {
+            "chartId": "EKWuLXdAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 5,
+            "width": 6
+          },
+          {
+            "chartId": "EKWuLTBAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 6,
+            "width": 12
+          },
+          {
+            "chartId": "EKWuPhVAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 7,
+            "width": 12
+          },
+          {
+            "chartId": "EKWuLWMAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 8,
+            "width": 6
+          },
+          {
+            "chartId": "EKWuL5aAgAA",
+            "column": 6,
+            "height": 1,
+            "row": 8,
+            "width": 6
+          },
+          {
+            "chartId": "EKWuMPkAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 9,
+            "width": 6
+          },
+          {
+            "chartId": "EKWuP6tAcAE",
+            "column": 6,
+            "height": 1,
+            "row": 9,
             "width": 6
           }
         ],
@@ -2522,7 +3749,10 @@
         "eventOverlays": null,
         "filters": {
           "sources": null,
-          "time": null,
+          "time": {
+            "end": "Now",
+            "start": "-1w"
+          },
           "variables": [
             {
               "alias": "Cluster",
@@ -2534,7 +3764,7 @@
               "required": true,
               "restricted": false,
               "value": [
-                "Choose Cluster"
+                "Choose cluster"
               ]
             },
             {
@@ -2547,7 +3777,7 @@
               "required": true,
               "restricted": false,
               "value": [
-                "Choose Service"
+                "Choose service"
               ]
             },
             {
@@ -2560,13 +3790,26 @@
               "required": true,
               "restricted": false,
               "value": [
-                "Choose Endpoint"
+                "Choose operation"
+              ]
+            },
+            {
+              "alias": "HTTP Method",
+              "applyIfExists": true,
+              "description": "HTTP Method",
+              "preferredSuggestions": [],
+              "property": "httpMethod",
+              "replaceOnly": true,
+              "required": false,
+              "restricted": false,
+              "value": [
+                "Choose HTTP Method"
               ]
             }
           ]
         },
         "groupId": "DsK5nuJAcAA",
-        "id": "D7F9AiGAgAA",
+        "id": "EKWuLPlAYAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "maxDelayOverride": null,
@@ -2580,115 +3823,164 @@
         "chartDensity": "DEFAULT",
         "charts": [
           {
-            "chartId": "D7x6v1cAgAk",
+            "chartId": "EKWt-3JAcAA",
             "column": 0,
             "height": 3,
             "row": 0,
             "width": 5
           },
           {
-            "chartId": "D7x6v1bAgEM",
+            "chartId": "EKWuAsKAYAA",
             "column": 8,
             "height": 1,
             "row": 0,
             "width": 4
           },
           {
-            "chartId": "D7x6v1bAgD8",
+            "chartId": "EKWt8VZAYAA",
             "column": 5,
             "height": 1,
             "row": 0,
             "width": 3
           },
           {
-            "chartId": "D7x6v1cAgAM",
+            "chartId": "EKWt_AVAYAA",
             "column": 5,
             "height": 1,
             "row": 1,
             "width": 3
           },
           {
-            "chartId": "D7x6v1cAgAA",
+            "chartId": "EKWt__8AgAA",
             "column": 8,
             "height": 1,
             "row": 1,
             "width": 4
           },
           {
-            "chartId": "D7x6v1cAgAY",
+            "chartId": "EKWt-RJAcAA",
             "column": 5,
             "height": 1,
             "row": 2,
             "width": 3
           },
           {
-            "chartId": "D7x6v1bAgD4",
+            "chartId": "EKWt-S6AYAA",
             "column": 8,
             "height": 1,
             "row": 2,
             "width": 4
           },
           {
-            "chartId": "D7x6v1bAgEE",
+            "chartId": "EKWt9R3AgAA",
             "column": 0,
             "height": 1,
             "row": 3,
             "width": 4
           },
           {
-            "chartId": "D7x6v1bAgEI",
+            "chartId": "EKWt-riAgAA",
             "column": 4,
             "height": 1,
             "row": 3,
             "width": 4
           },
           {
-            "chartId": "D7x6v1cAgAE",
+            "chartId": "EKWt_euAcAA",
             "column": 8,
             "height": 1,
             "row": 3,
             "width": 4
           },
           {
-            "chartId": "D7x6v1cAgAU",
+            "chartId": "EKWt-eoAYAA",
             "column": 0,
             "height": 1,
             "row": 4,
             "width": 6
           },
           {
-            "chartId": "D7x6v1cAgAQ",
+            "chartId": "EKWuA0EAgAA",
             "column": 6,
             "height": 1,
             "row": 4,
             "width": 6
           },
           {
-            "chartId": "D7x6v1cAgAc",
+            "chartId": "EKWuAj_AcAA",
             "column": 0,
             "height": 1,
             "row": 5,
-            "width": 6
+            "width": 12
           },
           {
-            "chartId": "D7x6v1bAgEA",
-            "column": 6,
-            "height": 1,
-            "row": 5,
-            "width": 6
-          },
-          {
-            "chartId": "D7x6v1cAgAg",
+            "chartId": "EKWt_CeAgAA",
             "column": 0,
             "height": 1,
             "row": 6,
             "width": 6
           },
           {
-            "chartId": "D7x6v1cAgAI",
+            "chartId": "EKWt-bVAcAA",
             "column": 6,
             "height": 1,
             "row": 6,
+            "width": 6
+          },
+          {
+            "chartId": "EKWt8VCAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 7,
+            "width": 6
+          },
+          {
+            "chartId": "EKWt_VSAgAA",
+            "column": 6,
+            "height": 1,
+            "row": 7,
+            "width": 6
+          },
+          {
+            "chartId": "EKWt_DVAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 8,
+            "width": 12
+          },
+          {
+            "chartId": "EKWt-UeAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 9,
+            "width": 12
+          },
+          {
+            "chartId": "EKWt8CmAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 10,
+            "width": 6
+          },
+          {
+            "chartId": "EKWt_NTAYAA",
+            "column": 6,
+            "height": 1,
+            "row": 10,
+            "width": 6
+          },
+          {
+            "chartId": "EKWt8OIAgC4",
+            "column": 0,
+            "height": 1,
+            "row": 11,
+            "width": 6
+          },
+          {
+            "chartId": "EKWt_qFAYAA",
+            "column": 6,
+            "height": 1,
+            "row": 11,
             "width": 6
           }
         ],
@@ -2731,7 +4023,7 @@
           ]
         },
         "groupId": "DsK5nuJAcAA",
-        "id": "DsK5tQFAcEo",
+        "id": "EKWt7miAcAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
         "maxDelayOverride": null,
@@ -2746,8 +4038,8 @@
       "created": 0,
       "creator": null,
       "dashboards": [
-        "DsK5tQFAcEo",
-        "D7F9AiGAgAA"
+        "EKWt7miAcAA",
+        "EKWuLPlAYAA"
       ],
       "description": "Microservices APM dashboards",
       "email": null,
@@ -2770,7 +4062,7 @@
       "teams": null
     }
   },
-  "hashCode": 1617446072,
+  "hashCode": 1095802076,
   "id": "DsK5nuJAcAA",
   "modelVersion": 1,
   "packageType": "GROUP"


### PR DESCRIPTION
* Adds Kubernetes pods usage charts in both service and service endpoint dashboards
* Fixes error rate charts for 100% error rate scenarios by adding zero extrapolation
* Fix crosslink export (will require manual cleanup of old APM crosslinks)