### PR TITLE
µAPM 2.0 dashboard updates

### DIFF
--- a/group/APM 2.0.json
+++ b/group/APM 2.0.json
@@ -102,7 +102,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_error', 'false') and filter('sf_operation', '*'), rollup='rate').sum(by=['sf_environment', 'sf_service', 'sf_operation']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*'), rollup='rate').sum(by=['sf_environment', 'sf_service', 'sf_operation']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_error', 'false') and filter('sf_operation', '*'), rollup='rate').sum().publish(label='A', enable=False)\nB = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*'), rollup='rate').sum().publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -188,7 +188,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "C = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*')).sum(by=['sf_environment', 'sf_service']).publish(label='C')",
+        "programText": "C = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*')).sum(by=['sf_service']).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -239,7 +239,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*')).sum(by=['sf_environment', 'sf_service']).publish(label='A')",
+        "programText": "A = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*')).sum().publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -290,7 +290,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*'), rollup='rate').sum(by=['sf_environment', 'sf_service', 'sf_operation']).publish(label='A')",
+        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*'), rollup='rate').sum().publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -396,7 +396,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('service.request.duration.ns.median', filter=filter('sf_environment', '*') and filter('sf_service', '*')).max(by=['sf_environment', 'sf_service']).publish(label='A')\nB = data('service.request.duration.ns.p90', filter=filter('sf_environment', '*') and filter('sf_service', '*')).max(by=['sf_environment', 'sf_service']).publish(label='B')\nC = data('service.request.duration.ns.p99', filter=filter('sf_environment', '*') and filter('sf_service', '*')).max(by=['sf_environment', 'sf_service']).publish(label='C')",
+        "programText": "A = data('service.request.duration.ns.median', filter=filter('sf_environment', '*') and filter('sf_service', '*')).max(by=['sf_service']).publish(label='A')\nB = data('service.request.duration.ns.p90', filter=filter('sf_environment', '*') and filter('sf_service', '*')).max(by=['sf_service']).publish(label='B')\nC = data('service.request.duration.ns.p99', filter=filter('sf_environment', '*') and filter('sf_service', '*')).max(by=['sf_service']).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -482,7 +482,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "C = data('spans.duration.ns.p99', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))).max(by=['sf_environment', 'sf_service', 'sf_operation']).publish(label='C')",
+        "programText": "C = data('spans.duration.ns.p99', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))).max(by=['sf_service', 'sf_operation']).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -588,7 +588,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_error', 'false'), rollup='delta').sum(by=['sf_environment', 'sf_service']).publish(label='A', enable=False)\nB = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='delta').sum(by=['sf_environment', 'sf_service']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "programText": "A = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_error', 'false'), rollup='delta').sum(by=['sf_service']).publish(label='A', enable=False)\nB = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='delta').sum(by=['sf_service']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -694,7 +694,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_error', 'false') and filter('sf_operation', '*'), rollup='rate').sum(by=['sf_environment', 'sf_service', 'sf_operation']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*'), rollup='rate').sum(by=['sf_environment', 'sf_service', 'sf_operation']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_error', 'false') and filter('sf_operation', '*'), rollup='rate').sum(by=['sf_service', 'sf_operation']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*'), rollup='rate').sum(by=['sf_service', 'sf_operation']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -780,7 +780,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['sf_environment', 'sf_service', 'sf_operation']).publish(label='A')",
+        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['sf_service', 'sf_operation']).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -831,7 +831,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.duration.ns.p99', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*')).max(by=['sf_environment', 'sf_service', 'sf_operation']).publish(label='A')",
+        "programText": "A = data('spans.duration.ns.p99', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*')).max().publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -917,7 +917,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*'), rollup='rate').sum(by=['sf_environment', 'sf_service', 'sf_operation']).publish(label='A')",
+        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*'), rollup='rate').sum(by=['sf_service', 'sf_operation']).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1023,7 +1023,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_error', 'false'), rollup='rate').sum(by=['sf_environment', 'sf_service', 'sf_operation']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['sf_environment', 'sf_service', 'sf_operation']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_error', 'false'), rollup='rate').sum(by=['sf_service', 'sf_operation']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['sf_service', 'sf_operation']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1129,7 +1129,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.duration.ns.median', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*')).max(by=['sf_environment', 'sf_service', 'sf_operation']).publish(label='A')\nB = data('spans.duration.ns.p90', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*')).max(by=['sf_environment', 'sf_service', 'sf_operation']).publish(label='B')\nC = data('spans.duration.ns.p99', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*')).max(by=['sf_environment', 'sf_service', 'sf_operation']).publish(label='C')",
+        "programText": "A = data('spans.duration.ns.median', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*')).max(by=['sf_service', 'sf_operation']).publish(label='A')\nB = data('spans.duration.ns.p90', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*')).max(by=['sf_service', 'sf_operation']).publish(label='B')\nC = data('spans.duration.ns.p99', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*')).max(by=['sf_service', 'sf_operation']).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1222,7 +1222,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_error', 'false'), rollup='delta').sum(by=['sf_environment', 'sf_service', 'sf_operation']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['sf_environment', 'sf_service', 'sf_operation']).publish(label='B', enable=False)\nC = (100*(B-A)/B).mean(over='1m').top(count=10).publish(label='C')",
+        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_error', 'false'), rollup='delta').sum(by=['sf_service', 'sf_operation']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['sf_service', 'sf_operation']).publish(label='B', enable=False)\nC = (100*(B-A)/B).mean(over='1m').top(count=10).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1295,7 +1295,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['sf_environment', 'sf_service', 'sf_operation']).mean(over='1m').top(count=10).publish(label='A')",
+        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['sf_service', 'sf_operation']).mean(over='1m').top(count=10).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1402,7 +1402,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_error', 'false'), rollup='delta').sum(by=['sf_environment', 'sf_service']).publish(label='A', enable=False)\nB = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='delta').sum(by=['sf_environment', 'sf_service']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "programText": "A = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_error', 'false'), rollup='delta').sum().publish(label='A', enable=False)\nB = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='delta').sum().publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1453,7 +1453,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('service.request.duration.ns.p99', filter=filter('sf_environment', '*') and filter('sf_service', '*')).max(by=['sf_environment', 'sf_service']).publish(label='A')",
+        "programText": "A = data('service.request.duration.ns.p99', filter=filter('sf_environment', '*') and filter('sf_service', '*')).max().publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1757,7 +1757,7 @@
       "teams": null
     }
   },
-  "hashCode": -1727725298,
+  "hashCode": 1128389126,
   "id": "EPK1YluAgAA",
   "modelVersion": 1,
   "packageType": "GROUP"

--- a/group/APM 2.0.json
+++ b/group/APM 2.0.json
@@ -406,12 +406,12 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "99th percentile response time by endpoint of the service",
+        "description": "90th percentile response time by endpoint of the service",
         "id": "EPK1bG4AgBg",
         "importOf": "EO6R-tZAAAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Request Latency (p99) by endpoint",
+        "name": "Request Latency (p90) by endpoint",
         "options": {
           "areaChartOptions": {
             "showDataMarkers": false
@@ -482,7 +482,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "C = data('spans.duration.ns.p99', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))).max(by=['sf_service', 'sf_operation']).publish(label='C')",
+        "programText": "C = data('spans.duration.ns.p90', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))).max(by=['sf_service', 'sf_operation']).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -588,7 +588,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_error', 'false'), rollup='delta').sum(by=['sf_service']).publish(label='A', enable=False)\nB = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='delta').sum(by=['sf_service']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "programText": "A = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_error', 'false'), rollup='delta', extrapolation='zero').sum(by=['sf_service']).publish(label='A', enable=False)\nB = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='delta').sum(by=['sf_service']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -790,12 +790,12 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "99th percentile response time",
+        "description": "90th percentile response time",
         "id": "EPK1cBCAcAA",
         "importOf": "EO64rWYAEAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Request Latency (p99)",
+        "name": "Request Latency (p90)",
         "options": {
           "colorBy": "Dimension",
           "colorScale": null,
@@ -809,9 +809,9 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "p99 latency",
+              "displayName": "p90 latency",
               "label": "A",
-              "paletteIndex": 5,
+              "paletteIndex": 1,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -831,7 +831,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.duration.ns.p99', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*')).max().publish(label='A')",
+        "programText": "A = data('spans.duration.ns.p90', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*')).max().publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1402,7 +1402,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_error', 'false'), rollup='delta').sum().publish(label='A', enable=False)\nB = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='delta').sum().publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "programText": "A = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_error', 'false'), rollup='delta', extrapolation='zero').sum().publish(label='A', enable=False)\nB = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='delta').sum().publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1412,12 +1412,12 @@
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "99th percentile response time",
+        "description": "90th percentile response time",
         "id": "EPK1eBXAYAA",
         "importOf": "EO6P-FOAIAA",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Request Latency (p99)",
+        "name": "Request Latency (p90)",
         "options": {
           "colorBy": "Dimension",
           "colorScale": null,
@@ -1433,7 +1433,7 @@
             {
               "displayName": "p99 latency",
               "label": "A",
-              "paletteIndex": 5,
+              "paletteIndex": 1,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -1453,7 +1453,1923 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('service.request.duration.ns.p99', filter=filter('sf_environment', '*') and filter('sf_service', '*')).max().publish(label='A')",
+        "programText": "A = data('service.request.duration.ns.p90', filter=filter('sf_environment', '*') and filter('sf_service', '*')).max().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "CPU Utilization of the service hosts",
+        "id": "EUIvuURAgAA",
+        "importOf": "EKWt_CeAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host CPU usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "%",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "cpu.utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('cpu.utilization', filter=filter('sf_environment', '*') and filter('sf_service', '*')).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Storage utilization, in bytes, of the Kubernetes pods for this service",
+        "id": "EUIvubFAYAA",
+        "importOf": "EKWt8OIAgC4",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod disk usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Disk utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_fs_usage_bytes', filter=filter('sf_environment', '*') and filter('sf_service', '*')).sum(by=['kubernetes_pod_uid', 'container_id']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Cumulative network utilization of the service hosts",
+        "id": "EUIvwgpAgAA",
+        "importOf": "EKWt_VSAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host network usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Network utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('network.total', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='rate').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "EUIvy5bAcAA",
+        "importOf": "EKWt-UeAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": ".",
+        "options": {
+          "markdown": "<table width=\"100%\" height=\"50%\" rules=\"none\">\n<tr><td valign=\"middle\" align=\"center\" bgcolor=\"#4682B4\">\n<font size=\"5\" color=\"white\">Kubernetes Pod Metrics</font>\n</td></tr>\n</table>\n<p align=\"center\" ><br />\nKey metrics from the Kubernetes pod(s) that power this service.<br />\n<i>Metrics will only populate these charts if your service is running in Kubernetes and your <a href=\"https://docs.signalfx.com/en/latest/integrations/kubernetes/index.html\">SignalFx Smart Agent is configured to monitor your Kubernetes environment</a>.</i>\n</p>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Disk utilization of the service hosts",
+        "id": "EUIvzujAgAA",
+        "importOf": "EKWt8VCAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host disk usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "%",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "disk.summary_utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('disk.summary_utilization', filter=filter('sf_environment', '*') and filter('sf_service', '*')).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "CPU utilization of the containers in the Kubernetes pods of this service",
+        "id": "EUIvz2FAYAA",
+        "importOf": "EKWt8CmAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod CPU usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": true,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "metric_source"
+              },
+              {
+                "enabled": true,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Container CPU utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": true,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_percent', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='rate').sum(by=['kubernetes_pod_uid', 'container_id']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "EUIvz9HAYAA",
+        "importOf": "EKWuAj_AcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": ".",
+        "options": {
+          "markdown": "<table width=\"100%\" height=\"50%\" rules=\"none\">\n<tr><td valign=\"middle\" align=\"center\" bgcolor=\"#4682B4\">\n<font size=\"5\" color=\"white\">Host Metrics</font>\n</td></tr>\n</table>\n<p align=\"center\" ><br />\nKey system-level metrics for the host(s) that power this service\n</p>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Memory usage in bytes of the containers in the Kubernetes pods of this service, and their utilization (if a memory limit is set for the pod)",
+        "id": "EUIv0AlAcAA",
+        "importOf": "EKWt_NTAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod memory usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "%",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Memory usage in bytes",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            },
+            {
+              "displayName": "container_spec_memory_limit_bytes - Maximum by kubernetes_pod_uid,container_id - Exclude x < 0",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            },
+            {
+              "displayName": "Memory utilization (out of limit)",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('sf_environment', '*') and filter('sf_service', '*')).mean(by=['kubernetes_pod_uid', 'container_id']).publish(label='A')\nB = data('container_spec_memory_limit_bytes', filter=filter('sf_environment', '*') and filter('sf_service', '*')).max(by=['kubernetes_pod_uid', 'container_id']).above(0, inclusive=True).publish(label='B', enable=False)\nC = (100*A/B).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Memory utilization of the service hosts",
+        "id": "EUIv0R-AgAA",
+        "importOf": "EKWt-bVAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host memory usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "%",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "memory.utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('memory.utilization', filter=filter('sf_environment', '*') and filter('sf_service', '*')).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Saturation of the service hosts (max of CPU, memory and disk utilization)",
+        "id": "EUIv2ONAYAA",
+        "importOf": "EKWt_DVAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host saturation",
+        "options": {
+          "colorBy": "Scale",
+          "colorRange": null,
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 90,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 75,
+              "gte": null,
+              "lt": null,
+              "lte": 90,
+              "paletteIndex": 17
+            },
+            {
+              "gt": 50,
+              "gte": null,
+              "lt": null,
+              "lte": 75,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 50,
+              "paletteIndex": 20
+            }
+          ],
+          "groupBy": [],
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "cpu.utilization",
+              "label": "A",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
+            },
+            {
+              "displayName": "memory.utilization",
+              "label": "B",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
+            },
+            {
+              "displayName": "disk.summary_utilization",
+              "label": "C",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
+            },
+            {
+              "displayName": "Saturation",
+              "label": "D",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
+            }
+          ],
+          "refreshInterval": null,
+          "sortDirection": "Ascending",
+          "sortProperty": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "Heatmap",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "f = filter('sf_environment', '*') and filter('sf_service', '*')\nA = data('cpu.utilization', filter=f).publish(label='A', enable=False)\nB = data('memory.utilization', filter=f).publish(label='B', enable=False)\nC = data('disk.summary_utilization', filter=f).publish(label='C', enable=False)\nD = max(A, B, C).sum(by='host').publish(label='D')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Network utilization in bytes (in and out) of the Kubernetes pods for this service",
+        "id": "EUIv3QIAYYw",
+        "importOf": "EKWt_qFAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod network utilization (bytes/sec)",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Rx Bytes /sec (RED)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Tx Bytes /sec (BLUE)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx (bytes/sec)",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx (bytes/sec)",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 1
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='rate', extrapolation='zero').sum(by=['kubernetes_pod_uid', 'container_id']).publish(label='A')\nB = data('pod_network_transmit_bytes_total', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='rate', extrapolation='zero').sum(by=['kubernetes_pod_uid', 'container_id']).publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "EUIwvvUAcAA",
+        "importOf": "EKWuAj_AcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": ".",
+        "options": {
+          "markdown": "<table width=\"100%\" height=\"50%\" rules=\"none\">\n<tr><td valign=\"middle\" align=\"center\" bgcolor=\"#4682B4\">\n<font size=\"5\" color=\"white\">Host Metrics</font>\n</td></tr>\n</table>\n<p align=\"center\" ><br />\nKey system-level metrics for the host(s) that power this service\n</p>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Network utilization in bytes (in and out) of the Kubernetes pods for this service",
+        "id": "EUIwx5jAYAA",
+        "importOf": "EKWt_qFAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod network utilization (bytes/sec)",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Rx Bytes /sec (RED)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "Tx Bytes /sec (BLUE)",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Rx (bytes/sec)",
+              "label": "A",
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            },
+            {
+              "displayName": "Tx (bytes/sec)",
+              "label": "B",
+              "paletteIndex": 1,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 1
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('pod_network_receive_bytes_total', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='rate', extrapolation='zero').sum(by=['kubernetes_pod_uid', 'container_id']).publish(label='A')\nB = data('pod_network_transmit_bytes_total', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='rate', extrapolation='zero').sum(by=['kubernetes_pod_uid', 'container_id']).publish(label='B')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Disk utilization of the service hosts",
+        "id": "EUIwyZYAYAA",
+        "importOf": "EKWt8VCAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host disk usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "%",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "disk.summary_utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('disk.summary_utilization', filter=filter('sf_environment', '*') and filter('sf_service', '*')).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "EUIwzKRAgAA",
+        "importOf": "EKWt-UeAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": ".",
+        "options": {
+          "markdown": "<table width=\"100%\" height=\"50%\" rules=\"none\">\n<tr><td valign=\"middle\" align=\"center\" bgcolor=\"#4682B4\">\n<font size=\"5\" color=\"white\">Kubernetes Pod Metrics</font>\n</td></tr>\n</table>\n<p align=\"center\" ><br />\nKey metrics from the Kubernetes pod(s) that power this service.<br />\n<i>Metrics will only populate these charts if your service is running in Kubernetes and your <a href=\"https://docs.signalfx.com/en/latest/integrations/kubernetes/index.html\">SignalFx Smart Agent is configured to monitor your Kubernetes environment</a>.</i>\n</p>",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Memory utilization of the service hosts",
+        "id": "EUIwzcqAcAA",
+        "importOf": "EKWt-bVAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host memory usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "%",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "memory.utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('memory.utilization', filter=filter('sf_environment', '*') and filter('sf_service', '*')).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Cumulative network utilization of the service hosts",
+        "id": "EUIwzcvAgAA",
+        "importOf": "EKWt_VSAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host network usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Network utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('network.total', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='rate').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Saturation of the service hosts (max of CPU, memory and disk utilization)",
+        "id": "EUIwznJAYAA",
+        "importOf": "EKWt_DVAcAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host saturation",
+        "options": {
+          "colorBy": "Scale",
+          "colorRange": null,
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 90,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 16
+            },
+            {
+              "gt": 75,
+              "gte": null,
+              "lt": null,
+              "lte": 90,
+              "paletteIndex": 17
+            },
+            {
+              "gt": 50,
+              "gte": null,
+              "lt": null,
+              "lte": 75,
+              "paletteIndex": 18
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 50,
+              "paletteIndex": 20
+            }
+          ],
+          "groupBy": [],
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "cpu.utilization",
+              "label": "A",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
+            },
+            {
+              "displayName": "memory.utilization",
+              "label": "B",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
+            },
+            {
+              "displayName": "disk.summary_utilization",
+              "label": "C",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
+            },
+            {
+              "displayName": "Saturation",
+              "label": "D",
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null
+            }
+          ],
+          "refreshInterval": null,
+          "sortDirection": "Ascending",
+          "sortProperty": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "Heatmap",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "f = filter('sf_environment', '*') and filter('sf_service', '*')\nA = data('cpu.utilization', filter=f).publish(label='A', enable=False)\nB = data('memory.utilization', filter=f).publish(label='B', enable=False)\nC = data('disk.summary_utilization', filter=f).publish(label='C', enable=False)\nD = max(A, B, C).sum(by='host').publish(label='D')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "CPU Utilization of the service hosts",
+        "id": "EUIw21kAcAA",
+        "importOf": "EKWt_CeAgAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Host CPU usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "%",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": null
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "cpu.utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "%",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('cpu.utilization', filter=filter('sf_environment', '*') and filter('sf_service', '*')).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Memory usage in bytes of the containers in the Kubernetes pods of this service, and their utilization (if a memory limit is set for the pod)",
+        "id": "EUIw3AGAcAA",
+        "importOf": "EKWt_NTAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod memory usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "%",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": 100,
+              "min": 0
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Memory usage in bytes",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            },
+            {
+              "displayName": "container_spec_memory_limit_bytes - Maximum by kubernetes_pod_uid,container_id - Exclude x < 0",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            },
+            {
+              "displayName": "Memory utilization (out of limit)",
+              "label": "C",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 1
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_memory_usage_bytes', filter=filter('sf_environment', '*') and filter('sf_service', '*')).mean(by=['kubernetes_pod_uid', 'container_id']).publish(label='A')\nB = data('container_spec_memory_limit_bytes', filter=filter('sf_environment', '*') and filter('sf_service', '*')).max(by=['kubernetes_pod_uid', 'container_id']).above(0, inclusive=True).publish(label='B', enable=False)\nC = (100*A/B).publish(label='C')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "CPU utilization of the containers in the Kubernetes pods of this service",
+        "id": "EUIw3OyAgAA",
+        "importOf": "EKWt8CmAYAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod CPU usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": true,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_node"
+              },
+              {
+                "enabled": false,
+                "property": "host"
+              },
+              {
+                "enabled": true,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "metric_source"
+              },
+              {
+                "enabled": true,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Container CPU utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": true,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_cpu_percent', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='rate').sum(by=['kubernetes_pod_uid', 'container_id']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Storage utilization, in bytes, of the Kubernetes pods for this service",
+        "id": "EUIw4hRAYAA",
+        "importOf": "EKWt8OIAgC4",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pod disk usage",
+        "options": {
+          "areaChartOptions": {
+            "showDataMarkers": false
+          },
+          "axes": [
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            },
+            {
+              "highWatermark": null,
+              "highWatermarkLabel": null,
+              "label": "",
+              "lowWatermark": null,
+              "lowWatermarkLabel": null,
+              "max": null,
+              "min": null
+            }
+          ],
+          "axisPrecision": null,
+          "colorBy": "Dimension",
+          "defaultPlotType": "LineChart",
+          "eventPublishLabelOptions": [],
+          "histogramChartOptions": {
+            "colorThemeIndex": 16
+          },
+          "includeZero": false,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_name"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_namespace"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_cluster"
+              },
+              {
+                "enabled": true,
+                "property": "kubernetes_pod_uid"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "container_id"
+              }
+            ]
+          },
+          "lineChartOptions": {
+            "showDataMarkers": false
+          },
+          "onChartLegendOptions": {
+            "dimensionInLegend": null,
+            "showLegend": false
+          },
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": null,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "Disk utilization",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "showEventLines": false,
+          "stacked": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "TimeSeriesChart",
+          "unitPrefix": "Binary"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('container_fs_usage_bytes', filter=filter('sf_environment', '*') and filter('sf_service', '*')).sum(by=['kubernetes_pod_uid', 'container_id']).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1526,6 +3442,83 @@
             "height": 1,
             "row": 2,
             "width": 8
+          },
+          {
+            "chartId": "EUIwvvUAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 3,
+            "width": 12
+          },
+          {
+            "chartId": "EUIw21kAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 4,
+            "width": 6
+          },
+          {
+            "chartId": "EUIwzcqAcAA",
+            "column": 6,
+            "height": 1,
+            "row": 4,
+            "width": 6
+          },
+          {
+            "chartId": "EUIwyZYAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 5,
+            "width": 6
+          },
+          {
+            "chartId": "EUIwzcvAgAA",
+            "column": 6,
+            "height": 1,
+            "row": 5,
+            "width": 6
+          },
+          {
+            "chartId": "EUIwznJAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 6,
+            "width": 12
+          },
+          {
+            "chartId": "EUIwzKRAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 7,
+            "width": 12
+          },
+          {
+            "chartId": "EUIw3AGAcAA",
+            "column": 6,
+            "height": 1,
+            "row": 8,
+            "width": 6
+          },
+          {
+            "chartId": "EUIw3OyAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 8,
+            "width": 6
+          },
+          {
+            "chartId": "EUIw4hRAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 9,
+            "width": 6
+          },
+          {
+            "chartId": "EUIwx5jAYAA",
+            "column": 6,
+            "height": 1,
+            "row": 9,
+            "width": 6
           }
         ],
         "created": 0,
@@ -1670,6 +3663,83 @@
             "height": 1,
             "row": 4,
             "width": 6
+          },
+          {
+            "chartId": "EUIvz9HAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 5,
+            "width": 12
+          },
+          {
+            "chartId": "EUIvuURAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 6,
+            "width": 6
+          },
+          {
+            "chartId": "EUIv0R-AgAA",
+            "column": 6,
+            "height": 1,
+            "row": 6,
+            "width": 6
+          },
+          {
+            "chartId": "EUIvzujAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 7,
+            "width": 6
+          },
+          {
+            "chartId": "EUIvwgpAgAA",
+            "column": 6,
+            "height": 1,
+            "row": 7,
+            "width": 6
+          },
+          {
+            "chartId": "EUIv2ONAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 8,
+            "width": 12
+          },
+          {
+            "chartId": "EUIvy5bAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 9,
+            "width": 12
+          },
+          {
+            "chartId": "EUIvz2FAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 10,
+            "width": 6
+          },
+          {
+            "chartId": "EUIv0AlAcAA",
+            "column": 6,
+            "height": 1,
+            "row": 10,
+            "width": 6
+          },
+          {
+            "chartId": "EUIvubFAYAA",
+            "column": 0,
+            "height": 1,
+            "row": 11,
+            "width": 6
+          },
+          {
+            "chartId": "EUIv3QIAYYw",
+            "column": 6,
+            "height": 1,
+            "row": 11,
+            "width": 6
           }
         ],
         "created": 0,
@@ -1757,7 +3827,7 @@
       "teams": null
     }
   },
-  "hashCode": 1128389126,
+  "hashCode": -1094039171,
   "id": "EPK1YluAgAA",
   "modelVersion": 1,
   "packageType": "GROUP"


### PR DESCRIPTION
* Group-by fixes
* Remove crosslinks that weren't meant to be there
* Use p90 response time in single value charts of RED metrics (with color)
* Add infrastructure correlation charts for hosts and K8s pods