### PR TITLE
remove invalid crosslinks from otel collector group

### DIFF
--- a/group/OpenTelemetry Collector.json
+++ b/group/OpenTelemetry Collector.json
@@ -1331,42 +1331,7 @@
       }
     }
   ],
-  "crossLinkExports": [
-    {
-      "crossLink": {
-        "created": 0,
-        "creator": null,
-        "id": "EPK1fSsAcZY",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "propertyName": "sf_service",
-        "targets": []
-      }
-    },
-    {
-      "crossLink": {
-        "created": 0,
-        "creator": null,
-        "id": "EKWu-JXAcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "propertyName": "service",
-        "targets": []
-      }
-    },
-    {
-      "crossLink": {
-        "contextId": "D2SmRRbAcAA",
-        "created": 0,
-        "creator": null,
-        "id": "EQCenU1AcAA",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "propertyName": "kubernetes_node",
-        "targets": []
-      }
-    }
-  ],
+  "crossLinkExports": [],
   "dashboardExports": [
     {
       "dashboard": {
@@ -1601,7 +1566,7 @@
       "teams": null
     }
   },
-  "hashCode": 1495798048,
+  "hashCode": 1928026111,
   "id": "EUZXDheAgAA",
   "modelVersion": 1,
   "packageType": "GROUP"


### PR DESCRIPTION
This is a manual fix so the hashCode may not be valid and our logs may spit our some errors, but at least it will import correctly until the exporter is fixed.