### PR TITLE
Add cpu.num_processors metric support in kubernetes pods dashboard

### DIFF
--- a/navigators/Kubernetes/kubernetes pods.json
+++ b/navigators/Kubernetes/kubernetes pods.json
@@ -93,7 +93,7 @@
               "type" : "property"
             } ],
             "resolution" : 60000,
-            "template" : "A = data('container_cpu_utilization' {{#filter}}, filter={{{filter}}}{{/filter}}, rollup='rate').sum(by=['kubernetes_pod_name', 'host', 'kubernetes_pod_name', 'kubernetes_namespace', 'kubernetes_cluster', 'kubernetes_node']).publish(label='A', enable=False)\nB = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('host', '*')).sum(by=['kubernetes_node']).publish(label='E', enable=False)\nC = (A/B).publish(label='C')",
+            "template" : "A = data('container_cpu_utilization' {{#filter}}, filter={{{filter}}}{{/filter}}, rollup='rate').sum(by=['kubernetes_pod_name', 'host', 'kubernetes_pod_name', 'kubernetes_namespace', 'kubernetes_cluster', 'kubernetes_node']).publish(label='A', enable=False)\nB = data('cpu.num_processors', filter=filter('kubernetes_cluster', '*') and filter('host', '*')).sum(by=['kubernetes_node']).publish(label='E', enable=False)\nC = (A/B).publish(label='C')\nD = data('machine_cpu_cores', filter=filter('kubernetes_cluster', '*') and filter('host', '*')).sum(by=['kubernetes_node']).publish(label='E', enable=False)\nE = (A/E).publish(label='E')",
             "varName" : "C"
           },
           "metricSelectors" : [ "container_cpu_utilization" ],


### PR DESCRIPTION
`machine_cpu_cores` metric is deprecated in favor of `cpu.num_processors` that is  reported by signalfx-agent kubelet-metrics monitor. This change adds support of both `machine_cpu_cores` and `cpu.num_processors` metrics in kubernetes pods dashboard