### PR TITLE
change k8s import qualifier

### DIFF
--- a/group/APM 2.0.json
+++ b/group/APM 2.0.json
@@ -3397,7 +3397,7 @@
             "dashboardGroupId": "EPK1YluAgAA",
             "dashboardId": "EPK1eRKAcAA",
             "isDefault": true,
-            "name": "µAPM Service",
+            "name": "µAPM 2.0 Service",
             "type": "INTERNAL_LINK"
           }
         ]
@@ -3835,7 +3835,7 @@
       "teams": null
     }
   },
-  "hashCode": -819667370,
+  "hashCode": -2011642771,
   "id": "EPK1YluAgAA",
   "modelVersion": 1,
   "packageType": "GROUP"

--- a/group/Kubernetes.json
+++ b/group/Kubernetes.json
@@ -10145,7 +10145,7 @@
       "teams" : null
     }
   },
-  "hashCode" : 1144989010,
+  "hashCode" : 1144989011,
   "id" : "DiVWf-iAgAA",
   "modelVersion" : 1,
   "packageType" : "GROUP"

--- a/group/Kubernetes.json
+++ b/group/Kubernetes.json
@@ -10134,8 +10134,8 @@
       "importQualifiers" : [ {
         "filters" : [ {
           "not" : false,
-          "property" : "metric_source",
-          "values" : [ "kubernetes" ]
+          "property" : "sf_key",
+          "values" : [ "kubernetes_pod_uid" ]
         } ],
         "metric" : "container_cpu_utilization"
       } ],
@@ -10145,7 +10145,7 @@
       "teams" : null
     }
   },
-  "hashCode" : 1144989011,
+  "hashCode" : 1771538912,
   "id" : "DiVWf-iAgAA",
   "modelVersion" : 1,
   "packageType" : "GROUP"

--- a/group/Kubernetes.json
+++ b/group/Kubernetes.json
@@ -8854,23 +8854,6 @@
     }
   }, {
     "crossLink" : {
-      "contextId" : "DkBnHSpAYAA",
-      "created" : 0,
-      "creator" : null,
-      "id" : "EZHM8keAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "propertyName" : "kubernetes_pod_uid",
-      "targets" : [ {
-        "dashboardGroupId" : "DiVWf-iAgAA",
-        "dashboardId" : "D8I_-P3AcAA",
-        "isDefault" : true,
-        "name" : "k8s-node-pod-uid-link",
-        "type" : "INTERNAL_LINK"
-      } ]
-    }
-  }, {
-    "crossLink" : {
       "contextId" : "D2SlSb5AgAA",
       "created" : 0,
       "creator" : null,
@@ -8951,6 +8934,23 @@
         "dashboardId" : "D8I_-P3AcAA",
         "isDefault" : true,
         "name" : "k8s-node-pod-name-link",
+        "type" : "INTERNAL_LINK"
+      } ]
+    }
+  }, {
+    "crossLink" : {
+      "contextId" : "DkBnHSpAYAA",
+      "created" : 0,
+      "creator" : null,
+      "id" : "EZHM8keAYAA",
+      "lastUpdated" : 0,
+      "lastUpdatedBy" : null,
+      "propertyName" : "kubernetes_pod_uid",
+      "targets" : [ {
+        "dashboardGroupId" : "DiVWf-iAgAA",
+        "dashboardId" : "D8I_-P3AcAA",
+        "isDefault" : true,
+        "name" : "k8s-node-pod-uid-link",
         "type" : "INTERNAL_LINK"
       } ]
     }
@@ -9161,8 +9161,8 @@
       "customProperties" : null,
       "description" : null,
       "discoveryOptions" : {
-        "query" : "_exists_:kubernetes_cluster AND _exists_:kubernetes_node",
-        "selectors" : [ "_exists_:kubernetes_node" ]
+        "query" : "_exists_:kubernetes_cluster AND _exists_:host",
+        "selectors" : [ "_exists_:host" ]
       },
       "eventOverlays" : null,
       "filters" : {
@@ -9437,7 +9437,7 @@
       "customProperties" : null,
       "description" : "An overview of multiple Kubernetes nodes",
       "discoveryOptions" : {
-        "query" : "_exists_:kubernetes_cluster AND _exists_:kubernetes_node",
+        "query" : "_exists_:kubernetes_cluster AND _exists_:host",
         "selectors" : [ "sf_key:kubernetes_cluster" ]
       },
       "eventOverlays" : null,
@@ -10145,7 +10145,7 @@
       "teams" : null
     }
   },
-  "hashCode" : -334284798,
+  "hashCode" : 1144989010,
   "id" : "DiVWf-iAgAA",
   "modelVersion" : 1,
   "packageType" : "GROUP"

--- a/navigators/Kubernetes/kubernetes nodes.json
+++ b/navigators/Kubernetes/kubernetes nodes.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 1275808377,
+  "hashCode" : 1275808378,
   "id" : "DiVVM3IAgAA",
   "importQualifiers" : [ {
     "filters" : [ {

--- a/navigators/Kubernetes/kubernetes nodes.json
+++ b/navigators/Kubernetes/kubernetes nodes.json
@@ -1,6 +1,14 @@
 {
-  "hashCode" : 1581120549,
+  "hashCode" : 1275808377,
   "id" : "DiVVM3IAgAA",
+  "importQualifiers" : [ {
+    "filters" : [ {
+      "not" : false,
+      "property" : "sf_key",
+      "values" : [ "kubernetes_cluster" ]
+    } ],
+    "metric" : "cpu.utilization"
+  } ],
   "modelVersion" : 1,
   "navigatorExport" : {
     "navigator" : {
@@ -30,10 +38,10 @@
         "filterProperties" : null,
         "id" : "kubernetes nodes",
         "idName" : "Node",
-        "idTemplate" : "{{kubernetes_node}} ({{kubernetes_cluster}})",
+        "idTemplate" : "{{host}} ({{kubernetes_cluster}})",
         "listColumns" : [ {
           "aggregate" : null,
-          "displayName" : "Node (Cluster)",
+          "displayName" : "Host",
           "format" : "id",
           "metric" : null,
           "property" : "id",
@@ -61,26 +69,24 @@
             "minValue" : 0,
             "range" : null
           },
-          "description" : "Color nodes based on percentage of CPU being used: under 20% (green) to over 80% (red)",
+          "description" : "Color hosts based on percentage of CPU being used: under 20% (green) to over 80% (red)",
           "displayName" : "CPU utilization",
           "id" : "collectd.cpu.utilization",
           "job" : {
             "filters" : [ {
-              "not" : false,
               "property" : "_exists_",
-              "propertyValue" : "kubernetes_node",
+              "propertyValue" : "host",
               "type" : "property"
             }, {
-              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "kubernetes_cluster",
               "type" : "property"
             } ],
             "resolution" : 60000,
-            "template" : "CTNR_CPU_USGE = data(\"container_cpu_utilization\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"rate\").sum(by=[\"kubernetes_node\", \"kubernetes_cluster\"]).mean(over=\"1m\")\nNEW_NUM_CORES = data(\"cpu.num_processors\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"average\").sum(by=[\"kubernetes_node\", \"kubernetes_cluster\"]).mean(over=\"1m\")\nNODE_CPU_NEW = (CTNR_CPU_USGE/NEW_NUM_CORES)\nOLD_NUM_CORES = data(\"machine_cpu_cores\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"average\").sum(by=[\"kubernetes_node\", \"kubernetes_cluster\"])\nNODE_CPU_OLD = (CTNR_CPU_USGE/OLD_NUM_CORES)\nNODE_CPU_USAGE = union(NODE_CPU_NEW, NODE_CPU_OLD)",
-            "varName" : "NODE_CPU_USAGE"
+            "template" : "CPU_UTILIZATION = data(\"cpu.utilization\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"kubernetes_cluster\", \"host\"])",
+            "varName" : "CPU_UTILIZATION"
           },
-          "metricSelectors" : [ "container_cpu_utilization", "cpu.num_processors", "machine_cpu_cores" ],
+          "metricSelectors" : [ "cpu.utilization" ],
           "type" : "metric",
           "valueFormat" : "Percentage",
           "valueLabel" : "CPU Use",
@@ -93,23 +99,21 @@
             "minValue" : 0,
             "range" : null
           },
-          "description" : "Color nodes based on percentage of available memory being used: under 20% (green) to over 80% (red)",
+          "description" : "Color hosts based on percentage of available memory being used: under 20% (green) to over 80% (red)",
           "displayName" : "Memory utilization",
           "id" : "collectd.memory.utilization",
           "job" : {
             "filters" : [ {
-              "not" : false,
               "property" : "_exists_",
-              "propertyValue" : "kubernetes_node",
+              "propertyValue" : "host",
               "type" : "property"
             }, {
-              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "kubernetes_cluster",
               "type" : "property"
             } ],
             "resolution" : 60000,
-            "template" : "MEMORY_UTILIZATION = data(\"memory.utilization\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"kubernetes_cluster\", \"kubernetes_node\"])",
+            "template" : "MEMORY_UTILIZATION = data(\"memory.utilization\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"kubernetes_cluster\", \"host\"])",
             "varName" : "MEMORY_UTILIZATION"
           },
           "metricSelectors" : [ "memory.utilization" ],
@@ -125,23 +129,21 @@
             "minValue" : 0,
             "range" : null
           },
-          "description" : "Color nodes based on percentage of available disk space being used: under 20% (green) to over 80% (red)",
+          "description" : "Color hosts based on percentage of available disk space being used: under 20% (green) to over 80% (red)",
           "displayName" : "Disk utilization",
           "id" : "collectd.disk.summary_utilization",
           "job" : {
             "filters" : [ {
-              "not" : false,
               "property" : "_exists_",
-              "propertyValue" : "kubernetes_node",
+              "propertyValue" : "host",
               "type" : "property"
             }, {
-              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "kubernetes_cluster",
               "type" : "property"
             } ],
             "resolution" : 60000,
-            "template" : "DISK_UTILIZATION = data(\"disk.summary_utilization\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"kubernetes_cluster\", \"kubernetes_node\"])",
+            "template" : "DISK_UTILIZATION = data(\"disk.summary_utilization\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"kubernetes_cluster\", \"host\"])",
             "varName" : "DISK_UTILIZATION"
           },
           "metricSelectors" : [ "disk.summary_utilization" ],
@@ -157,23 +159,21 @@
             "minValue" : 0,
             "range" : null
           },
-          "description" : "Color nodes by relative amount of network traffic in bits per second: lowest 20% of traffic (green) to highest 20% of traffic (red)",
+          "description" : "Color hosts by relative amount of network traffic in bits per second: lowest 20% of traffic (green) to highest 20% of traffic (red)",
           "displayName" : "Network total",
           "id" : "collectd.network.total",
           "job" : {
             "filters" : [ {
-              "not" : false,
               "property" : "_exists_",
-              "propertyValue" : "kubernetes_node",
+              "propertyValue" : "host",
               "type" : "property"
             }, {
-              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "kubernetes_cluster",
               "type" : "property"
             } ],
             "resolution" : 60000,
-            "template" : "NETWORK_TOTAL = data(\"network.total\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"kubernetes_cluster\", \"kubernetes_node\"])",
+            "template" : "NETWORK_TOTAL = data(\"network.total\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"kubernetes_cluster\", \"host\"])",
             "varName" : "NETWORK_TOTAL"
           },
           "metricSelectors" : [ "network.total" ],
@@ -200,18 +200,16 @@
           "id" : "network.errors",
           "job" : {
             "filters" : [ {
-              "not" : false,
               "property" : "_exists_",
-              "propertyValue" : "kubernetes_node",
+              "propertyValue" : "host",
               "type" : "property"
             }, {
-              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "kubernetes_cluster",
               "type" : "property"
             } ],
             "resolution" : 60000,
-            "template" : "ERR_TX = data(\"pod_network_transmit_errors_total\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"kubernetes_cluster\", \"kubernetes_node\"])\nERR_RX = data(\"pod_network_receive_errors_total\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"kubernetes_cluster\", \"kubernetes_node\"])\nERR_TOTAL = ERR_TX + ERR_RX",
+            "template" : "ERR_TX = data(\"pod_network_transmit_errors_total\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"kubernetes_cluster\", \"host\"])\nERR_RX = data(\"pod_network_receive_errors_total\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"kubernetes_cluster\", \"host\"])\nERR_TOTAL = ERR_TX + ERR_RX",
             "varName" : "ERR_TOTAL"
           },
           "metricSelectors" : [ "pod_network_transmit_errors_total", "pod_network_receive_errors_total" ],
@@ -229,23 +227,21 @@
             "minValue" : 0,
             "range" : null
           },
-          "description" : "Color nodes by the highest alert level they are currently reporting – critical, major, minor, warning, none",
+          "description" : "Color hosts by the highest alert level they are currently reporting – critical, major, minor, warning, none",
           "displayName" : "Most severe alert",
           "id" : "___SF_ALERT_COLLECTD",
           "job" : {
             "filters" : [ {
-              "not" : false,
               "property" : "_exists_",
-              "propertyValue" : "kubernetes_node",
+              "propertyValue" : "host",
               "type" : "property"
             }, {
-              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "kubernetes_cluster",
               "type" : "property"
             } ],
             "resolution" : 60000,
-            "template" : "CPU_UTILIZATION = data(\"cpu.utilization\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"kubernetes_cluster\", \"kubernetes_node\"])",
+            "template" : "CPU_UTILIZATION = data(\"cpu.utilization\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"kubernetes_cluster\", \"host\"])",
             "varName" : "CPU_UTILIZATION"
           },
           "metricSelectors" : [ ],
@@ -265,12 +261,12 @@
           "properties" : [ ]
         } ] ],
         "proxyProperties" : null,
-        "requiredProperties" : [ "kubernetes_node" ],
+        "requiredProperties" : [ "host" ],
         "singleHostSystemDashboardName" : "K8s Node",
         "systemDashboardName" : "K8s Nodes",
         "systemDashboardPrefix" : null,
         "tooltipKeyList" : [ {
-          "displayName" : "Node (cluster)",
+          "displayName" : "Host",
           "format" : null,
           "isSummaryProperty" : true,
           "property" : "id"


### PR DESCRIPTION
OpenTelemetry Collector will not emit `metric_source: kubernetes` so keying off the existence of the dimension `kubernetes_pod_uid` seems better.