### PR TITLE
task(branding): rename dashboard group to APM

### DIFF
--- a/group/APM 2.0.json
+++ b/group/APM 2.0.json
@@ -3397,7 +3397,7 @@
             "dashboardGroupId": "EPK1YluAgAA",
             "dashboardId": "EPK1eRKAcAA",
             "isDefault": true,
-            "name": "µAPM 2.0 Service",
+            "name": "APM 2.0 Service",
             "type": "INTERNAL_LINK"
           }
         ]
@@ -3532,7 +3532,7 @@
         "created": 0,
         "creator": null,
         "customProperties": null,
-        "description": "Endpoint-level indicators from µAPM Tracing Metrics",
+        "description": "Endpoint-level indicators from APM Tracing Metrics",
         "discoveryOptions": null,
         "eventOverlays": null,
         "filters": {
@@ -3542,7 +3542,7 @@
             {
               "alias": "Environment",
               "applyIfExists": false,
-              "description": "µAPM Environment Name",
+              "description": "APM Environment Name",
               "preferredSuggestions": [],
               "property": "sf_environment",
               "replaceOnly": true,
@@ -3555,7 +3555,7 @@
             {
               "alias": "Service",
               "applyIfExists": false,
-              "description": "µAPM Service Name",
+              "description": "APM Service Name",
               "preferredSuggestions": [],
               "property": "sf_service",
               "replaceOnly": true,
@@ -3568,7 +3568,7 @@
             {
               "alias": "Endpoint",
               "applyIfExists": false,
-              "description": "µAPM Service Endpoint Name",
+              "description": "APM Service Endpoint Name",
               "preferredSuggestions": [],
               "property": "sf_operation",
               "replaceOnly": true,
@@ -3753,7 +3753,7 @@
         "created": 0,
         "creator": null,
         "customProperties": null,
-        "description": "Service-level indicators from µAPM Tracing Metrics",
+        "description": "Service-level indicators from APM Tracing Metrics",
         "discoveryOptions": null,
         "eventOverlays": null,
         "filters": {
@@ -3763,7 +3763,7 @@
             {
               "alias": "Environment",
               "applyIfExists": false,
-              "description": "µAPM Environment Name",
+              "description": "APM Environment Name",
               "preferredSuggestions": [],
               "property": "sf_environment",
               "replaceOnly": true,
@@ -3776,7 +3776,7 @@
             {
               "alias": "Service",
               "applyIfExists": false,
-              "description": "µAPM Service Name",
+              "description": "APM Service Name",
               "preferredSuggestions": [],
               "property": "sf_service",
               "replaceOnly": true,
@@ -3808,7 +3808,7 @@
         "EPK1eRKAcAA",
         "EPK1eMHAgAA"
       ],
-      "description": "µAPM Service and Endpoint dashboards",
+      "description": "APM Service and Endpoint dashboards",
       "email": null,
       "id": "EPK1YluAgAA",
       "importDetails": {
@@ -3831,7 +3831,7 @@
       ],
       "lastUpdated": 0,
       "lastUpdatedBy": null,
-      "name": "µAPM",
+      "name": "APM",
       "teams": null
     }
   },

--- a/group/Smart Gateway.json
+++ b/group/Smart Gateway.json
@@ -1150,7 +1150,7 @@
       "lastUpdatedBy" : null,
       "name" : ".",
       "options" : {
-        "markdown" : "<table width=\"100%\" height=\"30%\" rules=\"none\"><tr><td valign=\"middle\" align=\"center\" bgcolor=\"#4682B4\">\n<font size=\"5\" color=\"white\">Internal Smart Gateway Metrics</font>\n</td></tr></table><br>\nThis dashboard requires turning on the sending of [Internal Gateway Metrics] (https://github.com/signalfx/integrations/tree/master/gateway#signalfx-performance-options) by setting the `EmitDebugMetrics` parameter in your Smart Gateway configuration.\n\n_Note that these metrics will take up some of your Custom Metrics and DPM capacity and are **not** included in your µAPM plan._",
+        "markdown" : "<table width=\"100%\" height=\"30%\" rules=\"none\"><tr><td valign=\"middle\" align=\"center\" bgcolor=\"#4682B4\">\n<font size=\"5\" color=\"white\">Internal Smart Gateway Metrics</font>\n</td></tr></table><br>\nThis dashboard requires turning on the sending of [Internal Gateway Metrics] (https://github.com/signalfx/integrations/tree/master/gateway#signalfx-performance-options) by setting the `EmitDebugMetrics` parameter in your Smart Gateway configuration.\n\n_Note that these metrics will take up some of your Custom Metrics and DPM capacity and are **not** included in your APM plan._",
         "type" : "Text"
       },
       "packageSpecifications" : "",


### PR DESCRIPTION
This changes the build-in dashbaord group from µAPM
to APM.

Issue: https://signalfuse.atlassian.net/browse/APMF-2155