### PR TITLE
aks: Fix certain charts

### DIFF
--- a/group/Azure Kubernetes Service.json
+++ b/group/Azure Kubernetes Service.json
@@ -1,830 +1,936 @@
 {
-  "chartExports" : [ {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Number of pods in the cluster. Apply the namespace filter to see number of pods in a namespace.",
-      "id" : "D0RX4z_AcAA",
-      "importOf" : "Dzw508MAAAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "# of Pods",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale" : null,
-        "colorScale2" : null,
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : 0,
-          "minimumResolution" : 0,
-          "timezone" : null
+  "chartExports": [
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Number of pods in the cluster. Apply the namespace filter to see number of pods in a namespace.",
+        "id": "D0RX4z_AcAA",
+        "importOf": "Dzw508MAAAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# of Pods",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
         },
-        "publishLabelOptions" : [ {
-          "displayName" : "",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "None",
-        "showSparkLine" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
+        "packageSpecifications": "",
+        "programText": "A = data('kube_pod_status_ready', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='average', extrapolation='zero').mean(by=['pod']).count().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Number of pods NOT in Ready state by namespace",
+        "id": "D0RX46NAgAE",
+        "importOf": "DztsRbPAEAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# of Pods NOT in Ready state per namespace",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "hideMissingValues": false,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": true,
+                "property": "namespace"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "primary_aggregation_type"
+              },
+              {
+                "enabled": true,
+                "property": "azure_resource_id"
+              },
+              {
+                "enabled": true,
+                "property": "pod"
+              },
+              {
+                "enabled": true,
+                "property": "resource_group_id"
+              },
+              {
+                "enabled": true,
+                "property": "resource_type"
+              },
+              {
+                "enabled": true,
+                "property": "aggregation_type"
+              },
+              {
+                "enabled": true,
+                "property": "subscription_id"
+              },
+              {
+                "enabled": true,
+                "property": "unit"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "kube_pod_status_ready - Exclude x > 0 - Count by namespace",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": 300000,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "",
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
         },
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('kube_pod_status_ready', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='average', extrapolation='zero').mean(by=['pod']).count().publish(label='A')",
-      "relatedDetectorIds" : [ ],
-      "tags" : null
+        "packageSpecifications": "",
+        "programText": "A = data('kube_pod_status_ready', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='average', extrapolation='zero').mean(by=['pod']).below(0, inclusive=True).count(by=['namespace']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Number of pods in running phase across the cluster. Apply the namespace filter to see number of pods in a namespace.",
+        "id": "D0RX5ESAYAA",
+        "importOf": "Dz0QGmwAIAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# of Pods in Unknown Phase",
+        "options": {
+          "colorBy": "Scale",
+          "colorRange": null,
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 1,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 20
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 1,
+              "paletteIndex": 20
+            }
+          ],
+          "groupBy": [],
+          "programOptions": {
+            "disableSampling": true,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "kube_pod_status_phase - Mean by pod,namespace - Exclude x <= 0",
+              "label": "A",
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null
+            }
+          ],
+          "refreshInterval": null,
+          "sortDirection": "Ascending",
+          "sortProperty": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "Heatmap",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kube_pod_status_phase', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true') and filter('phase', 'Unknown', 'unknown'), rollup='latest').mean(by=['pod', 'namespace']).above(0).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Total number of available cpu cores in a managed cluster",
+        "id": "D0RX5MjAcAA",
+        "importOf": "DztsRbWAIAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Allocatable CPU Cores",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "kube_node_status_allocatable_cpu_cores",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kube_node_status_allocatable_cpu_cores', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='latest').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Number of pods in failed phase across the cluster. Apply the namespace filter to see number of pods in a namespace.",
+        "id": "D0RX5QwAgAA",
+        "importOf": "Dz0QFZeAAAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# of Pods in Failed Phase",
+        "options": {
+          "colorBy": "Scale",
+          "colorRange": null,
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 1,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 20
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 1,
+              "paletteIndex": 20
+            }
+          ],
+          "groupBy": [],
+          "programOptions": {
+            "disableSampling": true,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "kube_pod_status_phase - Mean by pod - Exclude x <= 0",
+              "label": "A",
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null
+            }
+          ],
+          "refreshInterval": null,
+          "sortDirection": "Ascending",
+          "sortProperty": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "Heatmap",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kube_pod_status_phase', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true') and filter('phase', 'Failed'), rollup='latest').mean(by=['pod']).above(0).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Pods by state within the cluster. GREEN indicates a pod is READY. Apply the namespace filter to see number of pods in a namespace.",
+        "id": "D0RX5SzAYDI",
+        "importOf": "Dz0QGjqAAAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pods by State",
+        "options": {
+          "colorBy": "Scale",
+          "colorRange": null,
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 0,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 19
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 0,
+              "paletteIndex": 16
+            }
+          ],
+          "groupBy": [],
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "",
+              "label": "A",
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null
+            }
+          ],
+          "refreshInterval": 300000,
+          "sortDirection": "Ascending",
+          "sortProperty": null,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "Heatmap",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kube_pod_status_ready', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='latest', extrapolation='zero').mean(by=['pod']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Number of pods in pending phase across the cluster. Apply the namespace filter to see number of pods in a namespace.",
+        "id": "D0RX5VKAcAE",
+        "importOf": "Dz0QGkOAEAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# of Pods in Pending Phase",
+        "options": {
+          "colorBy": "Scale",
+          "colorRange": null,
+          "colorScale": null,
+          "colorScale2": [
+            {
+              "gt": 1,
+              "gte": null,
+              "lt": null,
+              "lte": null,
+              "paletteIndex": 20
+            },
+            {
+              "gt": null,
+              "gte": null,
+              "lt": null,
+              "lte": 1,
+              "paletteIndex": 20
+            }
+          ],
+          "groupBy": [],
+          "programOptions": {
+            "disableSampling": true,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "kube_pod_status_phase - Mean by pod - Exclude x <= 0",
+              "label": "A",
+              "valuePrefix": "",
+              "valueSuffix": "",
+              "valueUnit": null
+            }
+          ],
+          "refreshInterval": null,
+          "sortDirection": "Ascending",
+          "sortProperty": null,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "Heatmap",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kube_pod_status_phase', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true') and filter('phase', 'Pending'), rollup='latest').mean(by=['pod']).above(0).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Number of pods NOT in Ready state across the cluster. Apply the namespace filter to see number of pods in a namespace.",
+        "id": "D0RX5ZVAgB8",
+        "importOf": "DzwpzRwAAAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# of Pods NOT in Ready state",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "kube_pod_status_ready - Exclude x > 0 - Count",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": 300000,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kube_pod_status_ready', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='latest', extrapolation='zero').mean(by=['pod']).below(0, inclusive=True).count().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Number of pods by phase in the cluster. Apply the namespace filter to see number of pods in a namespace.",
+        "id": "D0RX5d_AYAA",
+        "importOf": "DzttL-aAEAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# of Pods by Phase",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale2": null,
+          "hideMissingValues": false,
+          "legendOptions": {
+            "fields": [
+              {
+                "enabled": false,
+                "property": "aggregation_type"
+              },
+              {
+                "enabled": false,
+                "property": "azure_resource_id"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": true,
+                "property": "namespace"
+              },
+              {
+                "enabled": true,
+                "property": "phase"
+              },
+              {
+                "enabled": false,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "pod"
+              },
+              {
+                "enabled": false,
+                "property": "primary_aggregation_type"
+              },
+              {
+                "enabled": false,
+                "property": "resource_group_id"
+              },
+              {
+                "enabled": false,
+                "property": "resource_type"
+              },
+              {
+                "enabled": false,
+                "property": "subscription_id"
+              },
+              {
+                "enabled": false,
+                "property": "unit"
+              }
+            ]
+          },
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": true,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "kube_pod_status_phase - Count by phase",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "-value",
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "type": "List",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kube_pod_status_phase', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='average').above(0).mean(by=['pod', 'phase']).count(by=['phase']).publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Total amount of available memory in a managed cluster",
+        "id": "D0RX5fkAcAA",
+        "importOf": "DztsRbxAAAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Available Memory",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": 4,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": null,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "kube_node_status_allocatable_memory_bytes",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": "Byte",
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 3600000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kube_node_status_allocatable_memory_bytes', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='latest').publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "Number of nodes in the cluster",
+        "id": "D0RX5mFAgAA",
+        "importOf": "DzttL-bAIAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "# of Nodes",
+        "options": {
+          "colorBy": "Dimension",
+          "colorScale": null,
+          "colorScale2": null,
+          "maximumPrecision": null,
+          "programOptions": {
+            "disableSampling": false,
+            "maxDelay": 0,
+            "minimumResolution": 0,
+            "timezone": null
+          },
+          "publishLabelOptions": [
+            {
+              "displayName": "kube_node_status_condition - Mean by node - Count",
+              "label": "A",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            }
+          ],
+          "refreshInterval": null,
+          "secondaryVisualization": "None",
+          "showSparkLine": false,
+          "time": {
+            "range": 900000,
+            "type": "relative"
+          },
+          "timestampHidden": false,
+          "type": "SingleValue",
+          "unitPrefix": "Metric"
+        },
+        "packageSpecifications": "",
+        "programText": "A = data('kube_node_status_condition', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'),rollup='rate').mean(by=['node']).count().publish(label='A')",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
+    },
+    {
+      "chart": {
+        "created": 0,
+        "creator": null,
+        "customProperties": {},
+        "description": "",
+        "id": "D0RX5ugAcAI",
+        "importOf": "Dz0QF2jAEAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "name": "Pods by Phase",
+        "options": {
+          "markdown": "Heatmaps below indicate the number of pods in each of below specified phases\n\n**Pending**\n\nThe Pod has been accepted by the Kubernetes system, but one or more of the Container images has not been created. This includes time before being scheduled as well as time spent downloading images over the network, which could take a while.\n\n**Failed** \n\nAll Containers in the Pod have terminated, and at least one Container has terminated in failure. That is, the Container either exited with non-zero status or was terminated by the system.\n\n**Unknown**\n\n For some reason the state of the Pod could not be obtained, typically due to an error in communicating with the host of the Pod .",
+          "type": "Text"
+        },
+        "packageSpecifications": "",
+        "programText": "",
+        "relatedDetectorIds": [],
+        "tags": null
+      }
     }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Number of pods NOT in Ready state by namespace",
-      "id" : "D0RX46NAgAE",
-      "importOf" : "DztsRbPAEAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "# of Pods NOT in Ready state per namespace",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale2" : null,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : false,
-            "property" : "sf_originatingMetric"
-          }, {
-            "enabled" : true,
-            "property" : "namespace"
-          }, {
-            "enabled" : false,
-            "property" : "sf_metric"
-          }, {
-            "enabled" : true,
-            "property" : "primary_aggregation_type"
-          }, {
-            "enabled" : true,
-            "property" : "azure_resource_id"
-          }, {
-            "enabled" : true,
-            "property" : "pod"
-          }, {
-            "enabled" : true,
-            "property" : "resource_group_id"
-          }, {
-            "enabled" : true,
-            "property" : "resource_type"
-          }, {
-            "enabled" : true,
-            "property" : "aggregation_type"
-          }, {
-            "enabled" : true,
-            "property" : "subscription_id"
-          }, {
-            "enabled" : true,
-            "property" : "unit"
-          } ]
+  ],
+  "crossLinkExports": [],
+  "dashboardExports": [
+    {
+      "dashboard": {
+        "chartDensity": "DEFAULT",
+        "charts": [
+          {
+            "chartId": "D0RX4z_AcAA",
+            "column": 4,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "D0RX5ZVAgB8",
+            "column": 8,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "D0RX5mFAgAA",
+            "column": 0,
+            "height": 1,
+            "row": 0,
+            "width": 4
+          },
+          {
+            "chartId": "D0RX5MjAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 1,
+            "width": 4
+          },
+          {
+            "chartId": "D0RX5SzAYDI",
+            "column": 4,
+            "height": 2,
+            "row": 1,
+            "width": 8
+          },
+          {
+            "chartId": "D0RX5fkAcAA",
+            "column": 0,
+            "height": 1,
+            "row": 2,
+            "width": 4
+          },
+          {
+            "chartId": "D0RX5ugAcAI",
+            "column": 0,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "D0RX46NAgAE",
+            "column": 8,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "D0RX5d_AYAA",
+            "column": 4,
+            "height": 1,
+            "row": 3,
+            "width": 4
+          },
+          {
+            "chartId": "D0RX5VKAcAE",
+            "column": 0,
+            "height": 2,
+            "row": 4,
+            "width": 4
+          },
+          {
+            "chartId": "D0RX5ESAYAA",
+            "column": 8,
+            "height": 2,
+            "row": 4,
+            "width": 4
+          },
+          {
+            "chartId": "D0RX5QwAgAA",
+            "column": 4,
+            "height": 2,
+            "row": 4,
+            "width": 4
+          }
+        ],
+        "created": 0,
+        "creator": null,
+        "customProperties": null,
+        "description": "An overview of Azure Managed Cluster (AKS)",
+        "discoveryOptions": null,
+        "eventOverlays": null,
+        "filters": {
+          "sources": null,
+          "time": null,
+          "variables": [
+            {
+              "alias": "Subscription Name",
+              "applyIfExists": false,
+              "description": "",
+              "preferredSuggestions": [],
+              "property": "azure_subscription_display_name",
+              "replaceOnly": false,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            },
+            {
+              "alias": "Cluster Resource ID",
+              "applyIfExists": false,
+              "description": "",
+              "preferredSuggestions": [],
+              "property": "azure_resource_id",
+              "replaceOnly": false,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            },
+            {
+              "alias": "namespace",
+              "applyIfExists": true,
+              "description": "",
+              "preferredSuggestions": [],
+              "property": "namespace",
+              "replaceOnly": true,
+              "required": false,
+              "restricted": false,
+              "value": ""
+            }
+          ]
         },
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : 0,
-          "minimumResolution" : 0,
-          "timezone" : null
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : 300000,
-        "secondaryVisualization" : "Sparkline",
-        "sortBy" : "",
-        "time" : {
-          "range" : 3600000,
-          "type" : "relative"
-        },
-        "type" : "List",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('kube_pod_status_ready', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='average', extrapolation='zero').below(0, inclusive=True).count(by=['namespace']).publish(label='A')",
-      "relatedDetectorIds" : [ ],
-      "tags" : null
+        "groupId": "D0RX4scAYAA",
+        "id": "D0RX5z0AgAA",
+        "importOf": "DzttL-YAIAA",
+        "lastUpdated": 0,
+        "lastUpdatedBy": null,
+        "maxDelayOverride": null,
+        "name": "Azure Managed Cluster",
+        "selectedEventOverlays": null,
+        "tags": null
+      }
     }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Number of pods in running phase across the cluster. Apply the namespace filter to see number of pods in a namespace.",
-      "id" : "D0RX5ESAYAA",
-      "importOf" : "Dz0QGmwAIAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "# of Pods in Unknown Phase",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorRange" : null,
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 1.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 20
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 1.0,
-          "paletteIndex" : 20
-        } ],
-        "groupBy" : [ ],
-        "programOptions" : {
-          "disableSampling" : true,
-          "maxDelay" : 0,
-          "minimumResolution" : 0,
-          "timezone" : null
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "kube_pod_status_phase - Mean by pod,namespace - Exclude x <= 0",
-          "label" : "A",
-          "valuePrefix" : "",
-          "valueSuffix" : "",
-          "valueUnit" : null
-        } ],
-        "refreshInterval" : null,
-        "sortDirection" : "Ascending",
-        "sortProperty" : null,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "timestampHidden" : false,
-        "type" : "Heatmap",
-        "unitPrefix" : "Metric"
+  ],
+  "groupExport": {
+    "group": {
+      "created": 0,
+      "creator": null,
+      "dashboards": [
+        "D0RX5z0AgAA"
+      ],
+      "description": "",
+      "email": null,
+      "id": "D0RX4scAYAA",
+      "importDetails": {
+        "hashCode": -1808524001,
+        "importOf": "DzttL-PAEAA",
+        "importTime": 1551120183146
       },
-      "packageSpecifications" : "",
-      "programText" : "A = data('kube_pod_status_phase', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true') and filter('phase', 'Unknown', 'unknown'), rollup='latest').mean(by=['pod', 'namespace']).above(0).publish(label='A')",
-      "relatedDetectorIds" : [ ],
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Total number of available cpu cores in a managed cluster",
-      "id" : "D0RX5MjAcAA",
-      "importOf" : "DztsRbWAIAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Allocatable CPU Cores",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale" : null,
-        "colorScale2" : null,
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : 0,
-          "minimumResolution" : 0,
-          "timezone" : null
+      "importOf": "DzttL-PAEAA",
+      "importQualifiers": [
+        {
+          "filters": [
+            {
+              "not": false,
+              "property": "resource_type",
+              "values": [
+                "Microsoft.ContainerService/managedClusters"
+              ]
+            }
+          ],
+          "metric": "kube_node_status_allocatable_cpu_cores"
         },
-        "publishLabelOptions" : [ {
-          "displayName" : "kube_node_status_allocatable_cpu_cores",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "None",
-        "showSparkLine" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('kube_node_status_allocatable_cpu_cores', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='latest').publish(label='A')",
-      "relatedDetectorIds" : [ ],
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Number of pods in failed phase across the cluster. Apply the namespace filter to see number of pods in a namespace.",
-      "id" : "D0RX5QwAgAA",
-      "importOf" : "Dz0QFZeAAAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "# of Pods in Failed Phase",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorRange" : null,
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 1.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 20
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 1.0,
-          "paletteIndex" : 20
-        } ],
-        "groupBy" : [ ],
-        "programOptions" : {
-          "disableSampling" : true,
-          "maxDelay" : 0,
-          "minimumResolution" : 0,
-          "timezone" : null
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "kube_pod_status_phase - Mean by pod - Exclude x <= 0",
-          "label" : "A",
-          "valuePrefix" : "",
-          "valueSuffix" : "",
-          "valueUnit" : null
-        } ],
-        "refreshInterval" : null,
-        "sortDirection" : "Ascending",
-        "sortProperty" : null,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "timestampHidden" : false,
-        "type" : "Heatmap",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('kube_pod_status_phase', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true') and filter('phase', 'Failed'), rollup='latest').mean(by=['pod']).above(0).publish(label='A')",
-      "relatedDetectorIds" : [ ],
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Pods by state within the cluster. GREEN indicates a pod is READY. Apply the namespace filter to see number of pods in a namespace.",
-      "id" : "D0RX5SzAYDI",
-      "importOf" : "Dz0QGjqAAAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Pods by State",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorRange" : null,
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 0.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 19
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 0.0,
-          "paletteIndex" : 16
-        } ],
-        "groupBy" : [ ],
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : 0,
-          "minimumResolution" : 0,
-          "timezone" : null
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "",
-          "label" : "A",
-          "valuePrefix" : "",
-          "valueSuffix" : "",
-          "valueUnit" : null
-        } ],
-        "refreshInterval" : 300000,
-        "sortDirection" : "Ascending",
-        "sortProperty" : null,
-        "time" : {
-          "range" : 3600000,
-          "type" : "relative"
-        },
-        "timestampHidden" : false,
-        "type" : "Heatmap",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('kube_pod_status_ready', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='latest', extrapolation='zero').mean(by=['pod']).publish(label='A')",
-      "relatedDetectorIds" : [ ],
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Number of pods in pending phase across the cluster. Apply the namespace filter to see number of pods in a namespace.",
-      "id" : "D0RX5VKAcAE",
-      "importOf" : "Dz0QGkOAEAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "# of Pods in Pending Phase",
-      "options" : {
-        "colorBy" : "Scale",
-        "colorRange" : null,
-        "colorScale" : null,
-        "colorScale2" : [ {
-          "gt" : 1.0,
-          "gte" : null,
-          "lt" : null,
-          "lte" : null,
-          "paletteIndex" : 20
-        }, {
-          "gt" : null,
-          "gte" : null,
-          "lt" : null,
-          "lte" : 1.0,
-          "paletteIndex" : 20
-        } ],
-        "groupBy" : [ ],
-        "programOptions" : {
-          "disableSampling" : true,
-          "maxDelay" : 0,
-          "minimumResolution" : 0,
-          "timezone" : null
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "kube_pod_status_phase - Mean by pod - Exclude x <= 0",
-          "label" : "A",
-          "valuePrefix" : "",
-          "valueSuffix" : "",
-          "valueUnit" : null
-        } ],
-        "refreshInterval" : null,
-        "sortDirection" : "Ascending",
-        "sortProperty" : null,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "timestampHidden" : false,
-        "type" : "Heatmap",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('kube_pod_status_phase', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true') and filter('phase', 'Pending'), rollup='latest').mean(by=['pod']).above(0).publish(label='A')",
-      "relatedDetectorIds" : [ ],
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Number of pods NOT in Ready state across the cluster. Apply the namespace filter to see number of pods in a namespace.",
-      "id" : "D0RX5ZVAgB8",
-      "importOf" : "DzwpzRwAAAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "# of Pods NOT in Ready state",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale" : null,
-        "colorScale2" : null,
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : 0,
-          "minimumResolution" : 0,
-          "timezone" : null
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : 300000,
-        "secondaryVisualization" : "None",
-        "showSparkLine" : false,
-        "time" : {
-          "range" : 3600000,
-          "type" : "relative"
-        },
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('kube_pod_status_ready', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='latest', extrapolation='zero').below(0, inclusive=True).count().publish(label='A')",
-      "relatedDetectorIds" : [ ],
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Number of pods by phase in the cluster. Apply the namespace filter to see number of pods in a namespace.",
-      "id" : "D0RX5d_AYAA",
-      "importOf" : "DzttL-aAEAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "# of Pods by Phase",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale2" : null,
-        "legendOptions" : {
-          "fields" : [ {
-            "enabled" : false,
-            "property" : "aggregation_type"
-          }, {
-            "enabled" : false,
-            "property" : "azure_resource_id"
-          }, {
-            "enabled" : false,
-            "property" : "sf_originatingMetric"
-          }, {
-            "enabled" : true,
-            "property" : "namespace"
-          }, {
-            "enabled" : true,
-            "property" : "phase"
-          }, {
-            "enabled" : false,
-            "property" : "sf_metric"
-          }, {
-            "enabled" : false,
-            "property" : "pod"
-          }, {
-            "enabled" : false,
-            "property" : "primary_aggregation_type"
-          }, {
-            "enabled" : false,
-            "property" : "resource_group_id"
-          }, {
-            "enabled" : false,
-            "property" : "resource_type"
-          }, {
-            "enabled" : false,
-            "property" : "subscription_id"
-          }, {
-            "enabled" : false,
-            "property" : "unit"
-          } ]
-        },
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : true,
-          "maxDelay" : 0,
-          "minimumResolution" : 0,
-          "timezone" : null
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "kube_pod_status_phase - Count by phase",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "Sparkline",
-        "sortBy" : "-value",
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "type" : "List",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('kube_pod_status_phase', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'),rollup='rate').count(by=['phase']).publish(label='A')",
-      "relatedDetectorIds" : [ ],
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Total amount of available memory in a managed cluster",
-      "id" : "D0RX5fkAcAA",
-      "importOf" : "DztsRbxAAAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Available Memory",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale" : null,
-        "colorScale2" : null,
-        "maximumPrecision" : 4,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : 0,
-          "minimumResolution" : null,
-          "timezone" : null
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "kube_node_status_allocatable_memory_bytes",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : "Byte",
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "None",
-        "showSparkLine" : false,
-        "time" : {
-          "range" : 3600000,
-          "type" : "relative"
-        },
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('kube_node_status_allocatable_memory_bytes', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='latest').publish(label='A')",
-      "relatedDetectorIds" : [ ],
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "Number of nodes in the cluster",
-      "id" : "D0RX5mFAgAA",
-      "importOf" : "DzttL-bAIAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "# of Nodes",
-      "options" : {
-        "colorBy" : "Dimension",
-        "colorScale" : null,
-        "colorScale2" : null,
-        "maximumPrecision" : null,
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : 0,
-          "minimumResolution" : 0,
-          "timezone" : null
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "kube_node_status_condition - Mean by node - Count",
-          "label" : "A",
-          "paletteIndex" : null,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "refreshInterval" : null,
-        "secondaryVisualization" : "None",
-        "showSparkLine" : false,
-        "time" : {
-          "range" : 900000,
-          "type" : "relative"
-        },
-        "timestampHidden" : false,
-        "type" : "SingleValue",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('kube_node_status_condition', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'),rollup='rate').mean(by=['node']).count().publish(label='A')",
-      "relatedDetectorIds" : [ ],
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "",
-      "id" : "D0RX5ugAcAI",
-      "importOf" : "Dz0QF2jAEAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Pods by Phase",
-      "options" : {
-        "markdown" : "Heatmaps below indicate the number of pods in each of below specified phases\n\n**Pending**\n\nThe Pod has been accepted by the Kubernetes system, but one or more of the Container images has not been created. This includes time before being scheduled as well as time spent downloading images over the network, which could take a while.\n\n**Failed** \n\nAll Containers in the Pod have terminated, and at least one Container has terminated in failure. That is, the Container either exited with non-zero status or was terminated by the system.\n\n**Unknown**\n\n For some reason the state of the Pod could not be obtained, typically due to an error in communicating with the host of the Pod .",
-        "type" : "Text"
-      },
-      "packageSpecifications" : "",
-      "programText" : "",
-      "relatedDetectorIds" : [ ],
-      "tags" : null
-    }
-  } ],
-  "crossLinkExports" : [ ],
-  "dashboardExports" : [ {
-    "dashboard" : {
-      "chartDensity" : "DEFAULT",
-      "charts" : [ {
-        "chartId" : "D0RX4z_AcAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "D0RX5ZVAgB8",
-        "column" : 8,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "D0RX5mFAgAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "D0RX5MjAcAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "D0RX5SzAYDI",
-        "column" : 4,
-        "height" : 2,
-        "row" : 1,
-        "width" : 8
-      }, {
-        "chartId" : "D0RX5fkAcAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 2,
-        "width" : 4
-      }, {
-        "chartId" : "D0RX5ugAcAI",
-        "column" : 0,
-        "height" : 1,
-        "row" : 3,
-        "width" : 4
-      }, {
-        "chartId" : "D0RX46NAgAE",
-        "column" : 8,
-        "height" : 1,
-        "row" : 3,
-        "width" : 4
-      }, {
-        "chartId" : "D0RX5d_AYAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 3,
-        "width" : 4
-      }, {
-        "chartId" : "D0RX5VKAcAE",
-        "column" : 0,
-        "height" : 2,
-        "row" : 4,
-        "width" : 4
-      }, {
-        "chartId" : "D0RX5ESAYAA",
-        "column" : 8,
-        "height" : 2,
-        "row" : 4,
-        "width" : 4
-      }, {
-        "chartId" : "D0RX5QwAgAA",
-        "column" : 4,
-        "height" : 2,
-        "row" : 4,
-        "width" : 4
-      } ],
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : null,
-      "description" : "An overview of Azure Managed Cluster (AKS)",
-      "discoveryOptions" : null,
-      "eventOverlays" : null,
-      "filters" : {
-        "sources" : null,
-        "time" : null,
-        "variables" : [ {
-          "alias" : "Subscription Name",
-          "applyIfExists" : false,
-          "description" : "",
-          "preferredSuggestions" : [ ],
-          "property" : "azure_subscription_display_name",
-          "replaceOnly" : false,
-          "required" : false,
-          "restricted" : false,
-          "value" : ""
-        }, {
-          "alias" : "Cluster Resource ID",
-          "applyIfExists" : false,
-          "description" : "",
-          "preferredSuggestions" : [ ],
-          "property" : "azure_resource_id",
-          "replaceOnly" : false,
-          "required" : false,
-          "restricted" : false,
-          "value" : ""
-        }, {
-          "alias" : "namespace",
-          "applyIfExists" : true,
-          "description" : "",
-          "preferredSuggestions" : [ ],
-          "property" : "namespace",
-          "replaceOnly" : true,
-          "required" : false,
-          "restricted" : false,
-          "value" : ""
-        } ]
-      },
-      "groupId" : "D0RX4scAYAA",
-      "id" : "D0RX5z0AgAA",
-      "importOf" : "DzttL-YAIAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "maxDelayOverride" : null,
-      "name" : "Azure Managed Cluster",
-      "selectedEventOverlays" : null,
-      "tags" : null
-    }
-  } ],
-  "groupExport" : {
-    "group" : {
-      "created" : 0,
-      "creator" : null,
-      "dashboards" : [ "D0RX5z0AgAA" ],
-      "description" : "",
-      "email" : null,
-      "id" : "D0RX4scAYAA",
-      "importDetails" : {
-        "hashCode" : -1808524001,
-        "importOf" : "DzttL-PAEAA",
-        "importTime" : 1551120183146
-      },
-      "importOf" : "DzttL-PAEAA",
-      "importQualifiers" : [ {
-        "filters" : [ {
-          "not" : false,
-          "property" : "resource_type",
-          "values" : [ "Microsoft.ContainerService/managedClusters" ]
-        } ],
-        "metric" : "kube_node_status_allocatable_cpu_cores"
-      }, {
-        "filters" : [ {
-          "not" : false,
-          "property" : "resource_type",
-          "values" : [ "Microsoft.ContainerService/managedClusters" ]
-        } ],
-        "metric" : "kube_node_status_allocatable_memory_bytes"
-      } ],
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Azure Kubernetes Service",
-      "teams" : null
+        {
+          "filters": [
+            {
+              "not": false,
+              "property": "resource_type",
+              "values": [
+                "Microsoft.ContainerService/managedClusters"
+              ]
+            }
+          ],
+          "metric": "kube_node_status_allocatable_memory_bytes"
+        }
+      ],
+      "lastUpdated": 0,
+      "lastUpdatedBy": null,
+      "name": "Azure Kubernetes Service",
+      "teams": null
     }
   },
-  "hashCode" : 2080969001,
-  "id" : "D0RX4scAYAA",
-  "modelVersion" : 1,
-  "packageType" : "GROUP"
+  "hashCode": -864256213,
+  "id": "D0RX4scAYAA",
+  "modelVersion": 1,
+  "packageType": "GROUP"
 }


### PR DESCRIPTION
- Charts: # of Pods NOT in Ready state and # of Pods NOT in Ready state per namespace - Mean by Pod before count
- Chart: # of Pods by Phase- Exclude MTSes if value is zero before count