### PR TITLE
apm: fix error rate charts to work when either error or non-error timeries are missing

### DIFF
--- a/group/APM 2.0.json
+++ b/group/APM 2.0.json
@@ -60,7 +60,7 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "Successful requests",
+              "displayName": "Errors",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -70,7 +70,7 @@
               "yAxis": 0
             },
             {
-              "displayName": "All requests",
+              "displayName": "Requests",
               "label": "B",
               "paletteIndex": null,
               "plotType": null,
@@ -102,7 +102,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_error', 'false') and filter('sf_operation', '*'), rollup='rate').sum().publish(label='A', enable=False)\nB = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*'), rollup='rate').sum().publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*') and filter('sf_error', 'true'), rollup='rate').sum().publish(label='A', enable=False)\nB = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*'), rollup='rate').sum().publish(label='B', enable=False)\nC = combine(100*((A if A is not None else 0)/B)).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -548,7 +548,7 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "Successful requests",
+              "displayName": "Errors",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -558,7 +558,7 @@
               "yAxis": 0
             },
             {
-              "displayName": "All requests",
+              "displayName": "Requests",
               "label": "B",
               "paletteIndex": null,
               "plotType": null,
@@ -588,7 +588,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_error', 'false') and (not filter('sf_dimensionalized', '*')), rollup='delta', extrapolation='zero').sum(by=['sf_service']).publish(label='A', enable=False)\nB = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and (not filter('sf_dimensionalized', '*')), rollup='delta').sum(by=['sf_service']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "programText": "A = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and (not filter('sf_dimensionalized', '*') and filter('sf_error', 'true') ), rollup='delta').sum(by=['sf_service']).publish(label='A', enable=False)\nB = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and (not filter('sf_dimensionalized', '*')), rollup='delta').sum(by=['sf_service']).publish(label='B', enable=False)\nC = combine(100*((A if A is not None else 0) / B)).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -654,7 +654,7 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "Successful requests",
+              "displayName": "Errors",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -664,7 +664,7 @@
               "yAxis": 0
             },
             {
-              "displayName": "All requests",
+              "displayName": "Requests",
               "label": "B",
               "paletteIndex": null,
               "plotType": null,
@@ -694,7 +694,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_error', 'false') and filter('sf_operation', '*'), rollup='rate').sum(by=['sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*'), rollup='rate').sum(by=['sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*') and filter('sf_error', 'true'), rollup='rate').sum().publish(label='A', enable=False)\nB = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_operation', '*'), rollup='rate').sum().publish(label='B', enable=False)\nC = combine(100*((A if A is not None else 0)/B)).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -959,7 +959,7 @@
           ],
           "axisPrecision": null,
           "colorBy": "Dimension",
-          "defaultPlotType": "AreaChart",
+          "defaultPlotType": "LineChart",
           "eventPublishLabelOptions": [],
           "histogramChartOptions": {
             "colorThemeIndex": 16
@@ -983,7 +983,7 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "Successful requests",
+              "displayName": "Errors",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -993,7 +993,7 @@
               "yAxis": 0
             },
             {
-              "displayName": "All requests",
+              "displayName": "Requests",
               "label": "B",
               "paletteIndex": null,
               "plotType": null,
@@ -1014,7 +1014,7 @@
             }
           ],
           "showEventLines": false,
-          "stacked": true,
+          "stacked": false,
           "time": {
             "range": 900000,
             "type": "relative"
@@ -1023,7 +1023,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_error', 'false'), rollup='rate').sum(by=['sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_error', 'true'), rollup='rate').sum(by=['sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).publish(label='B', enable=False)\nC = combine(100*((A if A is not None else 0)/B)).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1186,7 +1186,7 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "Successful requests",
+              "displayName": "Errors",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -1196,7 +1196,7 @@
               "yAxis": 0
             },
             {
-              "displayName": "All requests",
+              "displayName": "Requests",
               "label": "B",
               "paletteIndex": null,
               "plotType": null,
@@ -1227,7 +1227,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_error', 'false'), rollup='delta').sum(by=['sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='delta').sum(by=['sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).publish(label='B', enable=False)\nC = (100*(B-A)/B).mean(over='1m').top(count=10).publish(label='C')",
+        "programText": "A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')) and filter('sf_error', 'true'), rollup='rate').sum(by=['sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).publish(label='A', enable=False)\nB = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*')), rollup='rate').sum(by=['sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).publish(label='B', enable=False)\nC = combine(100*((A if A is not None else 0)/B)).mean(over='1m').top(count=10).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -1370,7 +1370,7 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "Successful requests",
+              "displayName": "Errors",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -1380,7 +1380,7 @@
               "yAxis": 0
             },
             {
-              "displayName": "All requests",
+              "displayName": "Requests",
               "label": "B",
               "paletteIndex": null,
               "plotType": null,
@@ -1412,7 +1412,7 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_error', 'false') and (not filter('sf_dimensionalized', '*')), rollup='delta', extrapolation='zero').sum().publish(label='A', enable=False)\nB = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and (not filter('sf_dimensionalized', '*')), rollup='delta').sum().publish(label='B', enable=False)\nC = (100*(B-A)/B).publish(label='C')",
+        "programText": "A = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and (not filter('sf_dimensionalized', '*') and filter('sf_error', 'true') ), rollup='delta').sum(by=['sf_service']).publish(label='A', enable=False)\nB = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and (not filter('sf_dimensionalized', '*')), rollup='delta').sum(by=['sf_service']).publish(label='B', enable=False)\nC = combine(100*((A if A is not None else 0) / B)).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
@@ -3837,7 +3837,7 @@
       "teams": null
     }
   },
-  "hashCode": 657909266,
+  "hashCode": 1127020428,
   "id": "EPK1YluAgAA",
   "modelVersion": 1,
   "packageType": "GROUP"


### PR DESCRIPTION
Leverage the combine() SignalFlow function to correctly support those
scenarios. Simplify the calculation back to an "100 * failures / requests"
base formula, but with combine() to help the join.

Also removed the stacking on the Top endpoints by error rate chart.