### PR TITLE
Updating o11y fields for AWS navigators

### DIFF
--- a/navigators/AWS/AWS instances.json
+++ b/navigators/AWS/AWS instances.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -53630964,
+  "hashCode" : 1318572987,
   "id" : "DiVU-9WAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -365,7 +365,7 @@
           "valueLabel" : "Most severe alert"
         } ],
         "mtsQuery" : "sf_metric:CPUUtilization AND sf_key:InstanceId AND _exists_:InstanceId",
-        "o11yMetricName" : "Active Hosts",
+        "o11yMetricName" : "Running Instances",
         "o11yMetricUnit" : null,
         "o11yProductName" : "EC2",
         "o11ySignalflowTemplate" : "A = data('CPUUtilization', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'upper') and filter('InstanceId', '*'), extrapolation='last_value', maxExtrapolations=5).max(over='1h').count().publish(label='A')",

--- a/navigators/AWS/AWS instances.json
+++ b/navigators/AWS/AWS instances.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 1318572987,
+  "hashCode" : -53630964,
   "id" : "DiVU-9WAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -365,7 +365,7 @@
           "valueLabel" : "Most severe alert"
         } ],
         "mtsQuery" : "sf_metric:CPUUtilization AND sf_key:InstanceId AND _exists_:InstanceId",
-        "o11yMetricName" : "Running Instances",
+        "o11yMetricName" : "Active Hosts",
         "o11yMetricUnit" : null,
         "o11yProductName" : "EC2",
         "o11ySignalflowTemplate" : "A = data('CPUUtilization', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'upper') and filter('InstanceId', '*'), extrapolation='last_value', maxExtrapolations=5).max(over='1h').count().publish(label='A')",

--- a/navigators/AWS/awsebs.json
+++ b/navigators/AWS/awsebs.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -1952813183,
+  "hashCode" : 491706471,
   "id" : "DiVU_CpAgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -247,7 +247,7 @@
         } ],
         "mtsQuery" : "sf_metric:VolumeWriteOps AND sf_key:VolumeId AND _exists_:VolumeId",
         "o11yMetricName" : "Running Volumes",
-        "o11yMetricUnit" : "Volumes",
+        "o11yMetricUnit" : null,
         "o11yProductName" : "EBS",
         "o11ySignalflowTemplate" : "A = data('VolumeIdleTime', filter=filter('stat', 'mean') and filter('namespace', 'AWS/EBS')).max(over='1h').count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",

--- a/navigators/AWS/awsecs.json
+++ b/navigators/AWS/awsecs.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -673698876,
+  "hashCode" : -1842886123,
   "id" : "DiVU_KHAcAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -181,7 +181,7 @@
         } ],
         "mtsQuery" : "sf_metric:CPUReservation AND sf_key:ClusterName AND _exists_:ClusterName",
         "o11yMetricName" : "Running Clusters",
-        "o11yMetricUnit" : "clusters",
+        "o11yMetricUnit" : null,
         "o11yProductName" : "ECS",
         "o11ySignalflowTemplate" : "A = data('CPUReservation', filter=filter('namespace', 'AWS/ECS'), extrapolation='last_value', maxExtrapolations=5, rollup='rate').mean(by=['ClusterName']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",

--- a/navigators/AWS/awsecs.json
+++ b/navigators/AWS/awsecs.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 75941532,
+  "hashCode" : -673698876,
   "id" : "DiVU_KHAcAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -181,7 +181,7 @@
         } ],
         "mtsQuery" : "sf_metric:CPUReservation AND sf_key:ClusterName AND _exists_:ClusterName",
         "o11yMetricName" : "Running Clusters",
-        "o11yMetricUnit" : "Clusters",
+        "o11yMetricUnit" : "clusters",
         "o11yProductName" : "ECS",
         "o11ySignalflowTemplate" : "A = data('CPUReservation', filter=filter('namespace', 'AWS/ECS'), extrapolation='last_value', maxExtrapolations=5, rollup='rate').mean(by=['ClusterName']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",

--- a/navigators/AWS/cloudfront.json
+++ b/navigators/AWS/cloudfront.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 2039548986,
+  "hashCode" : -2052578575,
   "id" : "DiVVOGwAgAE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -181,7 +181,7 @@
         } ],
         "mtsQuery" : "sf_metric:Requests AND sf_key:DistributionId AND _exists_:DistributionId",
         "o11yMetricName" : "# Distributions",
-        "o11yMetricUnit" : "Distributions",
+        "o11yMetricUnit" : null,
         "o11yProductName" : "CloudFront Distributions",
         "o11ySignalflowTemplate" : "A = data('Requests', filter=filter('namespace', 'AWS/CloudFront') and filter('stat', 'sum'), extrapolation='last_value', maxExtrapolations=5,rollup='rate').count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",

--- a/navigators/AWS/elasticache.json
+++ b/navigators/AWS/elasticache.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 2070293453,
+  "hashCode" : 1739476366,
   "id" : "DiVU-9XAgAE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -447,7 +447,7 @@
         } ],
         "mtsQuery" : "sf_key:CacheNodeId AND _exists_:CacheNodeId",
         "o11yMetricName" : "# Clusters",
-        "o11yMetricUnit" : "Clusters",
+        "o11yMetricUnit" : null,
         "o11yProductName" : "ElastiCache",
         "o11ySignalflowTemplate" : "A = data('CPUUtilization', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'mean') and filter('CacheClusterId', '*'), extrapolation='last_value', maxExtrapolations=5).mean(by=['aws_region', 'aws_cache_cluster_name']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",

--- a/navigators/AWS/elb.json
+++ b/navigators/AWS/elb.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 1820433663,
+  "hashCode" : 27581701,
   "id" : "DiVVOB3AYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -380,7 +380,7 @@
         } ],
         "mtsQuery" : "sf_metric:RequestCount AND sf_key:LoadBalancerName AND _exists_:LoadBalancerName",
         "o11yMetricName" : "Active Load Balancers",
-        "o11yMetricUnit" : "Instances",
+        "o11yMetricUnit" : null,
         "o11yProductName" : "Elastic Load Balancers",
         "o11ySignalflowTemplate" : "A = data('RequestCount', filter=filter('AvailabilityZone', '*') and filter('LoadBalancerName', '*') and filter('stat', 'mean'), extrapolation='zero').sum(by=['LoadBalancerName']).count().max(over='1h').publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",

--- a/navigators/AWS/lambda.json
+++ b/navigators/AWS/lambda.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -1012489114,
+  "hashCode" : -1100398122,
   "id" : "DiVVN4WAgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -186,7 +186,7 @@
         } ],
         "mtsQuery" : "(sf_metric:Invocations OR sf_metric:function.invocations OR sf_metric:Errors OR sf_metric:function.errors OR sf_metric:Throttles) AND _exists_:aws_function_name",
         "o11yMetricName" : "Active Functions",
-        "o11yMetricUnit" : "Functions",
+        "o11yMetricUnit" : null,
         "o11yProductName" : "Lambda Functions",
         "o11ySignalflowTemplate" : "A = data('Duration', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'count') and filter('Resource', '*'), rollup='count', extrapolation='zero').count(by=['Resource']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",

--- a/navigators/AWS/rds databases.json
+++ b/navigators/AWS/rds databases.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 1630836323,
+  "hashCode" : 35258478,
   "id" : "DiVVFU6AcAE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -400,7 +400,7 @@
         } ],
         "mtsQuery" : "sf_metric:DatabaseConnections AND sf_key:DBInstanceIdentifier AND _exists_:DBInstanceIdentifier",
         "o11yMetricName" : "# DB Instances",
-        "o11yMetricUnit" : "Instances",
+        "o11yMetricUnit" : null,
         "o11yProductName" : "RDS",
         "o11ySignalflowTemplate" : "A = data('CPUUtilization', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*'), extrapolation='last_value', maxExtrapolations=5).mean(by=['aws_account_id', 'aws_region', 'DBInstanceIdentifier']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",

--- a/navigators/AWS/sns.json
+++ b/navigators/AWS/sns.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -879160945,
+  "hashCode" : -762338976,
   "id" : "DiVVEqDAcAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -159,7 +159,7 @@
         } ],
         "mtsQuery" : "sf_metric:NumberOfMessagesPublished AND sf_key:TopicName AND _exists_:TopicName",
         "o11yMetricName" : "Active Topics",
-        "o11yMetricUnit" : "Topics",
+        "o11yMetricUnit" : null,
         "o11yProductName" : "SNS Topics",
         "o11ySignalflowTemplate" : "A = data('NumberOfMessagesPublished', filter=filter('TopicName', '*') and filter('namespace', 'AWS/SNS') and filter('stat', 'sum'),rollup='rate').max(over='1h').mean(by=['TopicName']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",

--- a/navigators/AWS/sqs queues.json
+++ b/navigators/AWS/sqs queues.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 1662959881,
+  "hashCode" : -403747277,
   "id" : "DiVU-_uAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -533,7 +533,7 @@
         } ],
         "mtsQuery" : "sf_metric:NumberOfMessagesSent AND sf_key:QueueName AND _exists_:QueueName",
         "o11yMetricName" : "Active Queues",
-        "o11yMetricUnit" : "Queues",
+        "o11yMetricUnit" : null,
         "o11yProductName" : "SQS Queues",
         "o11ySignalflowTemplate" : "A = data('NumberOfMessagesSent', filter=filter('namespace', 'AWS/SQS') and filter('stat', 'sum'),rollup='rate').mean(over='15m').count(by=['QueueName', 'aws_region']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",


### PR DESCRIPTION
Reverting the changes from the previous commit where I updated the AWS navigators, except the change to the EC2 instances nav. Also removed the "o11yMetricUnit" value from the ECS navigator.