### PR TITLE
aks: Fix certain charts

### DIFF
--- a/group/Azure Kubernetes Service.json
+++ b/group/Azure Kubernetes Service.json
@@ -61,6 +61,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : false,
@@ -105,7 +106,7 @@
           "timezone" : null
         },
         "publishLabelOptions" : [ {
-          "displayName" : "",
+          "displayName" : "kube_pod_status_ready - Exclude x > 0 - Count by namespace",
           "label" : "A",
           "paletteIndex" : null,
           "plotType" : null,
@@ -125,7 +126,7 @@
         "unitPrefix" : "Metric"
       },
       "packageSpecifications" : "",
-      "programText" : "A = data('kube_pod_status_ready', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='average', extrapolation='zero').below(0, inclusive=True).count(by=['namespace']).publish(label='A')",
+      "programText" : "A = data('kube_pod_status_ready', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='average', extrapolation='zero').mean(by=['pod']).below(0, inclusive=True).count(by=['namespace']).publish(label='A')",
       "relatedDetectorIds" : [ ],
       "tags" : null
     }
@@ -432,7 +433,7 @@
           "timezone" : null
         },
         "publishLabelOptions" : [ {
-          "displayName" : "",
+          "displayName" : "kube_pod_status_ready - Exclude x > 0 - Count",
           "label" : "A",
           "paletteIndex" : null,
           "plotType" : null,
@@ -453,7 +454,7 @@
         "unitPrefix" : "Metric"
       },
       "packageSpecifications" : "",
-      "programText" : "A = data('kube_pod_status_ready', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='latest', extrapolation='zero').below(0, inclusive=True).count().publish(label='A')",
+      "programText" : "A = data('kube_pod_status_ready', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='latest', extrapolation='zero').mean(by=['pod']).below(0, inclusive=True).count().publish(label='A')",
       "relatedDetectorIds" : [ ],
       "tags" : null
     }
@@ -471,6 +472,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : false,
@@ -538,7 +540,7 @@
         "unitPrefix" : "Metric"
       },
       "packageSpecifications" : "",
-      "programText" : "A = data('kube_pod_status_phase', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'),rollup='rate').count(by=['phase']).publish(label='A')",
+      "programText" : "A = data('kube_pod_status_phase', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'), rollup='average').above(0).mean(by=['pod', 'phase']).count(by=['phase']).publish(label='A')",
       "relatedDetectorIds" : [ ],
       "tags" : null
     }
@@ -823,7 +825,7 @@
       "teams" : null
     }
   },
-  "hashCode" : 2080969001,
+  "hashCode" : -351982593,
   "id" : "D0RX4scAYAA",
   "modelVersion" : 1,
   "packageType" : "GROUP"


### PR DESCRIPTION
- Charts: # of Pods NOT in Ready state and # of Pods NOT in Ready state per namespace - Mean by Pod before count
- Chart: # of Pods by Phase- Exclude MTSes if value is zero before count

Relates to #232, #236 