### PR TITLE
Fix filter issue on k8s pods infra nav

### DIFF
--- a/navigators/Kubernetes/kubernetes pods.json
+++ b/navigators/Kubernetes/kubernetes pods.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 1574805257,
+  "hashCode" : 1574805258,
   "id" : "DiVVQ6FAgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -88,7 +88,7 @@
               "type" : "property"
             } ],
             "resolution" : 60000,
-            "template" : "POD_CPU = data(\"container_cpu_utilization\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"rate\").sum(by=[\"kubernetes_node\", \"kubernetes_cluster\", \"kubernetes_pod_name\"]).mean(over=\"1m\")\nNEW_NUM_CORES = data(\"cpu.num_processors\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"average\").sum(by=[\"kubernetes_node\", \"kubernetes_cluster\"]).mean(over=\"1m\")\nPOD_CPU_NEW = (POD_CPU/NEW_NUM_CORES)\nOLD_NUM_CORES = data(\"machine_cpu_cores\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"average\").sum(by=[\"kubernetes_node\", \"kubernetes_cluster\"])\nPOD_CPU_OLD = (POD_CPU/OLD_NUM_CORES)\nPOD_CPU_USAGE = union(POD_CPU_NEW, POD_CPU_OLD)",
+            "template" : "POD_CPU = data(\"container_cpu_utilization\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"rate\").sum(by=[\"kubernetes_node\", \"kubernetes_cluster\", \"kubernetes_pod_name\"]).mean(over=\"1m\")\nNEW_NUM_CORES = data(\"cpu.num_processors\", rollup=\"average\").sum(by=[\"kubernetes_node\", \"kubernetes_cluster\"]).mean(over=\"1m\")\nPOD_CPU_NEW = (POD_CPU/NEW_NUM_CORES)\nOLD_NUM_CORES = data(\"machine_cpu_cores\", rollup=\"average\").sum(by=[\"kubernetes_node\", \"kubernetes_cluster\"])\nPOD_CPU_OLD = (POD_CPU/OLD_NUM_CORES)\nPOD_CPU_USAGE = union(POD_CPU_NEW, POD_CPU_OLD)",
             "varName" : "POD_CPU_USAGE"
           },
           "metricSelectors" : [ "container_cpu_utilization" ],
@@ -237,7 +237,7 @@
           },
           "metricSelectors" : [ "pod_network_receive_bytes_total", "pod_network_transmit_bytes_total" ],
           "type" : "metric",
-          "valueFormat" : null,
+          "valueFormat" : "Number",
           "valueLabel" : null,
           "valueType" : null
         }, {


### PR DESCRIPTION
In the CPU calculation, `cpu.num_processors` is not  guaranteed to have any k8s related dimensions attached because it is reported by a separate monitor than `container_cpu_utilization`. 

By omitting the `{{filter}}` for this metric, we can still filter by k8s related properties in the first time series.