### PR TITLE
MongoDB: Add new metric for heap usage

### DIFF
--- a/group/MongoDB.json
+++ b/group/MongoDB.json
@@ -12,6 +12,7 @@
       "options" : {
         "colorBy" : "Metric",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -252,6 +253,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -413,6 +415,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -479,6 +482,7 @@
       "options" : {
         "colorBy" : "Metric",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -649,6 +653,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -951,122 +956,6 @@
       },
       "packageSpecifications" : "",
       "programText" : "A = data('gauge.objects', filter=filter('plugin', 'mongo') and (not filter('cluster', '*')), maxExtrapolations=2).sum(by=['db']).top(count=100).publish(label='A')",
-      "relatedDetectorIds" : [ ],
-      "tags" : null
-    }
-  }, {
-    "chart" : {
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : { },
-      "description" : "percentile distribution",
-      "id" : "DiVWUQwAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "name" : "Heap Usage",
-      "options" : {
-        "areaChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "axes" : [ {
-          "highWatermark" : null,
-          "highWatermarkLabel" : null,
-          "label" : "bytes used",
-          "lowWatermark" : null,
-          "lowWatermarkLabel" : null,
-          "max" : null,
-          "min" : 0.0
-        } ],
-        "axisPrecision" : null,
-        "colorBy" : "Metric",
-        "defaultPlotType" : "AreaChart",
-        "eventPublishLabelOptions" : [ ],
-        "histogramChartOptions" : {
-          "colorThemeIndex" : 16
-        },
-        "includeZero" : false,
-        "legendOptions" : {
-          "fields" : null
-        },
-        "lineChartOptions" : {
-          "showDataMarkers" : false
-        },
-        "onChartLegendOptions" : {
-          "dimensionInLegend" : null,
-          "showLegend" : false
-        },
-        "programOptions" : {
-          "disableSampling" : false,
-          "maxDelay" : null,
-          "minimumResolution" : 0,
-          "timezone" : null
-        },
-        "publishLabelOptions" : [ {
-          "displayName" : "total heap size used by db",
-          "label" : "A",
-          "paletteIndex" : 4,
-          "plotType" : "LineChart",
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Min",
-          "label" : "B",
-          "paletteIndex" : 14,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "P10",
-          "label" : "C",
-          "paletteIndex" : 15,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "P50",
-          "label" : "D",
-          "paletteIndex" : 2,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "P90",
-          "label" : "E",
-          "paletteIndex" : 9,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        }, {
-          "displayName" : "Max",
-          "label" : "F",
-          "paletteIndex" : 7,
-          "plotType" : null,
-          "valuePrefix" : null,
-          "valueSuffix" : null,
-          "valueUnit" : null,
-          "yAxis" : 0
-        } ],
-        "showEventLines" : false,
-        "stacked" : false,
-        "time" : {
-          "range" : 3600000,
-          "type" : "relative"
-        },
-        "type" : "TimeSeriesChart",
-        "unitPrefix" : "Metric"
-      },
-      "packageSpecifications" : "",
-      "programText" : "A = data('gauge.extra_info.heap_usage_bytes', filter=filter('plugin', 'mongo') and (not filter('cluster', '*'))).publish(label='A', enable=False)\nB = (A).min().publish(label='B')\nC = (A).percentile(pct=10).publish(label='C')\nD = (A).percentile(pct=50).publish(label='D')\nE = (A).percentile(pct=90).publish(label='E')\nF = (A).max().publish(label='F')",
       "relatedDetectorIds" : [ ],
       "tags" : null
     }
@@ -1544,6 +1433,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -1607,6 +1497,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -1679,6 +1570,14 @@
           "lowWatermarkLabel" : null,
           "max" : null,
           "min" : 0.0
+        }, {
+          "highWatermark" : null,
+          "highWatermarkLabel" : null,
+          "label" : "",
+          "lowWatermark" : null,
+          "lowWatermarkLabel" : null,
+          "max" : null,
+          "min" : null
         } ],
         "axisPrecision" : null,
         "colorBy" : "Metric",
@@ -1715,8 +1614,8 @@
           "yAxis" : 0
         }, {
           "displayName" : "min",
-          "label" : "B",
-          "paletteIndex" : 14,
+          "label" : "H",
+          "paletteIndex" : 6,
           "plotType" : null,
           "valuePrefix" : null,
           "valueSuffix" : null,
@@ -1758,6 +1657,60 @@
           "valueSuffix" : null,
           "valueUnit" : null,
           "yAxis" : 0
+        }, {
+          "displayName" : "heap usage mongo > 4.x",
+          "label" : "G",
+          "paletteIndex" : null,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "min",
+          "label" : "I",
+          "paletteIndex" : 6,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "p10",
+          "label" : "J",
+          "paletteIndex" : 15,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "median",
+          "label" : "K",
+          "paletteIndex" : 2,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "p90",
+          "label" : "L",
+          "paletteIndex" : 9,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "max",
+          "label" : "M",
+          "paletteIndex" : 7,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
         } ],
         "showEventLines" : false,
         "stacked" : false,
@@ -1769,7 +1722,7 @@
         "unitPrefix" : "Binary"
       },
       "packageSpecifications" : "",
-      "programText" : "A = data('gauge.extra_info.heap_usage_bytes', filter=filter('plugin', 'mongo') and filter('cluster', 'rs0')).publish(label='A', enable=False)\nB = (A).min().publish(label='B')\nC = (A).percentile(pct=10).publish(label='C')\nD = (A).percentile(pct=50).publish(label='D')\nE = (A).percentile(pct=90).publish(label='E')\nF = (A).max().publish(label='F')",
+      "programText" : "A = data('gauge.extra_info.heap_usage_bytes', filter=filter('plugin', 'mongo')).publish(label='A', enable=False)\nH = (A).min().publish(label='H')\nC = (A).percentile(pct=10).publish(label='C')\nD = (A).percentile(pct=50).publish(label='D')\nE = (A).percentile(pct=90).publish(label='E')\nF = (A).max().publish(label='F')\nG = data('gauge.tcmalloc.generic.heap_size', filter=filter('plugin', 'mongo')).publish(label='G', enable=False)\nI = (G).min().publish(label='I')\nJ = (G).percentile(pct=10).publish(label='J')\nK = (G).percentile(pct=50).publish(label='K')\nL = (G).percentile(pct=90).publish(label='L')\nM = (G).max().publish(label='M')",
       "relatedDetectorIds" : [ ],
       "tags" : null
     }
@@ -2006,6 +1959,7 @@
       "options" : {
         "colorBy" : "Metric",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -2255,6 +2209,7 @@
       "options" : {
         "colorBy" : "Metric",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -2700,6 +2655,7 @@
       "options" : {
         "colorBy" : "Metric",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -2833,6 +2789,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -3117,6 +3074,14 @@
           "lowWatermarkLabel" : null,
           "max" : null,
           "min" : 0.0
+        }, {
+          "highWatermark" : null,
+          "highWatermarkLabel" : null,
+          "label" : "",
+          "lowWatermark" : null,
+          "lowWatermarkLabel" : null,
+          "max" : null,
+          "min" : null
         } ],
         "axisPrecision" : null,
         "colorBy" : "Metric",
@@ -3143,8 +3108,17 @@
           "timezone" : null
         },
         "publishLabelOptions" : [ {
-          "displayName" : "gauge.extra_info.heap_usage_bytes",
+          "displayName" : "heap usage",
           "label" : "A",
+          "paletteIndex" : 5,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "heap usage mongo > 4.x",
+          "label" : "B",
           "paletteIndex" : 5,
           "plotType" : null,
           "valuePrefix" : null,
@@ -3162,7 +3136,7 @@
         "unitPrefix" : "Binary"
       },
       "packageSpecifications" : "",
-      "programText" : "A = data('gauge.extra_info.heap_usage_bytes', filter=filter('plugin', 'mongo') and filter('host', 'integration-test-mongodb-2.6-0')).publish(label='A')",
+      "programText" : "A = data('gauge.extra_info.heap_usage_bytes', filter=filter('plugin', 'mongo')).publish(label='A')\nB = data('gauge.tcmalloc.generic.heap_size', filter=filter('plugin', 'mongo')).publish(label='B')",
       "relatedDetectorIds" : [ ],
       "tags" : null
     }
@@ -3989,6 +3963,184 @@
       "relatedDetectorIds" : [ ],
       "tags" : null
     }
+  }, {
+    "chart" : {
+      "created" : 0,
+      "creator" : null,
+      "customProperties" : { },
+      "description" : "percentile distribution",
+      "id" : "EoUldA3AcAA",
+      "lastUpdated" : 0,
+      "lastUpdatedBy" : null,
+      "name" : "Heap Usage",
+      "options" : {
+        "areaChartOptions" : {
+          "showDataMarkers" : false
+        },
+        "axes" : [ {
+          "highWatermark" : null,
+          "highWatermarkLabel" : null,
+          "label" : "bytes",
+          "lowWatermark" : null,
+          "lowWatermarkLabel" : null,
+          "max" : null,
+          "min" : 0.0
+        }, {
+          "highWatermark" : null,
+          "highWatermarkLabel" : null,
+          "label" : "",
+          "lowWatermark" : null,
+          "lowWatermarkLabel" : null,
+          "max" : null,
+          "min" : null
+        } ],
+        "axisPrecision" : null,
+        "colorBy" : "Metric",
+        "defaultPlotType" : "AreaChart",
+        "eventPublishLabelOptions" : [ ],
+        "histogramChartOptions" : {
+          "colorThemeIndex" : 16
+        },
+        "includeZero" : false,
+        "legendOptions" : {
+          "fields" : null
+        },
+        "lineChartOptions" : {
+          "showDataMarkers" : false
+        },
+        "onChartLegendOptions" : {
+          "dimensionInLegend" : null,
+          "showLegend" : false
+        },
+        "programOptions" : {
+          "disableSampling" : false,
+          "maxDelay" : null,
+          "minimumResolution" : 0,
+          "timezone" : null
+        },
+        "publishLabelOptions" : [ {
+          "displayName" : "total heap size used by db",
+          "label" : "A",
+          "paletteIndex" : 4,
+          "plotType" : "LineChart",
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "min",
+          "label" : "H",
+          "paletteIndex" : 14,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "p10",
+          "label" : "C",
+          "paletteIndex" : 15,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "median",
+          "label" : "D",
+          "paletteIndex" : 2,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "p90",
+          "label" : "E",
+          "paletteIndex" : 9,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "max",
+          "label" : "F",
+          "paletteIndex" : 7,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "heap usage mongo > 4.x",
+          "label" : "G",
+          "paletteIndex" : null,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "min",
+          "label" : "I",
+          "paletteIndex" : 14,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "p10",
+          "label" : "J",
+          "paletteIndex" : 15,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "median",
+          "label" : "K",
+          "paletteIndex" : 2,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "p90",
+          "label" : "L",
+          "paletteIndex" : 9,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "max",
+          "label" : "M",
+          "paletteIndex" : 7,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        } ],
+        "showEventLines" : false,
+        "stacked" : false,
+        "time" : {
+          "range" : 3600000,
+          "type" : "relative"
+        },
+        "type" : "TimeSeriesChart",
+        "unitPrefix" : "Binary"
+      },
+      "packageSpecifications" : "",
+      "programText" : "A = data('gauge.extra_info.heap_usage_bytes', filter=filter('plugin', 'mongo') and (not filter('cluster', '*'))).publish(label='A', enable=False)\nH = (A).min().publish(label='H')\nC = (A).percentile(pct=10).publish(label='C')\nD = (A).percentile(pct=50).publish(label='D')\nE = (A).percentile(pct=90).publish(label='E')\nF = (A).max().publish(label='F')\nG = data('gauge.tcmalloc.generic.heap_size', filter=filter('plugin', 'mongo') and (not filter('cluster', '*'))).publish(label='G', enable=False)\nI = (G).min().publish(label='I')\nJ = (G).percentile(pct=10).publish(label='J')\nK = (G).percentile(pct=50).publish(label='K')\nL = (G).percentile(pct=90).publish(label='L')\nM = (G).max().publish(label='M')",
+      "relatedDetectorIds" : [ ],
+      "tags" : null
+    }
   } ],
   "crossLinkExports" : [ ],
   "dashboardExports" : [ {
@@ -4031,12 +4183,6 @@
         "row" : 1,
         "width" : 4
       }, {
-        "chartId" : "DiVWUQwAYAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 2,
-        "width" : 4
-      }, {
         "chartId" : "DiVWRQeAcAA",
         "column" : 8,
         "height" : 1,
@@ -4049,14 +4195,14 @@
         "row" : 2,
         "width" : 4
       }, {
-        "chartId" : "DiVWSPDAcAE",
-        "column" : 0,
+        "chartId" : "EoUldA3AcAA",
+        "column" : 4,
         "height" : 1,
-        "row" : 3,
+        "row" : 2,
         "width" : 4
       }, {
-        "chartId" : "DiVWRlKAYAA",
-        "column" : 4,
+        "chartId" : "DiVWSPDAcAE",
+        "column" : 0,
         "height" : 1,
         "row" : 3,
         "width" : 4
@@ -4067,10 +4213,10 @@
         "row" : 3,
         "width" : 4
       }, {
-        "chartId" : "DiVWUz_AgAA",
+        "chartId" : "DiVWRlKAYAA",
         "column" : 4,
         "height" : 1,
-        "row" : 4,
+        "row" : 3,
         "width" : 4
       }, {
         "chartId" : "DiVWT32AcAA",
@@ -4085,14 +4231,20 @@
         "row" : 4,
         "width" : 4
       }, {
-        "chartId" : "DiVWUdlAgAA",
+        "chartId" : "DiVWUz_AgAA",
         "column" : 4,
         "height" : 1,
-        "row" : 5,
+        "row" : 4,
         "width" : 4
       }, {
         "chartId" : "DiVWRGCAgBs",
         "column" : 0,
+        "height" : 1,
+        "row" : 5,
+        "width" : 4
+      }, {
+        "chartId" : "DiVWUdlAgAA",
+        "column" : 4,
         "height" : 1,
         "row" : 5,
         "width" : 4
@@ -4415,7 +4567,7 @@
       "teams" : null
     }
   },
-  "hashCode" : -766377778,
+  "hashCode" : -180468989,
   "id" : "DiVWQ8qAgAA",
   "modelVersion" : 1,
   "packageType" : "GROUP"


### PR DESCRIPTION
Starting mongo v3.3 mongodb/mongo@bba9c97 extra_info.heap_usage_bytes is no longer available the recommendation is to use tcmalloc.generic.heap_size instead