### PR TITLE
AKS: fix num nodes chart

### DIFF
--- a/group/Azure Kubernetes Service.json
+++ b/group/Azure Kubernetes Service.json
@@ -636,7 +636,7 @@
         "unitPrefix" : "Metric"
       },
       "packageSpecifications" : "",
-      "programText" : "A = data('kube_node_status_allocatable_cpu_cores', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true'),rollup='rate').mean(by=['azure_resource_id']).count().publish(label='A')",
+      "programText" : "A = data('kube_node_status_condition', filter=filter('resource_type', 'Microsoft.ContainerService/managedClusters') and filter('primary_aggregation_type', 'true')).mean(by=['azure_resource_id', 'node']).count().publish(label='A')",
       "relatedDetectorIds" : [ ],
       "tags" : null
     }
@@ -825,7 +825,7 @@
       "teams" : null
     }
   },
-  "hashCode" : -1099793333,
+  "hashCode" : -13164607,
   "id" : "D0RX4scAYAA",
   "modelVersion" : 1,
   "packageType" : "GROUP"


### PR DESCRIPTION
reverts the previous change - https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftcontainerservicemanagedclusters - according to azure docs, this metric is the only one with the `node` dimension associated with it, so we need to count by it. 