### PR TITLE
RAP-551 add setting for where to show content - first test one Azure Redis Cache

### DIFF
--- a/navigators/Azure/azurerediscaches.json
+++ b/navigators/Azure/azurerediscaches.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -1611130278,
+  "hashCode" : -739264885,
   "id" : "DiVVN2KAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,6 +21,7 @@
       "name" : "Redis Cache",
       "navigatorCategory" : "Azure",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:azure_resource_id",
         "category" : "Azure",


### PR DESCRIPTION
entity-nav: Add setting where to show Azure Redis Cache

Set a value for the new setting added to the navigator 
content that will allow this nav to show up both in o11y 
and in signalview.

https://signalfuse.atlassian.net/browse/RAP-551