### PR TITLE
RAP-551 Enable AWS Navigators for o11y

### DIFF
--- a/navigators/AWS/AWS instances.json
+++ b/navigators/AWS/AWS instances.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 1318572987,
+  "hashCode" : 1098383097,
   "id" : "DiVU-9WAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,6 +21,7 @@
       "name" : "EC2 Instances",
       "navigatorCategory" : "AWS",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:InstanceId",
         "category" : "AWS",

--- a/navigators/AWS/autoscaling.json
+++ b/navigators/AWS/autoscaling.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 1819466665,
+  "hashCode" : -462791681,
   "id" : "DiVVNnDAcEQ",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,6 +21,7 @@
       "name" : "AutoScaling Groups",
       "navigatorCategory" : "AWS",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:AutoScalingGroupName",
         "category" : "AWS",

--- a/navigators/AWS/awsdynamodb.json
+++ b/navigators/AWS/awsdynamodb.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -1847669425,
+  "hashCode" : 385661686,
   "id" : "DiVVE8tAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,6 +21,7 @@
       "name" : "DynamoDB",
       "navigatorCategory" : "AWS",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:TableName",
         "category" : "AWS",

--- a/navigators/AWS/awsebs.json
+++ b/navigators/AWS/awsebs.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 491706471,
+  "hashCode" : 1629533569,
   "id" : "DiVU_CpAgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,6 +21,7 @@
       "name" : "EBS Volumes",
       "navigatorCategory" : "AWS",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:VolumeId",
         "category" : "AWS",

--- a/navigators/AWS/awsecs.json
+++ b/navigators/AWS/awsecs.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -1842886123,
+  "hashCode" : -900304344,
   "id" : "DiVU_KHAcAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,6 +21,7 @@
       "name" : "ECS Clusters",
       "navigatorCategory" : "AWS",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:ClusterName",
         "category" : "AWS",

--- a/navigators/AWS/cloudfront.json
+++ b/navigators/AWS/cloudfront.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -2052578575,
+  "hashCode" : -1539260204,
   "id" : "DiVVOGwAgAE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,6 +21,7 @@
       "name" : "CloudFront Distributions",
       "navigatorCategory" : "AWS",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:DistributionId",
         "category" : "AWS",

--- a/navigators/AWS/elasticache.json
+++ b/navigators/AWS/elasticache.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 1739476366,
+  "hashCode" : -81968489,
   "id" : "DiVU-9XAgAE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,6 +21,7 @@
       "name" : "ElastiCache Nodes",
       "navigatorCategory" : "AWS",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:CacheClusterId",
         "category" : "AWS",

--- a/navigators/AWS/elb.json
+++ b/navigators/AWS/elb.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 27581701,
+  "hashCode" : 1203923552,
   "id" : "DiVVOB3AYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,6 +21,7 @@
       "name" : "ELB Load Balancers",
       "navigatorCategory" : "AWS",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:LoadBalancerName",
         "category" : "AWS",

--- a/navigators/AWS/lambda.json
+++ b/navigators/AWS/lambda.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -1100398122,
+  "hashCode" : -2087790099,
   "id" : "DiVVN4WAgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -42,6 +42,7 @@
       "name" : "Lambda Functions",
       "navigatorCategory" : "AWS",
       "navigatorType" : "list",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:aws_function_name",
         "alwaysGroupBy" : "aws_function_name",

--- a/navigators/AWS/rds databases.json
+++ b/navigators/AWS/rds databases.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 35258478,
+  "hashCode" : 662853946,
   "id" : "DiVVFU6AcAE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,6 +21,7 @@
       "name" : "RDS Databases",
       "navigatorCategory" : "AWS",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:DBInstanceIdentifier",
         "category" : "AWS",

--- a/navigators/AWS/sns.json
+++ b/navigators/AWS/sns.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -762338976,
+  "hashCode" : 2105834600,
   "id" : "DiVVEqDAcAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,6 +21,7 @@
       "name" : "SNS Topics",
       "navigatorCategory" : "AWS",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:TopicName",
         "category" : "AWS",

--- a/navigators/AWS/sqs queues.json
+++ b/navigators/AWS/sqs queues.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -403747277,
+  "hashCode" : -2097391982,
   "id" : "DiVU-_uAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,6 +21,7 @@
       "name" : "SQS Queues",
       "navigatorCategory" : "AWS",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:QueueName",
         "category" : "AWS",


### PR DESCRIPTION
entity nav: Enable AWS Navigators for o11y

Set a value for the new setting added to the
navigator content that will allow these navs
to show up both in o11y and in signalview.

https://signalfuse.atlassian.net/browse/RAP-551