### PR TITLE
RAP-551 Enable Hosts+K8S Navigators for o11y

### DIFF
--- a/navigators/Hosts/collectd hosts.json
+++ b/navigators/Hosts/collectd hosts.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 82164467,
+  "hashCode" : -43770749,
   "id" : "DiVVQHAAcAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,6 +21,7 @@
       "name" : "Hosts (Smart Agent / collectd)",
       "navigatorCategory" : "Hosts",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:host",
         "category" : "Hosts",

--- a/navigators/Hosts/telegraf hosts.json
+++ b/navigators/Hosts/telegraf hosts.json
@@ -1,14 +1,6 @@
 {
-  "hashCode" : 2097822078,
+  "hashCode" : -1860182451,
   "id" : "DiVVN15AcAA",
-  "importQualifiers" : [ {
-    "filters" : [ {
-      "not" : false,
-      "property" : "sf_key",
-      "values" : [ "agent" ]
-    } ],
-    "metric" : "cpu.utilization"
-  } ],
   "modelVersion" : 1,
   "navigatorExport" : {
     "navigator" : {
@@ -29,6 +21,7 @@
       "name" : "Hosts (telegraf)",
       "navigatorCategory" : "Hosts",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:host AND agent:telegraf",
         "category" : "Hosts",
@@ -88,6 +81,7 @@
           "id" : "telegraf.cpu.utilization",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "agent",
               "propertyValue" : "telegraf",
               "type" : "property"
@@ -114,6 +108,7 @@
           "id" : "telegraf.memory.utilization",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "agent",
               "propertyValue" : "telegraf",
               "type" : "property"
@@ -140,6 +135,7 @@
           "id" : "telegraf.disk.summary_utilization",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "agent",
               "propertyValue" : "telegraf",
               "type" : "property"
@@ -166,6 +162,7 @@
           "id" : "telegraf.network.total",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "agent",
               "propertyValue" : "telegraf",
               "type" : "property"
@@ -192,6 +189,7 @@
           "id" : "telegraf.disk_ops.total",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "agent",
               "propertyValue" : "telegraf",
               "type" : "property"
@@ -220,6 +218,7 @@
           "id" : "___SF_ALERT_TELEGRAF",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "agent",
               "propertyValue" : "telegraf",
               "type" : "property"
@@ -234,6 +233,11 @@
           "valueLabel" : "Most severe alert"
         } ],
         "mtsQuery" : "sf_metric:cpu.utilization AND _exists_:agent",
+        "o11yMetricName" : null,
+        "o11yMetricUnit" : null,
+        "o11yProductName" : null,
+        "o11ySignalflowTemplate" : null,
+        "o11yTrendDisplayMode" : null,
         "propertyColumns" : [ [ {
           "header" : "Memory",
           "properties" : [ "host_mem_total" ]

--- a/navigators/Hosts/windows hosts.json
+++ b/navigators/Hosts/windows hosts.json
@@ -1,14 +1,6 @@
 {
-  "hashCode" : -1028931334,
+  "hashCode" : -1580205024,
   "id" : "DiVU-9dAcAA",
-  "importQualifiers" : [ {
-    "filters" : [ {
-      "not" : false,
-      "property" : "sf_key",
-      "values" : [ "host" ]
-    } ],
-    "metric" : "processor.pct_processor_time"
-  } ],
   "modelVersion" : 1,
   "navigatorExport" : {
     "navigator" : {
@@ -29,6 +21,7 @@
       "name" : "Hosts (Windows - PerfCounter)",
       "navigatorCategory" : "Hosts",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:host",
         "category" : "Hosts",
@@ -67,10 +60,12 @@
           "id" : "windows.processor.pct_processor_time",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "host",
               "type" : "property"
             }, {
+              "not" : false,
               "property" : "instance",
               "propertyValue" : "_total",
               "type" : "property"
@@ -97,6 +92,7 @@
           "id" : "windows.memory.utilization",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "host",
               "type" : "property"
@@ -123,10 +119,12 @@
           "id" : "windows.logicaldisk.pct_free_space",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "host",
               "type" : "property"
             }, {
+              "not" : false,
               "property" : "instance",
               "propertyValue" : "_total",
               "type" : "property"
@@ -153,6 +151,7 @@
           "id" : "windows.network_interface.bytes_total_sec",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "host",
               "type" : "property"
@@ -179,10 +178,12 @@
           "id" : "windows.paging_file.pct_usage",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "instance",
               "propertyValue" : "_total",
               "type" : "property"
             }, {
+              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "host",
               "type" : "property"
@@ -211,6 +212,7 @@
           "id" : "___SF_ALERT_COLLECTD",
           "job" : {
             "filters" : [ {
+              "not" : false,
               "property" : "_exists_",
               "propertyValue" : "host",
               "type" : "property"
@@ -225,6 +227,11 @@
           "valueLabel" : "Most severe alert"
         } ],
         "mtsQuery" : "sf_metric:processor.pct_processor_time AND _exists_:host",
+        "o11yMetricName" : null,
+        "o11yMetricUnit" : null,
+        "o11yProductName" : null,
+        "o11ySignalflowTemplate" : null,
+        "o11yTrendDisplayMode" : null,
         "propertyColumns" : [ [ {
           "header" : "Tags",
           "properties" : [ "sf_tags" ]

--- a/navigators/Kubernetes/kubernetes containers.json
+++ b/navigators/Kubernetes/kubernetes containers.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -861178787,
+  "hashCode" : 646144153,
   "id" : "D85Z_TlAcFE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,6 +21,7 @@
       "name" : "Kubernetes Nodes",
       "navigatorCategory" : "Kubernetes",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:container_id",
         "category" : "Kubernetes",

--- a/navigators/Kubernetes/kubernetes nodes.json
+++ b/navigators/Kubernetes/kubernetes nodes.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -2141776852,
+  "hashCode" : -266474902,
   "id" : "DiVVM3IAgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,6 +21,7 @@
       "name" : "Kubernetes Nodes",
       "navigatorCategory" : "Kubernetes",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:kubernetes_cluster",
         "category" : "Kubernetes",

--- a/navigators/Kubernetes/kubernetes pods.json
+++ b/navigators/Kubernetes/kubernetes pods.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 1574805258,
+  "hashCode" : -1016546515,
   "id" : "DiVVQ6FAgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -25,6 +25,7 @@
       "name" : "Kubernetes Pods",
       "navigatorCategory" : "Kubernetes",
       "navigatorType" : "elemental",
+      "sites" : "o11yandsignalview",
       "uiModel" : {
         "alertQuery" : "_exists_:kubernetes_pod_name",
         "category" : "Kubernetes",


### PR DESCRIPTION
entity nav: Enable Hosts+K8S Navigators for o11y

Set a value for the new setting added to the
navigator content that will allow these navs
to show up both in o11y and in signalview.

https://signalfuse.atlassian.net/browse/RAP-551