### PR TITLE
Update apiserver charts with newer metric

### DIFF
--- a/group/Kubernetes.json
+++ b/group/Kubernetes.json
@@ -12,6 +12,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : false,
@@ -161,6 +162,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : false,
@@ -352,6 +354,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : false,
@@ -445,6 +448,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : false,
@@ -529,6 +533,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : false,
@@ -586,6 +591,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : true,
@@ -673,6 +679,7 @@
       "options" : {
         "colorBy" : "Metric",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -754,6 +761,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : false,
@@ -964,6 +972,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -1012,6 +1021,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -1606,6 +1616,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -2138,6 +2149,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : true,
@@ -2438,6 +2450,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -3328,6 +3341,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : true,
@@ -3483,6 +3497,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -3675,6 +3690,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : true,
@@ -3771,6 +3787,7 @@
           "lte" : 20.0,
           "paletteIndex" : 20
         } ],
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : true,
@@ -3933,6 +3950,7 @@
           "lte" : 20.0,
           "paletteIndex" : 20
         } ],
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : false,
@@ -4029,6 +4047,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : true,
@@ -4101,6 +4120,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -4252,6 +4272,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -4388,6 +4409,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -4997,6 +5019,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -5075,6 +5098,7 @@
           "lte" : 20.0,
           "paletteIndex" : 20
         } ],
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : true,
@@ -5224,6 +5248,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -5269,6 +5294,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -5317,6 +5343,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -5392,6 +5419,7 @@
           "lte" : 20.0,
           "paletteIndex" : 20
         } ],
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : true,
@@ -5494,6 +5522,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -5828,6 +5857,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -5876,6 +5906,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -6021,6 +6052,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : null
         },
@@ -6567,6 +6599,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : true,
@@ -6654,6 +6687,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : false,
@@ -6744,6 +6778,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : false,
@@ -7246,12 +7281,30 @@
           "timezone" : null
         },
         "publishLabelOptions" : [ {
-          "displayName" : "apiserver_request_count - Sum",
+          "displayName" : "apiserver_request_count (deprecated)",
           "label" : "A",
           "paletteIndex" : null,
           "plotType" : null,
           "valuePrefix" : null,
           "valueSuffix" : "ops",
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "api_request_total",
+          "label" : "B",
+          "paletteIndex" : null,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "RPC Rate",
+          "label" : "C",
+          "paletteIndex" : null,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
           "valueUnit" : null,
           "yAxis" : 0
         } ],
@@ -7265,7 +7318,7 @@
         "unitPrefix" : "Metric"
       },
       "packageSpecifications" : "",
-      "programText" : "A = data('apiserver_request_count', filter=filter('metric_source', 'kubernetes-apiserver'),rollup='rate').sum().publish(label='A')",
+      "programText" : "A = data('apiserver_request_count', filter=filter('metric_source', 'kubernetes-apiserver'), rollup='rate').sum().publish(label='A', enable=False)\nB = data('apiserver_request_total', filter=filter('metric_source', 'kubernetes-apiserver')).sum().publish(label='B', enable=False)\nC = (A+B).publish(label='C')",
       "relatedDetectorIds" : [ ],
       "tags" : null
     }
@@ -7645,6 +7698,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : false,
@@ -8512,8 +8566,26 @@
           "timezone" : null
         },
         "publishLabelOptions" : [ {
-          "displayName" : "apiserver_request_count - Sum by kubernetes_cluster,kubernetes_node - Count",
+          "displayName" : "deprecated request count",
           "label" : "A",
+          "paletteIndex" : null,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "request count",
+          "label" : "B",
+          "paletteIndex" : null,
+          "plotType" : null,
+          "valuePrefix" : null,
+          "valueSuffix" : null,
+          "valueUnit" : null,
+          "yAxis" : 0
+        }, {
+          "displayName" : "A+B",
+          "label" : "C",
           "paletteIndex" : null,
           "plotType" : null,
           "valuePrefix" : null,
@@ -8533,7 +8605,7 @@
         "unitPrefix" : "Metric"
       },
       "packageSpecifications" : "",
-      "programText" : "A = data('apiserver_request_count', filter=filter('metric_source', 'kubernetes-apiserver'),rollup='rate').sum(by=['kubernetes_cluster', 'kubernetes_node']).count().publish(label='A')",
+      "programText" : "A = data('apiserver_request_count', filter=filter('metric_source', 'kubernetes-apiserver')).sum(by=['kubernetes_cluster', 'kubernetes_node']).count().publish(label='A', enable=False)\nB = data('apiserver_request_total', filter=filter('metric_source', 'kubernetes-apiserver')).sum(by=['kubernetes_cluster', 'kubernetes_node']).count().publish(label='B', enable=False)\nC = (A+B).publish(label='C')",
       "relatedDetectorIds" : [ ],
       "tags" : null
     }
@@ -8694,6 +8766,7 @@
       "options" : {
         "colorBy" : "Dimension",
         "colorScale2" : null,
+        "hideMissingValues" : false,
         "legendOptions" : {
           "fields" : [ {
             "enabled" : false,
@@ -8820,6 +8893,7 @@
   } ],
   "crossLinkExports" : [ {
     "crossLink" : {
+      "aliases" : null,
       "contextId" : "D-KtoUmAcAA",
       "created" : 0,
       "creator" : null,
@@ -8837,6 +8911,7 @@
     }
   }, {
     "crossLink" : {
+      "aliases" : null,
       "contextId" : "D2SlSb5AgAA",
       "created" : 0,
       "creator" : null,
@@ -8854,91 +8929,7 @@
     }
   }, {
     "crossLink" : {
-      "contextId" : "D2SlSb5AgAA",
-      "created" : 0,
-      "creator" : null,
-      "id" : "EZHL07BAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "propertyName" : "kubernetes_pod_uid",
-      "targets" : [ {
-        "dashboardGroupId" : "DiVWf-iAgAA",
-        "dashboardId" : "D8I_-P3AcAA",
-        "isDefault" : true,
-        "name" : "k8s-overview-pod-uid-link",
-        "type" : "INTERNAL_LINK"
-      } ]
-    }
-  }, {
-    "crossLink" : {
-      "contextId" : "D2SlSb5AgAA",
-      "created" : 0,
-      "creator" : null,
-      "id" : "EZHLeCgAgAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "propertyName" : "kubernetes_pod_name",
-      "targets" : [ {
-        "dashboardGroupId" : "DiVWf-iAgAA",
-        "dashboardId" : "D8I_-P3AcAA",
-        "isDefault" : true,
-        "name" : "k8s-overview-pod-name-link",
-        "type" : "INTERNAL_LINK"
-      } ]
-    }
-  }, {
-    "crossLink" : {
-      "contextId" : "D2SmRRbAcAA",
-      "created" : 0,
-      "creator" : null,
-      "id" : "EQCenU1AcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "propertyName" : "kubernetes_node",
-      "targets" : [ {
-        "dashboardGroupId" : "DiVWf-iAgAA",
-        "dashboardId" : "DkBnHSpAYAA",
-        "isDefault" : true,
-        "name" : "k8s-nodes-node-link",
-        "type" : "INTERNAL_LINK"
-      } ]
-    }
-  }, {
-    "crossLink" : {
-      "contextId" : "D8I_-P3AcAA",
-      "created" : 0,
-      "creator" : null,
-      "id" : "EZHN_osAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "propertyName" : "container_id",
-      "targets" : [ {
-        "dashboardGroupId" : "DiVWf-iAgAA",
-        "dashboardId" : "D-KwPVTAcFM",
-        "isDefault" : true,
-        "name" : "k8s-pod-container-link",
-        "type" : "INTERNAL_LINK"
-      } ]
-    }
-  }, {
-    "crossLink" : {
-      "contextId" : "DkBnHSpAYAA",
-      "created" : 0,
-      "creator" : null,
-      "id" : "EZHMk6gAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "propertyName" : "kubernetes_pod_name",
-      "targets" : [ {
-        "dashboardGroupId" : "DiVWf-iAgAA",
-        "dashboardId" : "D8I_-P3AcAA",
-        "isDefault" : true,
-        "name" : "k8s-node-pod-name-link",
-        "type" : "INTERNAL_LINK"
-      } ]
-    }
-  }, {
-    "crossLink" : {
+      "aliases" : null,
       "contextId" : "DkBnHSpAYAA",
       "created" : 0,
       "creator" : null,
@@ -8956,6 +8947,97 @@
     }
   }, {
     "crossLink" : {
+      "aliases" : null,
+      "contextId" : "D2SlSb5AgAA",
+      "created" : 0,
+      "creator" : null,
+      "id" : "EZHL07BAYAA",
+      "lastUpdated" : 0,
+      "lastUpdatedBy" : null,
+      "propertyName" : "kubernetes_pod_uid",
+      "targets" : [ {
+        "dashboardGroupId" : "DiVWf-iAgAA",
+        "dashboardId" : "D8I_-P3AcAA",
+        "isDefault" : true,
+        "name" : "k8s-overview-pod-uid-link",
+        "type" : "INTERNAL_LINK"
+      } ]
+    }
+  }, {
+    "crossLink" : {
+      "aliases" : null,
+      "contextId" : "D2SlSb5AgAA",
+      "created" : 0,
+      "creator" : null,
+      "id" : "EZHLeCgAgAA",
+      "lastUpdated" : 0,
+      "lastUpdatedBy" : null,
+      "propertyName" : "kubernetes_pod_name",
+      "targets" : [ {
+        "dashboardGroupId" : "DiVWf-iAgAA",
+        "dashboardId" : "D8I_-P3AcAA",
+        "isDefault" : true,
+        "name" : "k8s-overview-pod-name-link",
+        "type" : "INTERNAL_LINK"
+      } ]
+    }
+  }, {
+    "crossLink" : {
+      "aliases" : null,
+      "contextId" : "D2SmRRbAcAA",
+      "created" : 0,
+      "creator" : null,
+      "id" : "EQCenU1AcAA",
+      "lastUpdated" : 0,
+      "lastUpdatedBy" : null,
+      "propertyName" : "kubernetes_node",
+      "targets" : [ {
+        "dashboardGroupId" : "DiVWf-iAgAA",
+        "dashboardId" : "DkBnHSpAYAA",
+        "isDefault" : true,
+        "name" : "k8s-nodes-node-link",
+        "type" : "INTERNAL_LINK"
+      } ]
+    }
+  }, {
+    "crossLink" : {
+      "aliases" : null,
+      "contextId" : "D8I_-P3AcAA",
+      "created" : 0,
+      "creator" : null,
+      "id" : "EZHN_osAYAA",
+      "lastUpdated" : 0,
+      "lastUpdatedBy" : null,
+      "propertyName" : "container_id",
+      "targets" : [ {
+        "dashboardGroupId" : "DiVWf-iAgAA",
+        "dashboardId" : "D-KwPVTAcFM",
+        "isDefault" : true,
+        "name" : "k8s-pod-container-link",
+        "type" : "INTERNAL_LINK"
+      } ]
+    }
+  }, {
+    "crossLink" : {
+      "aliases" : null,
+      "contextId" : "DkBnHSpAYAA",
+      "created" : 0,
+      "creator" : null,
+      "id" : "EZHMk6gAYAA",
+      "lastUpdated" : 0,
+      "lastUpdatedBy" : null,
+      "propertyName" : "kubernetes_pod_name",
+      "targets" : [ {
+        "dashboardGroupId" : "DiVWf-iAgAA",
+        "dashboardId" : "D8I_-P3AcAA",
+        "isDefault" : true,
+        "name" : "k8s-node-pod-name-link",
+        "type" : "INTERNAL_LINK"
+      } ]
+    }
+  }, {
+    "crossLink" : {
+      "aliases" : null,
       "contextId" : "D4rhV71AcAA",
       "created" : 0,
       "creator" : null,
@@ -8973,6 +9055,7 @@
     }
   }, {
     "crossLink" : {
+      "aliases" : null,
       "contextId" : "D4rhV71AcAA",
       "created" : 0,
       "creator" : null,
@@ -8990,206 +9073,6 @@
     }
   } ],
   "dashboardExports" : [ {
-    "dashboard" : {
-      "chartDensity" : "DEFAULT",
-      "charts" : [ {
-        "chartId" : "DkBnAvVAYAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DkBnAW2AgAI",
-        "column" : 8,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DkBnCXLAgAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DkBnCYRAYAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DkBnCMpAgAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DkBnCUjAYAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "DkBnCV1AcAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 2,
-        "width" : 4
-      }, {
-        "chartId" : "DkBnBZnAgAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 2,
-        "width" : 8
-      }, {
-        "chartId" : "DkBnBhCAYAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 3,
-        "width" : 4
-      }, {
-        "chartId" : "DkBnB8XAcAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 3,
-        "width" : 4
-      }, {
-        "chartId" : "DkBnBFnAcAE",
-        "column" : 4,
-        "height" : 1,
-        "row" : 3,
-        "width" : 4
-      } ],
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : null,
-      "description" : "",
-      "discoveryOptions" : {
-        "query" : "metric_source:kubernetes",
-        "selectors" : [ "sf_key:kubernetes_cluster" ]
-      },
-      "eventOverlays" : null,
-      "filters" : {
-        "sources" : null,
-        "time" : null,
-        "variables" : [ {
-          "alias" : "Cluster",
-          "applyIfExists" : false,
-          "description" : "k8s cluster",
-          "preferredSuggestions" : [ ],
-          "property" : "kubernetes_cluster",
-          "replaceOnly" : false,
-          "required" : true,
-          "restricted" : false,
-          "value" : ""
-        } ]
-      },
-      "groupId" : "DiVWf-iAgAA",
-      "id" : "DkBm_nVAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "maxDelayOverride" : null,
-      "name" : "K8s Operations",
-      "selectedEventOverlays" : [ ],
-      "tags" : null
-    }
-  }, {
-    "dashboard" : {
-      "chartDensity" : "DEFAULT",
-      "charts" : [ {
-        "chartId" : "DkBnJQ3AYAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DkBnHTuAcAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DkBnJksAcAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "DkBnHSwAcAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 1,
-        "width" : 6
-      }, {
-        "chartId" : "DkBnI_OAcAA",
-        "column" : 6,
-        "height" : 1,
-        "row" : 1,
-        "width" : 6
-      }, {
-        "chartId" : "DkBnHTDAYAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 2,
-        "width" : 4
-      }, {
-        "chartId" : "DkBnJmPAgAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 2,
-        "width" : 4
-      }, {
-        "chartId" : "DkBnHS4AgAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 2,
-        "width" : 4
-      }, {
-        "chartId" : "DkBnJHhAgAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 3,
-        "width" : 6
-      }, {
-        "chartId" : "DkBnHZUAgAA",
-        "column" : 6,
-        "height" : 1,
-        "row" : 3,
-        "width" : 6
-      } ],
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : null,
-      "description" : null,
-      "discoveryOptions" : {
-        "query" : "_exists_:kubernetes_cluster AND _exists_:kubernetes_node",
-        "selectors" : [ "_exists_:kubernetes_node" ]
-      },
-      "eventOverlays" : null,
-      "filters" : {
-        "sources" : null,
-        "time" : null,
-        "variables" : [ {
-          "alias" : "Node",
-          "applyIfExists" : false,
-          "description" : "K8s Node",
-          "preferredSuggestions" : [ ],
-          "property" : "kubernetes_node",
-          "replaceOnly" : false,
-          "required" : true,
-          "restricted" : false,
-          "value" : [ "Choose a Node" ]
-        } ]
-      },
-      "groupId" : "DiVWf-iAgAA",
-      "id" : "DkBnHSpAYAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "maxDelayOverride" : null,
-      "name" : "K8s Node",
-      "selectedEventOverlays" : [ ],
-      "tags" : null
-    }
-  }, {
     "dashboard" : {
       "chartDensity" : "DEFAULT",
       "charts" : [ {
@@ -9319,6 +9202,7 @@
           "description" : "",
           "preferredSuggestions" : [ ],
           "property" : "kubernetes_cluster",
+          "propertyMappings" : [ "kubernetes_cluster" ],
           "replaceOnly" : true,
           "required" : false,
           "restricted" : false,
@@ -9329,6 +9213,7 @@
           "description" : "",
           "preferredSuggestions" : [ ],
           "property" : "kubernetes_namespace",
+          "propertyMappings" : [ "kubernetes_namespace" ],
           "replaceOnly" : true,
           "required" : false,
           "restricted" : false,
@@ -9339,6 +9224,7 @@
           "description" : "",
           "preferredSuggestions" : [ ],
           "property" : "kubernetes_node",
+          "propertyMappings" : [ "kubernetes_node" ],
           "replaceOnly" : true,
           "required" : false,
           "restricted" : false,
@@ -9349,6 +9235,7 @@
           "description" : "",
           "preferredSuggestions" : [ ],
           "property" : "deployment",
+          "propertyMappings" : [ "deployment" ],
           "replaceOnly" : true,
           "required" : false,
           "restricted" : false,
@@ -9359,6 +9246,7 @@
           "description" : "",
           "preferredSuggestions" : [ "kubernetes_service*" ],
           "property" : "sf_tags",
+          "propertyMappings" : [ "sf_tags" ],
           "replaceOnly" : true,
           "required" : false,
           "restricted" : true,
@@ -9371,6 +9259,179 @@
       "lastUpdatedBy" : null,
       "maxDelayOverride" : null,
       "name" : "K8s Overview",
+      "selectedEventOverlays" : [ ],
+      "tags" : null
+    }
+  }, {
+    "dashboard" : {
+      "chartDensity" : "DEFAULT",
+      "charts" : [ {
+        "chartId" : "D8I6ZUjAcAA",
+        "column" : 0,
+        "height" : 1,
+        "row" : 0,
+        "width" : 4
+      }, {
+        "chartId" : "D8I6Zv0AcAA",
+        "column" : 8,
+        "height" : 1,
+        "row" : 0,
+        "width" : 4
+      }, {
+        "chartId" : "D8I6ZjWAgAA",
+        "column" : 4,
+        "height" : 1,
+        "row" : 0,
+        "width" : 4
+      }, {
+        "chartId" : "D8I6ZNBAgAQ",
+        "column" : 0,
+        "height" : 2,
+        "row" : 1,
+        "width" : 4
+      }, {
+        "chartId" : "D8I6Z29AYAA",
+        "column" : 8,
+        "height" : 2,
+        "row" : 1,
+        "width" : 4
+      }, {
+        "chartId" : "D8I6ZZfAYAA",
+        "column" : 4,
+        "height" : 2,
+        "row" : 1,
+        "width" : 4
+      }, {
+        "chartId" : "D8I6aRTAgAA",
+        "column" : 6,
+        "height" : 1,
+        "row" : 3,
+        "width" : 6
+      }, {
+        "chartId" : "D8I6YG3AYAA",
+        "column" : 0,
+        "height" : 1,
+        "row" : 3,
+        "width" : 6
+      } ],
+      "created" : 0,
+      "creator" : null,
+      "customProperties" : null,
+      "description" : "",
+      "discoveryOptions" : {
+        "query" : "sf_metric:cpu.utilization AND _exists_:kubernetes_cluster",
+        "selectors" : [ "_exists_:kubernetes_cluster" ]
+      },
+      "eventOverlays" : null,
+      "filters" : {
+        "sources" : null,
+        "time" : null,
+        "variables" : null
+      },
+      "groupId" : "DiVWf-iAgAA",
+      "id" : "D8I6X2QAcAA",
+      "lastUpdated" : 0,
+      "lastUpdatedBy" : null,
+      "maxDelayOverride" : null,
+      "name" : "K8s Clusters",
+      "selectedEventOverlays" : [ ],
+      "tags" : null
+    }
+  }, {
+    "dashboard" : {
+      "chartDensity" : "DEFAULT",
+      "charts" : [ {
+        "chartId" : "DkBnJQ3AYAA",
+        "column" : 0,
+        "height" : 1,
+        "row" : 0,
+        "width" : 4
+      }, {
+        "chartId" : "DkBnHTuAcAA",
+        "column" : 4,
+        "height" : 1,
+        "row" : 0,
+        "width" : 4
+      }, {
+        "chartId" : "DkBnJksAcAA",
+        "column" : 8,
+        "height" : 1,
+        "row" : 0,
+        "width" : 4
+      }, {
+        "chartId" : "DkBnHSwAcAA",
+        "column" : 0,
+        "height" : 1,
+        "row" : 1,
+        "width" : 6
+      }, {
+        "chartId" : "DkBnI_OAcAA",
+        "column" : 6,
+        "height" : 1,
+        "row" : 1,
+        "width" : 6
+      }, {
+        "chartId" : "DkBnHTDAYAA",
+        "column" : 8,
+        "height" : 1,
+        "row" : 2,
+        "width" : 4
+      }, {
+        "chartId" : "DkBnJmPAgAA",
+        "column" : 0,
+        "height" : 1,
+        "row" : 2,
+        "width" : 4
+      }, {
+        "chartId" : "DkBnHS4AgAA",
+        "column" : 4,
+        "height" : 1,
+        "row" : 2,
+        "width" : 4
+      }, {
+        "chartId" : "DkBnJHhAgAA",
+        "column" : 0,
+        "height" : 1,
+        "row" : 3,
+        "width" : 6
+      }, {
+        "chartId" : "DkBnHZUAgAA",
+        "column" : 6,
+        "height" : 1,
+        "row" : 3,
+        "width" : 6
+      } ],
+      "created" : 0,
+      "creator" : null,
+      "customProperties" : null,
+      "description" : null,
+      "discoveryOptions" : {
+        "query" : "_exists_:kubernetes_cluster AND _exists_:kubernetes_node",
+        "selectors" : [ "_exists_:kubernetes_node" ]
+      },
+      "eventOverlays" : null,
+      "filters" : {
+        "sources" : null,
+        "time" : null,
+        "variables" : [ {
+          "alias" : "Node",
+          "applyIfExists" : false,
+          "description" : "K8s Node",
+          "preferredSuggestions" : [ ],
+          "property" : "kubernetes_node",
+          "propertyMappings" : [ "kubernetes_node" ],
+          "replaceOnly" : false,
+          "required" : true,
+          "restricted" : false,
+          "value" : [ "Choose a Node" ]
+        } ]
+      },
+      "groupId" : "DiVWf-iAgAA",
+      "id" : "DkBnHSpAYAA",
+      "lastUpdated" : 0,
+      "lastUpdatedBy" : null,
+      "maxDelayOverride" : null,
+      "name" : "K8s Node",
       "selectedEventOverlays" : [ ],
       "tags" : null
     }
@@ -9450,6 +9511,7 @@
           "description" : "Kubernetes Cluster Name",
           "preferredSuggestions" : [ ],
           "property" : "kubernetes_cluster",
+          "propertyMappings" : [ "kubernetes_cluster" ],
           "replaceOnly" : true,
           "required" : false,
           "restricted" : false,
@@ -9462,6 +9524,110 @@
       "lastUpdatedBy" : null,
       "maxDelayOverride" : null,
       "name" : "K8s Nodes",
+      "selectedEventOverlays" : [ ],
+      "tags" : null
+    }
+  }, {
+    "dashboard" : {
+      "chartDensity" : "DEFAULT",
+      "charts" : [ {
+        "chartId" : "DkBnAvVAYAA",
+        "column" : 0,
+        "height" : 1,
+        "row" : 0,
+        "width" : 4
+      }, {
+        "chartId" : "DkBnAW2AgAI",
+        "column" : 8,
+        "height" : 1,
+        "row" : 0,
+        "width" : 4
+      }, {
+        "chartId" : "DkBnCXLAgAA",
+        "column" : 4,
+        "height" : 1,
+        "row" : 0,
+        "width" : 4
+      }, {
+        "chartId" : "DkBnCYRAYAA",
+        "column" : 0,
+        "height" : 1,
+        "row" : 1,
+        "width" : 4
+      }, {
+        "chartId" : "DkBnCMpAgAA",
+        "column" : 8,
+        "height" : 1,
+        "row" : 1,
+        "width" : 4
+      }, {
+        "chartId" : "DkBnCUjAYAA",
+        "column" : 4,
+        "height" : 1,
+        "row" : 1,
+        "width" : 4
+      }, {
+        "chartId" : "DkBnCV1AcAA",
+        "column" : 0,
+        "height" : 1,
+        "row" : 2,
+        "width" : 4
+      }, {
+        "chartId" : "DkBnBZnAgAA",
+        "column" : 4,
+        "height" : 1,
+        "row" : 2,
+        "width" : 8
+      }, {
+        "chartId" : "DkBnBhCAYAA",
+        "column" : 0,
+        "height" : 1,
+        "row" : 3,
+        "width" : 4
+      }, {
+        "chartId" : "DkBnB8XAcAA",
+        "column" : 8,
+        "height" : 1,
+        "row" : 3,
+        "width" : 4
+      }, {
+        "chartId" : "DkBnBFnAcAE",
+        "column" : 4,
+        "height" : 1,
+        "row" : 3,
+        "width" : 4
+      } ],
+      "created" : 0,
+      "creator" : null,
+      "customProperties" : null,
+      "description" : "",
+      "discoveryOptions" : {
+        "query" : "metric_source:kubernetes",
+        "selectors" : [ "sf_key:kubernetes_cluster" ]
+      },
+      "eventOverlays" : null,
+      "filters" : {
+        "sources" : null,
+        "time" : null,
+        "variables" : [ {
+          "alias" : "Cluster",
+          "applyIfExists" : false,
+          "description" : "k8s cluster",
+          "preferredSuggestions" : [ ],
+          "property" : "kubernetes_cluster",
+          "propertyMappings" : [ "kubernetes_cluster" ],
+          "replaceOnly" : false,
+          "required" : true,
+          "restricted" : false,
+          "value" : ""
+        } ]
+      },
+      "groupId" : "DiVWf-iAgAA",
+      "id" : "DkBm_nVAcAA",
+      "lastUpdated" : 0,
+      "lastUpdatedBy" : null,
+      "maxDelayOverride" : null,
+      "name" : "K8s Operations",
       "selectedEventOverlays" : [ ],
       "tags" : null
     }
@@ -9553,6 +9719,7 @@
           "description" : "",
           "preferredSuggestions" : [ ],
           "property" : "kubernetes_cluster",
+          "propertyMappings" : [ "kubernetes_cluster" ],
           "replaceOnly" : true,
           "required" : false,
           "restricted" : false,
@@ -9563,6 +9730,7 @@
           "description" : "",
           "preferredSuggestions" : [ ],
           "property" : "kubernetes_namespace",
+          "propertyMappings" : [ "kubernetes_namespace" ],
           "replaceOnly" : true,
           "required" : false,
           "restricted" : false,
@@ -9573,6 +9741,7 @@
           "description" : "",
           "preferredSuggestions" : [ ],
           "property" : "deployment",
+          "propertyMappings" : [ "deployment" ],
           "replaceOnly" : true,
           "required" : false,
           "restricted" : false,
@@ -9583,6 +9752,7 @@
           "description" : "",
           "preferredSuggestions" : [ "kubernetes_service*" ],
           "property" : "sf_tags",
+          "propertyMappings" : [ "sf_tags" ],
           "replaceOnly" : true,
           "required" : false,
           "restricted" : false,
@@ -9595,81 +9765,6 @@
       "lastUpdatedBy" : null,
       "maxDelayOverride" : null,
       "name" : "K8s Pods",
-      "selectedEventOverlays" : [ ],
-      "tags" : null
-    }
-  }, {
-    "dashboard" : {
-      "chartDensity" : "DEFAULT",
-      "charts" : [ {
-        "chartId" : "D8I6ZUjAcAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "D8I6Zv0AcAA",
-        "column" : 8,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "D8I6ZjWAgAA",
-        "column" : 4,
-        "height" : 1,
-        "row" : 0,
-        "width" : 4
-      }, {
-        "chartId" : "D8I6ZNBAgAQ",
-        "column" : 0,
-        "height" : 2,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "D8I6Z29AYAA",
-        "column" : 8,
-        "height" : 2,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "D8I6ZZfAYAA",
-        "column" : 4,
-        "height" : 2,
-        "row" : 1,
-        "width" : 4
-      }, {
-        "chartId" : "D8I6aRTAgAA",
-        "column" : 6,
-        "height" : 1,
-        "row" : 3,
-        "width" : 6
-      }, {
-        "chartId" : "D8I6YG3AYAA",
-        "column" : 0,
-        "height" : 1,
-        "row" : 3,
-        "width" : 6
-      } ],
-      "created" : 0,
-      "creator" : null,
-      "customProperties" : null,
-      "description" : "",
-      "discoveryOptions" : {
-        "query" : "sf_metric:cpu.utilization AND _exists_:kubernetes_cluster",
-        "selectors" : [ "_exists_:kubernetes_cluster" ]
-      },
-      "eventOverlays" : null,
-      "filters" : {
-        "sources" : null,
-        "time" : null,
-        "variables" : null
-      },
-      "groupId" : "DiVWf-iAgAA",
-      "id" : "D8I6X2QAcAA",
-      "lastUpdated" : 0,
-      "lastUpdatedBy" : null,
-      "maxDelayOverride" : null,
-      "name" : "K8s Clusters",
       "selectedEventOverlays" : [ ],
       "tags" : null
     }
@@ -9737,6 +9832,7 @@
           "description" : "",
           "preferredSuggestions" : [ ],
           "property" : "kubernetes_pod_name",
+          "propertyMappings" : [ "kubernetes_pod_name" ],
           "replaceOnly" : false,
           "required" : true,
           "restricted" : false,
@@ -9828,6 +9924,7 @@
           "description" : "",
           "preferredSuggestions" : [ ],
           "property" : "kubernetes_cluster",
+          "propertyMappings" : [ "kubernetes_cluster" ],
           "replaceOnly" : true,
           "required" : false,
           "restricted" : false,
@@ -9838,6 +9935,7 @@
           "description" : "",
           "preferredSuggestions" : [ ],
           "property" : "kubernetes_namespace",
+          "propertyMappings" : [ "kubernetes_namespace" ],
           "replaceOnly" : true,
           "required" : false,
           "restricted" : false,
@@ -9848,6 +9946,7 @@
           "description" : "Deployment",
           "preferredSuggestions" : [ ],
           "property" : "deployment",
+          "propertyMappings" : [ "deployment" ],
           "replaceOnly" : false,
           "required" : false,
           "restricted" : false,
@@ -9858,6 +9957,7 @@
           "description" : "",
           "preferredSuggestions" : [ "kubernetes_service*" ],
           "property" : "sf_tags",
+          "propertyMappings" : [ "sf_tags" ],
           "replaceOnly" : true,
           "required" : false,
           "restricted" : false,
@@ -9919,6 +10019,7 @@
           "description" : "Container Id",
           "preferredSuggestions" : [ ],
           "property" : "container_id",
+          "propertyMappings" : [ "container_id" ],
           "replaceOnly" : false,
           "required" : true,
           "restricted" : false,
@@ -10097,6 +10198,7 @@
           "description" : "",
           "preferredSuggestions" : [ ],
           "property" : "kubernetes_cluster",
+          "propertyMappings" : [ "kubernetes_cluster" ],
           "replaceOnly" : false,
           "required" : false,
           "restricted" : false,
@@ -10107,6 +10209,7 @@
           "description" : "",
           "preferredSuggestions" : [ ],
           "property" : "kubernetes_node",
+          "propertyMappings" : [ "kubernetes_node" ],
           "replaceOnly" : false,
           "required" : false,
           "restricted" : false,
@@ -10145,7 +10248,7 @@
       "teams" : null
     }
   },
-  "hashCode" : 697637579,
+  "hashCode" : -308857961,
   "id" : "DiVWf-iAgAA",
   "modelVersion" : 1,
   "packageType" : "GROUP"


### PR DESCRIPTION
apiserver_request_count is deprecated
apiserver_request_total is the replacement.
Updated signalflow on charts to use both.