### PR TITLE
Updating olly fields for select navigators

### DIFF
--- a/navigators/AWS/autoscaling.json
+++ b/navigators/AWS/autoscaling.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -462791681,
+  "hashCode" : 1280770250,
   "id" : "DiVVNnDAcEQ",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,7 +21,7 @@
       "name" : "AutoScaling Groups",
       "navigatorCategory" : "AWS",
       "navigatorType" : "elemental",
-      "sites" : "o11yandsignalview",
+      "sites" : "signalview",
       "uiModel" : {
         "alertQuery" : "_exists_:AutoScalingGroupName",
         "category" : "AWS",

--- a/navigators/AWS/awsdynamodb.json
+++ b/navigators/AWS/awsdynamodb.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 385661686,
+  "hashCode" : -373539131,
   "id" : "DiVVE8tAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -269,10 +269,10 @@
           "valueType" : null
         } ],
         "mtsQuery" : "sf_metric:SuccessfulRequestLatency AND sf_key:TableName AND _exists_:TableName",
-        "o11yMetricName" : "Average Request Latency",
+        "o11yMetricName" : "Running Databases",
         "o11yMetricUnit" : null,
         "o11yProductName" : "DynamoDB",
-        "o11ySignalflowTemplate" : "A = data('SuccessfulRequestLatency', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean')).mean().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('SuccessfulRequestLatency', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean') and filter('TableName', '*'), extrapolation='last_value', maxExtrapolations=2).mean(by=['TableName', 'AWSUniqueId']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "AWS",

--- a/navigators/AWS/cloudfront.json
+++ b/navigators/AWS/cloudfront.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -1539260204,
+  "hashCode" : 1666090753,
   "id" : "DiVVOGwAgAE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -181,7 +181,7 @@
           "valueType" : null
         } ],
         "mtsQuery" : "sf_metric:Requests AND sf_key:DistributionId AND _exists_:DistributionId",
-        "o11yMetricName" : "# Distributions",
+        "o11yMetricName" : "Active Distributions",
         "o11yMetricUnit" : null,
         "o11yProductName" : "CloudFront Distributions",
         "o11ySignalflowTemplate" : "A = data('Requests', filter=filter('namespace', 'AWS/CloudFront') and filter('stat', 'sum'), extrapolation='last_value', maxExtrapolations=5,rollup='rate').count().publish(label='A')",

--- a/navigators/AWS/elasticache.json
+++ b/navigators/AWS/elasticache.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -81968489,
+  "hashCode" : 1589416389,
   "id" : "DiVU-9XAgAE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -447,7 +447,7 @@
           "valueType" : null
         } ],
         "mtsQuery" : "sf_key:CacheNodeId AND _exists_:CacheNodeId",
-        "o11yMetricName" : "# Clusters",
+        "o11yMetricName" : "Running Clusters",
         "o11yMetricUnit" : null,
         "o11yProductName" : "ElastiCache",
         "o11ySignalflowTemplate" : "A = data('CPUUtilization', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'mean') and filter('CacheClusterId', '*'), extrapolation='last_value', maxExtrapolations=5).mean(by=['aws_region', 'aws_cache_cluster_name']).count().publish(label='A')",

--- a/navigators/AWS/rds databases.json
+++ b/navigators/AWS/rds databases.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 662853946,
+  "hashCode" : 230094444,
   "id" : "DiVVFU6AcAE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -400,7 +400,7 @@
           "valueType" : null
         } ],
         "mtsQuery" : "sf_metric:DatabaseConnections AND sf_key:DBInstanceIdentifier AND _exists_:DBInstanceIdentifier",
-        "o11yMetricName" : "# DB Instances",
+        "o11yMetricName" : "Running Databases",
         "o11yMetricUnit" : null,
         "o11yProductName" : "RDS",
         "o11ySignalflowTemplate" : "A = data('CPUUtilization', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*'), extrapolation='last_value', maxExtrapolations=5).mean(by=['aws_account_id', 'aws_region', 'DBInstanceIdentifier']).count().publish(label='A')",

--- a/navigators/Azure/azureappservice.json
+++ b/navigators/Azure/azureappservice.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 89575050,
+  "hashCode" : -1668486479,
   "id" : "DiVVSdvAgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -351,10 +351,10 @@
           "valueType" : null
         } ],
         "mtsQuery" : "resource_type:Microsoft.Web\\/sites AND is_Azure_Function:false",
-        "o11yMetricName" : "Connections per App",
+        "o11yMetricName" : "Active App Services",
         "o11yMetricUnit" : null,
         "o11yProductName" : "App Service",
-        "o11ySignalflowTemplate" : "A = data('AppConnections', filter=filter('resource_type', 'Microsoft.Web/sites') and filter('primary_aggregation_type', 'true') and filter('is_Azure_Function', 'false')).mean(by=['azure_resource_id', 'azure_resource_name']).publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('AverageResponseTime', filter=filter('resource_type', 'Microsoft.Web/sites') and filter('primary_aggregation_type', 'true'), rollup='average', extrapolation='null', maxExtrapolations=-1).mean(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "Other",

--- a/navigators/Azure/azurebatch.json
+++ b/navigators/Azure/azurebatch.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -460665644,
+  "hashCode" : 656639925,
   "id" : "DiVVOg6AgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -17,7 +17,7 @@
       "name" : "Batch Accounts",
       "navigatorCategory" : "Azure",
       "navigatorType" : "elemental",
-      "sites" : "o11yandsignalview",
+      "sites" : "signalview",
       "uiModel" : {
         "alertQuery" : "_exists_:azure_resource_id",
         "category" : "Azure",

--- a/navigators/Azure/azureeventhubs.json
+++ b/navigators/Azure/azureeventhubs.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -534863358,
+  "hashCode" : -2088265885,
   "id" : "DiVVQTSAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -21,7 +21,7 @@
       "name" : "Event Hubs",
       "navigatorCategory" : "Azure",
       "navigatorType" : "elemental",
-      "sites" : "o11yandsignalview",
+      "sites" : "signalview",
       "uiModel" : {
         "alertQuery" : "_exists_:azure_resource_id",
         "category" : "Azure",

--- a/navigators/Azure/azurefunctions.json
+++ b/navigators/Azure/azurefunctions.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -322811742,
+  "hashCode" : -283234595,
   "id" : "DiVVM3FAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -208,7 +208,7 @@
         "mtsQuery" : "(sf_metric:FunctionExecutionCount OR sf_metric:FunctionExecutionUnits) AND is_Azure_Function:true",
         "o11yMetricName" : "Active Functions",
         "o11yMetricUnit" : null,
-        "o11yProductName" : "Functions",
+        "o11yProductName" : "Azure Functions",
         "o11ySignalflowTemplate" : "A = data('azure.function.invocations', filter=filter('is_Azure_Function', 'true'), rollup='latest').sum(over='1m').sum(by=['azure_function_name', 'azure_resource_name', 'azure_region']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {

--- a/navigators/Azure/azurelogicapps.json
+++ b/navigators/Azure/azurelogicapps.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 858084161,
+  "hashCode" : 2024912795,
   "id" : "DiVVAINAgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -415,10 +415,10 @@
           "valueType" : null
         } ],
         "mtsQuery" : "resource_type:Microsoft.Logic\\/workflows",
-        "o11yMetricName" : "Runs Succeeded",
+        "o11yMetricName" : "Active Logic Apps",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Logic Apps",
-        "o11ySignalflowTemplate" : "A = data('RunsSucceeded', filter=filter('resource_type', 'Microsoft.Logic/workflows') and filter('primary_aggregation_type', 'true'), rollup='sum').mean(by=['azure_resource_id', 'azure_resource_name']).publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('TotalBillableExecutions', filter=filter('resource_type', 'Microsoft.Logic/workflows') and filter('primary_aggregation_type', 'true'), rollup='sum', extrapolation='null', maxExtrapolations=-1).mean(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "Other",

--- a/navigators/Azure/azurerediscaches.json
+++ b/navigators/Azure/azurerediscaches.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -739264885,
+  "hashCode" : -1938454254,
   "id" : "DiVVN2KAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -285,7 +285,7 @@
           "valueType" : null
         } ],
         "mtsQuery" : "resource_type:Microsoft.Cache\\/Redis",
-        "o11yMetricName" : "# Caches",
+        "o11yMetricName" : "Active Caches",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Redis Cache",
         "o11ySignalflowTemplate" : "A = data('cachehits*', filter=filter('resource_type', 'Microsoft.Cache/Redis') and filter('primary_aggregation_type', 'true') and (not filter('sf_metric', 'cachehits')),rollup='rate').count().publish(label='A')",

--- a/navigators/Azure/azuresqldatabases.json
+++ b/navigators/Azure/azuresqldatabases.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 721260463,
+  "hashCode" : -848712332,
   "id" : "DiVVONgAcAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -238,7 +238,7 @@
           "valueType" : null
         } ],
         "mtsQuery" : "resource_type:Microsoft.Sql\\/servers\\/databases",
-        "o11yMetricName" : "Number of Databases",
+        "o11yMetricName" : "Running Databases",
         "o11yMetricUnit" : null,
         "o11yProductName" : "SQL Database",
         "o11ySignalflowTemplate" : "A = data('dtu_consumption_percent', filter=filter('primary_aggregation_type', 'true') and filter('resource_type', 'Microsoft.Sql/servers/databases'), extrapolation='last_value', maxExtrapolations=2).mean(by=['azure_resource_id']).count().publish(label='A')",

--- a/navigators/Azure/azurestorage.json
+++ b/navigators/Azure/azurestorage.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 1737539721,
+  "hashCode" : -967854780,
   "id" : "DiVVFMLAcAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -223,10 +223,10 @@
           "valueType" : null
         } ],
         "mtsQuery" : "resource_type:Microsoft.Storage\\/storageAccounts",
-        "o11yMetricName" : "Total Network Egress",
+        "o11yMetricName" : "Active Accounts",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Storage",
-        "o11ySignalflowTemplate" : "A = data('Egress', filter=filter('resource_type', 'Microsoft.Storage/storageAccounts') and filter('primary_aggregation_type', 'true'), rollup='average', extrapolation='zero').sum().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('Ingress', filter=filter('resource_type', 'Microsoft.Storage/storageAccounts') and filter('primary_aggregation_type', 'true'), rollup='average', extrapolation='zero', maxExtrapolations=-1).mean(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "Other",

--- a/navigators/Google Cloud Platform/gcp appengine.json
+++ b/navigators/Google Cloud Platform/gcp appengine.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -1852663395,
+  "hashCode" : 2100442041,
   "id" : "DiVVM2EAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -177,10 +177,10 @@
           "valueType" : null
         } ],
         "mtsQuery" : "sf_metric:http\\/server\\/response_count AND _exists_:gcp_id AND _exists_:version_id",
-        "o11yMetricName" : "Instance Count",
+        "o11yMetricName" : "Running Instances",
         "o11yMetricUnit" : null,
         "o11yProductName" : "App Engine",
-        "o11ySignalflowTemplate" : "A = data('system/instance_count').sum().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('http/server/response_count', rollup='latest', extrapolation='last_value', maxExtrapolations=-1).sum(by=['module_id', 'version_id','project_id']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "Other",

--- a/navigators/Google Cloud Platform/gcp bigtable.json
+++ b/navigators/Google Cloud Platform/gcp bigtable.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -702049457,
+  "hashCode" : -1934032664,
   "id" : "DiVVM8pAcAE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -144,7 +144,7 @@
           "valueType" : null
         } ],
         "mtsQuery" : "sf_metric:cluster\\/cpu_load AND _exists_:gcp_id",
-        "o11yMetricName" : "Number of Clusters",
+        "o11yMetricName" : "Running Clusters",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Cloud Bigtable",
         "o11ySignalflowTemplate" : "A = data('cluster/node_count', filter=filter('service', 'bigtable')).sum(by=['cluster']).count().publish(label='A')",

--- a/navigators/Google Cloud Platform/gcp containerengine.json
+++ b/navigators/Google Cloud Platform/gcp containerengine.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -1074094145,
+  "hashCode" : -1496113363,
   "id" : "DiVVG5EAcAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -144,7 +144,7 @@
           "valueType" : null
         } ],
         "mtsQuery" : "sf_metric:container\\/cpu\\/usage_time AND _exists_:gcp_id ",
-        "o11yMetricName" : "# Clusters",
+        "o11yMetricName" : "Running Clusters",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Container Engine",
         "o11ySignalflowTemplate" : "A = data('container/disk/bytes_used', filter=filter('gcp_id', '*')).sum(by=['cluster_name']).count().mean(over='1m').publish(label='A')",

--- a/navigators/Google Cloud Platform/gcp pubsub subscription.json
+++ b/navigators/Google Cloud Platform/gcp pubsub subscription.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -390256949,
+  "hashCode" : 1140670038,
   "id" : "DiVVAFYAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -17,7 +17,7 @@
       "name" : "Cloud Pub/Sub Subscriptions",
       "navigatorCategory" : "Google Cloud Platform",
       "navigatorType" : "elemental",
-      "sites" : "o11yandsignalview",
+      "sites" : "signalview",
       "uiModel" : {
         "alertQuery" : "(_exists_:gcp_id)",
         "category" : "Google Cloud Platform",

--- a/navigators/Google Cloud Platform/gcp pubsub topic.json
+++ b/navigators/Google Cloud Platform/gcp pubsub topic.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 2035705515,
+  "hashCode" : -728334794,
   "id" : "DiVU-2uAgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -17,7 +17,7 @@
       "name" : "Cloud Pub/Sub Topics",
       "navigatorCategory" : "Google Cloud Platform",
       "navigatorType" : "elemental",
-      "sites" : "o11yandsignalview",
+      "sites" : "signalview",
       "uiModel" : {
         "alertQuery" : "(_exists_:gcp_id)",
         "category" : "Google Cloud Platform",

--- a/navigators/Google Cloud Platform/gcp spanner.json
+++ b/navigators/Google Cloud Platform/gcp spanner.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -278110975,
+  "hashCode" : 2107211983,
   "id" : "DiVVN0hAgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -141,10 +141,10 @@
           "valueType" : null
         } ],
         "mtsQuery" : "sf_metric:instance\\/cpu\\/utilization AND _exists_:gcp_id AND service:spanner",
-        "o11yMetricName" : "Node Count",
+        "o11yMetricName" : "Running Nodes",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Cloud Spanner",
-        "o11ySignalflowTemplate" : "A = data('instance/node_count').sum().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('instance/cpu/utilization', filter=filter('monitored_resource', 'spanner_instance'), rollup='latest', extrapolation='last_value', maxExtrapolations=2).sum(by=['instance_id', 'project_id']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "Other",

--- a/navigators/Google Cloud Platform/gcp storage.json
+++ b/navigators/Google Cloud Platform/gcp storage.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -781763322,
+  "hashCode" : -291140267,
   "id" : "DiVVFQ5AgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -152,10 +152,10 @@
           "valueType" : null
         } ],
         "mtsQuery" : "sf_metric:network\\/received_bytes_count AND _exists_:gcp_id",
-        "o11yMetricName" : "Request Count / min",
+        "o11yMetricName" : "Active Buckets",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Cloud Storage",
-        "o11ySignalflowTemplate" : "A = data('api/request_count', filter=filter('bucket_name', '*'), rollup='latest').sum(by=['bucket_name']).publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('network/received_bytes_count', filter=filter('gcp_id', '*') and filter('project_id', '*'), rollup='latest', extrapolation='last_value', maxExtrapolations=2).sum(by=['bucket_name', 'project_id']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "Other",

--- a/navigators/Google Cloud Platform/gcp_k8s_clusters.json
+++ b/navigators/Google Cloud Platform/gcp_k8s_clusters.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -1094975200,
+  "hashCode" : -387757077,
   "id" : "Ea1OhQzAYJE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -110,7 +110,7 @@
           "valueType" : null
         } ],
         "mtsQuery" : "_exists_:cluster_name AND service:kubernetes",
-        "o11yMetricName" : "Clusters",
+        "o11yMetricName" : "Running Clusters",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Kubernetes Engine",
         "o11ySignalflowTemplate" : "A = data('node/memory/total_bytes').sum(by=['project_id', 'cluster_name']).count().publish(label='A')",


### PR DESCRIPTION
Adjusted o11ySignalflowTemplate, o11yMetricName, o11yProductName fields for various navigators in preparation for GA.

Hid the AWS Autoscaling, GCP Cloud Pub/Sub, Azure Batch, and Azure Event Hubs navigators for olly by modifying the sites field.