### PR TITLE
Update olly signalflow for navs + ECS dashboard bug fix

### DIFF
--- a/group/AWS ECS.json
+++ b/group/AWS ECS.json
@@ -3364,7 +3364,7 @@
       "customProperties" : null,
       "description" : "",
       "discoveryOptions" : {
-        "query" : "namespace:\"AWS/ECS\" AND _exists_:ServiceName AND _exists_:ClusterName",
+        "query" : "namespace:\"AWS/ECS\" AND _exists_:ClusterName",
         "selectors" : [ "sf_key:ServiceName", "sf_key:ClusterName", "namespace:AWS/ECS" ]
       },
       "eventOverlays" : null,
@@ -3420,7 +3420,7 @@
       "teams" : null
     }
   },
-  "hashCode" : 1309800395,
+  "hashCode" : 750391837,
   "id" : "DiVWWMuAgK4",
   "modelVersion" : 1,
   "packageType" : "GROUP"

--- a/navigators/AWS/AWS instances.json
+++ b/navigators/AWS/AWS instances.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 1098383097,
+  "hashCode" : -1911869636,
   "id" : "DiVU-9WAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -369,7 +369,7 @@
         "o11yMetricName" : "Running Instances",
         "o11yMetricUnit" : null,
         "o11yProductName" : "EC2",
-        "o11ySignalflowTemplate" : "A = data('CPUUtilization', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'upper') and filter('InstanceId', '*'), extrapolation='last_value', maxExtrapolations=5).max(over='1h').count().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('CPUUtilization', filter=filter('InstanceId', '*') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=2).mean(by=['InstanceId']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "AWS",

--- a/navigators/AWS/awsebs.json
+++ b/navigators/AWS/awsebs.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 1629533569,
+  "hashCode" : 1617755410,
   "id" : "DiVU_CpAgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -250,7 +250,7 @@
         "o11yMetricName" : "Running Volumes",
         "o11yMetricUnit" : null,
         "o11yProductName" : "EBS",
-        "o11ySignalflowTemplate" : "A = data('VolumeIdleTime', filter=filter('stat', 'mean') and filter('namespace', 'AWS/EBS')).max(over='1h').count().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('VolumeIdleTime', filter=filter('stat', 'mean') and filter('namespace', 'AWS/EBS') and filter('VolumeId', '*'), extrapolation='last_value', maxExtrapolations=2).mean(by=['VolumeId']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "AWS",

--- a/navigators/AWS/awsecs.json
+++ b/navigators/AWS/awsecs.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -900304344,
+  "hashCode" : -1735660457,
   "id" : "DiVU_KHAcAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -184,7 +184,7 @@
         "o11yMetricName" : "Running Clusters",
         "o11yMetricUnit" : null,
         "o11yProductName" : "ECS",
-        "o11ySignalflowTemplate" : "A = data('CPUReservation', filter=filter('namespace', 'AWS/ECS'), extrapolation='last_value', maxExtrapolations=5, rollup='rate').mean(by=['ClusterName']).count().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('CPUReservation', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and filter('ClusterName', '*'), extrapolation='last_value', maxExtrapolations=2).sum(by=['ClusterName']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "AWS",

--- a/navigators/AWS/cloudfront.json
+++ b/navigators/AWS/cloudfront.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 1666090753,
+  "hashCode" : 996388308,
   "id" : "DiVVOGwAgAE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -184,7 +184,7 @@
         "o11yMetricName" : "Active Distributions",
         "o11yMetricUnit" : null,
         "o11yProductName" : "CloudFront Distributions",
-        "o11ySignalflowTemplate" : "A = data('Requests', filter=filter('namespace', 'AWS/CloudFront') and filter('stat', 'sum'), extrapolation='last_value', maxExtrapolations=5,rollup='rate').count().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('TotalErrorRate', filter=filter('namespace', 'AWS/CloudFront') and filter('stat', 'mean') and filter('DistributionId', '*'), extrapolation='last_value', maxExtrapolations=2).mean(by=['DistributionId']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "AWS",

--- a/navigators/AWS/elasticache.json
+++ b/navigators/AWS/elasticache.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 1589416389,
+  "hashCode" : 331831035,
   "id" : "DiVU-9XAgAE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -447,10 +447,10 @@
           "valueType" : null
         } ],
         "mtsQuery" : "sf_key:CacheNodeId AND _exists_:CacheNodeId",
-        "o11yMetricName" : "Running Clusters",
+        "o11yMetricName" : "Running Nodes",
         "o11yMetricUnit" : null,
         "o11yProductName" : "ElastiCache",
-        "o11ySignalflowTemplate" : "A = data('CPUUtilization', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'mean') and filter('CacheClusterId', '*'), extrapolation='last_value', maxExtrapolations=5).mean(by=['aws_region', 'aws_cache_cluster_name']).count().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('CurrConnections', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'mean') and filter('CacheNodeId', '*'), extrapolation='last_value', maxExtrapolations=2).mean(by=['aws_region', 'CacheNodeId', 'CacheClusterId']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "AWS",

--- a/navigators/AWS/elb.json
+++ b/navigators/AWS/elb.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 1203923552,
+  "hashCode" : -1589625821,
   "id" : "DiVVOB3AYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -383,7 +383,7 @@
         "o11yMetricName" : "Active Load Balancers",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Elastic Load Balancers",
-        "o11ySignalflowTemplate" : "A = data('RequestCount', filter=filter('AvailabilityZone', '*') and filter('LoadBalancerName', '*') and filter('stat', 'mean'), extrapolation='zero').sum(by=['LoadBalancerName']).count().max(over='1h').publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('RequestCount', filter=filter('namespace', 'AWS/ELB') and filter('stat', 'sum') and filter('LoadBalancerName', '*') and filter('AvailabilityZone', '*'), rollup='rate', extrapolation='last_value', maxExtrapolations=2).sum(by=['LoadBalancerName', 'AWSUniqueId', 'AvailabilityZone']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "AWS",

--- a/navigators/AWS/rds databases.json
+++ b/navigators/AWS/rds databases.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 230094444,
+  "hashCode" : 1305343577,
   "id" : "DiVVFU6AcAE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -403,7 +403,7 @@
         "o11yMetricName" : "Running Databases",
         "o11yMetricUnit" : null,
         "o11yProductName" : "RDS",
-        "o11ySignalflowTemplate" : "A = data('CPUUtilization', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*'), extrapolation='last_value', maxExtrapolations=5).mean(by=['aws_account_id', 'aws_region', 'DBInstanceIdentifier']).count().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('DatabaseConnections', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*'), extrapolation='last_value', maxExtrapolations=2).mean(by=['DBInstanceIdentifier']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "AWS",

--- a/navigators/AWS/sns.json
+++ b/navigators/AWS/sns.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 2105834600,
+  "hashCode" : 416519889,
   "id" : "DiVVEqDAcAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -162,7 +162,7 @@
         "o11yMetricName" : "Active Topics",
         "o11yMetricUnit" : null,
         "o11yProductName" : "SNS Topics",
-        "o11ySignalflowTemplate" : "A = data('NumberOfMessagesPublished', filter=filter('TopicName', '*') and filter('namespace', 'AWS/SNS') and filter('stat', 'sum'),rollup='rate').max(over='1h').mean(by=['TopicName']).count().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('NumberOfMessagesPublished', filter=filter('namespace', 'AWS/SNS') and filter('stat', 'sum') and filter('TopicName', '*'), rollup='rate', extrapolation='last_value', maxExtrapolations=2).sum(by=['TopicName']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "AWS",

--- a/navigators/AWS/sqs queues.json
+++ b/navigators/AWS/sqs queues.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -2097391982,
+  "hashCode" : 1076001436,
   "id" : "DiVU-_uAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -536,7 +536,7 @@
         "o11yMetricName" : "Active Queues",
         "o11yMetricUnit" : null,
         "o11yProductName" : "SQS Queues",
-        "o11ySignalflowTemplate" : "A = data('NumberOfMessagesSent', filter=filter('namespace', 'AWS/SQS') and filter('stat', 'sum'),rollup='rate').mean(over='15m').count(by=['QueueName', 'aws_region']).count().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('NumberOfMessagesSent', filter=filter('namespace', 'AWS/SQS') and filter('stat', 'sum') and filter('aws_region', '*') and filter('QueueName', '*') and filter('AWSUniqueId', '*'), rollup='rate', extrapolation='last_value', maxExtrapolations=2).mean(by=['AWSUniqueId', 'QueueName', 'aws_region']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "AWS",

--- a/navigators/Azure/azurefunctions.json
+++ b/navigators/Azure/azurefunctions.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -283234595,
+  "hashCode" : 1622421860,
   "id" : "DiVVM3FAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -209,7 +209,7 @@
         "o11yMetricName" : "Active Functions",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Azure Functions",
-        "o11ySignalflowTemplate" : "A = data('azure.function.invocations', filter=filter('is_Azure_Function', 'true'), rollup='latest').sum(over='1m').sum(by=['azure_function_name', 'azure_resource_name', 'azure_region']).count().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('FunctionExecutionCount', filter=filter('is_Azure_Function', 'true') and filter('primary_aggregation_type', 'true'), rollup='sum', extrapolation='null', maxExtrapolations=-1).sum(by=['azure_resource_name', 'azure_region']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "Other",

--- a/navigators/Azure/azurerediscaches.json
+++ b/navigators/Azure/azurerediscaches.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -1938454254,
+  "hashCode" : -1819948814,
   "id" : "DiVVN2KAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -288,7 +288,7 @@
         "o11yMetricName" : "Active Caches",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Redis Cache",
-        "o11ySignalflowTemplate" : "A = data('cachehits*', filter=filter('resource_type', 'Microsoft.Cache/Redis') and filter('primary_aggregation_type', 'true') and (not filter('sf_metric', 'cachehits')),rollup='rate').count().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('usedmemory', filter('resource_type', 'Microsoft.Cache/Redis') and filter('primary_aggregation_type', 'true'), extrapolation='last_value', maxExtrapolations=-1).mean(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "Other",

--- a/navigators/Azure/azuresqldatabases.json
+++ b/navigators/Azure/azuresqldatabases.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -848712332,
+  "hashCode" : -1023820141,
   "id" : "DiVVONgAcAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -241,7 +241,7 @@
         "o11yMetricName" : "Running Databases",
         "o11yMetricUnit" : null,
         "o11yProductName" : "SQL Database",
-        "o11ySignalflowTemplate" : "A = data('dtu_consumption_percent', filter=filter('primary_aggregation_type', 'true') and filter('resource_type', 'Microsoft.Sql/servers/databases'), extrapolation='last_value', maxExtrapolations=2).mean(by=['azure_resource_id']).count().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('dtu_consumption_percent', filter=filter('resource_type', 'Microsoft.Sql/servers/databases') and filter('primary_aggregation_type', 'true'), rollup='rate', extrapolation='last_value', maxExtrapolations=5).mean(by=['azure_resource_name']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "Other",

--- a/navigators/Azure/azurevirtualmachines.json
+++ b/navigators/Azure/azurevirtualmachines.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 279621714,
+  "hashCode" : 2089783283,
   "id" : "DiVVN9fAcAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -319,7 +319,7 @@
         "o11yMetricName" : "Running Virtual Machines",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Virtual Machines",
-        "o11ySignalflowTemplate" : "A = data('Percentage CPU', filter=filter('azure_resource_id', '*') and filter('resource_type', 'Microsoft.Compute/virtualMachines', 'Microsoft.ClassicCompute/virtualMachines') and filter('primary_aggregation_type', 'true'), extrapolation='last_value', maxExtrapolations=5).count().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('Percentage CPU', filter=(filter('resource_type', 'Microsoft.Compute/virtualMachines') or filter('resource_type', 'Microsoft.ClassicCompute/virtualMachines')) and filter('primary_aggregation_type', 'true'), extrapolation='null', maxExtrapolations=-1).mean(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "Other",

--- a/navigators/Google Cloud Platform/gcp bigtable.json
+++ b/navigators/Google Cloud Platform/gcp bigtable.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -1934032664,
+  "hashCode" : -1555681107,
   "id" : "DiVVM8pAcAE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -147,7 +147,7 @@
         "o11yMetricName" : "Running Clusters",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Cloud Bigtable",
-        "o11ySignalflowTemplate" : "A = data('cluster/node_count', filter=filter('service', 'bigtable')).sum(by=['cluster']).count().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('cluster/cpu_load', rollup='latest', extrapolation='last_value', maxExtrapolations=2).sum(by=['cluster', 'project_id']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "Other",

--- a/navigators/Google Cloud Platform/gcp cloudfunctions.json
+++ b/navigators/Google Cloud Platform/gcp cloudfunctions.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -814761339,
+  "hashCode" : -746826229,
   "id" : "DiVVNqQAYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -148,7 +148,7 @@
         "o11yMetricName" : "Active Functions",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Cloud Functions",
-        "o11ySignalflowTemplate" : "A = data('function.invocations', rollup='sum', extrapolation='zero').sum(over='1m').sum(by=['gcp_function_name']).count().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('function/execution_count', filter=filter('gcp_id', '*'), rollup='sum', extrapolation='null', maxExtrapolations=-1).sum(by=['gcp_function_name']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "Other",

--- a/navigators/Google Cloud Platform/gcp compute.json
+++ b/navigators/Google Cloud Platform/gcp compute.json
@@ -1,376 +1,310 @@
 {
-    "hashCode": 1561136774,
-    "id": "DiVVQlDAgAA",
-    "modelVersion": 1,
-    "navigatorExport": {
-        "navigator": {
-            "created": 0,
-            "creator": null,
-            "description": "",
-            "id": "DiVVQlDAgAA",
-            "importQualifiers": [
-                {
-                    "filters": [
-                        {
-                            "not": false,
-                            "property": "sf_key",
-                            "values": [
-                                "gcp_id"
-                            ]
-                        },
-                        {
-                            "not": false,
-                            "property": "service",
-                            "values": [
-                                "compute"
-                            ]
-                        }
-                    ],
-                    "metric": "instance/cpu/utilization"
-                }
-            ],
-            "lastUpdated": 0,
-            "lastUpdatedBy": null,
-            "name": "Compute Engine",
-            "navigatorCategory": "Google Cloud Platform",
-            "navigatorType": "elemental",
-            "sites": "signalview",
-            "uiModel": {
-                "alertQuery": "_exists_:instance_name",
-                "category": "Google Cloud Platform",
-                "categoryPriority": 20,
-                "discoveryQuery": [
-                    "service:compute",
-                    "_exists_:gcp_id"
-                ],
-                "displayName": "Compute Engine",
-                "filterProperties": null,
-                "id": "gcp compute",
-                "idName": "Compute Engine",
-                "idTemplate": "{{instance_name}}",
-                "listColumns": [
-                    {
-                        "aggregate": null,
-                        "displayName": "Instance Name",
-                        "format": "id",
-                        "metric": null,
-                        "property": "id",
-                        "sortable": null
+    "hashCode" : -1139451370,
+    "id" : "DiVVQlDAgAA",
+    "modelVersion" : 1,
+    "navigatorExport" : {
+        "navigator" : {
+            "created" : 0,
+            "creator" : null,
+            "description" : "",
+            "id" : "DiVVQlDAgAA",
+            "importQualifiers" : [ {
+                "filters" : [ {
+                    "not" : false,
+                    "property" : "sf_key",
+                    "values" : [ "gcp_id" ]
+                }, {
+                    "not" : false,
+                    "property" : "service",
+                    "values" : [ "compute" ]
+                } ],
+                "metric" : "instance/cpu/utilization"
+            } ],
+            "lastUpdated" : 0,
+            "lastUpdatedBy" : null,
+            "name" : "Compute Engine",
+            "navigatorCategory" : "Google Cloud Platform",
+            "navigatorType" : "elemental",
+            "sites" : "signalview",
+            "uiModel" : {
+                "alertQuery" : "_exists_:instance_name",
+                "category" : "Google Cloud Platform",
+                "categoryPriority" : 20,
+                "discoveryQuery" : [ "service:compute", "_exists_:gcp_id" ],
+                "displayName" : "Compute Engine",
+                "filterProperties" : null,
+                "id" : "gcp compute",
+                "idName" : "Compute Engine",
+                "idTemplate" : "{{instance_name}}",
+                "listColumns" : [ {
+                    "aggregate" : null,
+                    "displayName" : "Instance Name",
+                    "format" : "id",
+                    "metric" : null,
+                    "property" : "id",
+                    "sortable" : null
+                }, {
+                    "aggregate" : null,
+                    "displayName" : "Value",
+                    "format" : "Number",
+                    "metric" : null,
+                    "property" : "value",
+                    "sortable" : null
+                }, {
+                    "aggregate" : null,
+                    "displayName" : "Instance ID",
+                    "format" : null,
+                    "metric" : null,
+                    "property" : "instance_id",
+                    "sortable" : null
+                }, {
+                    "aggregate" : null,
+                    "displayName" : "Project ID",
+                    "format" : null,
+                    "metric" : null,
+                    "property" : "project_id",
+                    "sortable" : null
+                } ],
+                "metrics" : [ {
+                    "coloring" : {
+                        "limits" : null,
+                        "maxValue" : 100,
+                        "method" : "quantile",
+                        "minValue" : 0,
+                        "range" : null
                     },
-                    {
-                        "aggregate": null,
-                        "displayName": "Value",
-                        "format": "Number",
-                        "metric": null,
-                        "property": "value",
-                        "sortable": null
+                    "description" : "Color hosts based on percentage of CPU being used: under 20% (green) to over 80% (red)",
+                    "displayName" : "CPU Utilization",
+                    "id" : "gcp.instance/cpu/utilization",
+                    "job" : {
+                        "filters" : [ {
+                            "not" : false,
+                            "property" : "_exists_",
+                            "propertyValue" : "instance_id",
+                            "type" : "property"
+                        }, {
+                            "not" : false,
+                            "property" : "monitored_resource",
+                            "propertyValue" : "gce_instance",
+                            "type" : "property"
+                        }, {
+                            "not" : false,
+                            "property" : "_exists_",
+                            "propertyValue" : "gcp_id",
+                            "type" : "property"
+                        } ],
+                        "resolution" : 300000,
+                        "template" : "CPU_UTILIZATION = data(\"instance/cpu/utilization\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).scale(100).mean(by=[\"instance_name\"])",
+                        "varName" : "CPU_UTILIZATION"
                     },
-                    {
-                        "aggregate": null,
-                        "displayName": "Instance ID",
-                        "format": null,
-                        "metric": null,
-                        "property": "instance_id",
-                        "sortable": null
+                    "metricSelectors" : [ "instance/cpu/utilization" ],
+                    "type" : "metric",
+                    "valueFormat" : "Percentage",
+                    "valueLabel" : "CPU Use",
+                    "valueType" : null
+                }, {
+                    "coloring" : {
+                        "limits" : null,
+                        "maxValue" : null,
+                        "method" : "quantile",
+                        "minValue" : 0,
+                        "range" : null
                     },
-                    {
-                        "aggregate": null,
-                        "displayName": "Project ID",
-                        "format": null,
-                        "metric": null,
-                        "property": "project_id",
-                        "sortable": null
-                    }
-                ],
-                "metrics": [
-                    {
-                        "coloring": {
-                            "limits": null,
-                            "maxValue": 100,
-                            "method": "quantile",
-                            "minValue": 0,
-                            "range": null
-                        },
-                        "description": "Color hosts based on percentage of CPU being used: under 20% (green) to over 80% (red)",
-                        "displayName": "CPU Utilization",
-                        "id": "gcp.instance/cpu/utilization",
-                        "job": {
-                            "filters": [
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "instance_id",
-                                    "type": "property"
-                                },
-                                {
-                                    "not": false,
-                                    "property": "monitored_resource",
-                                    "propertyValue": "gce_instance",
-                                    "type": "property"
-                                },
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "gcp_id",
-                                    "type": "property"
-                                }
-                            ],
-                            "resolution": 300000,
-                            "template": "CPU_UTILIZATION = data(\"instance/cpu/utilization\"{{#filter}}, filter={{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).scale(100).mean(by=[\"instance_name\"])",
-                            "varName": "CPU_UTILIZATION"
-                        },
-                        "metricSelectors": [
-                            "instance/cpu/utilization"
-                        ],
-                        "type": "metric",
-                        "valueFormat": "Percentage",
-                        "valueLabel": "CPU Use",
-                        "valueType": null
+                    "description" : "Color hosts based on network bytes in per second",
+                    "displayName" : "Network Received Bytes",
+                    "id" : "gcp.instance/network/received_bytes_count",
+                    "job" : {
+                        "filters" : [ {
+                            "not" : false,
+                            "property" : "_exists_",
+                            "propertyValue" : "instance_id",
+                            "type" : "property"
+                        } ],
+                        "resolution" : 300000,
+                        "template" : "NETWORK_IN = data(\"instance/network/received_bytes_count\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"rate\", extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"instance_name\"])",
+                        "varName" : "NETWORK_IN"
                     },
-                    {
-                        "coloring": {
-                            "limits": null,
-                            "maxValue": null,
-                            "method": "quantile",
-                            "minValue": 0,
-                            "range": null
-                        },
-                        "description": "Color hosts based on network bytes in per second",
-                        "displayName": "Network Received Bytes",
-                        "id": "gcp.instance/network/received_bytes_count",
-                        "job": {
-                            "filters": [
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "instance_id",
-                                    "type": "property"
-                                }
-                            ],
-                            "resolution": 300000,
-                            "template": "NETWORK_IN = data(\"instance/network/received_bytes_count\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"rate\", extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"instance_name\"])",
-                            "varName": "NETWORK_IN"
-                        },
-                        "metricSelectors": [
-                            "instance/network/received_bytes_count"
-                        ],
-                        "type": "metric",
-                        "valueFormat": null,
-                        "valueLabel": null,
-                        "valueType": null
+                    "metricSelectors" : [ "instance/network/received_bytes_count" ],
+                    "type" : "metric",
+                    "valueFormat" : null,
+                    "valueLabel" : null,
+                    "valueType" : null
+                }, {
+                    "coloring" : {
+                        "limits" : null,
+                        "maxValue" : null,
+                        "method" : "quantile",
+                        "minValue" : 0,
+                        "range" : null
                     },
-                    {
-                        "coloring": {
-                            "limits": null,
-                            "maxValue": null,
-                            "method": "quantile",
-                            "minValue": 0,
-                            "range": null
-                        },
-                        "description": "Color hosts based on network bytes in per second",
-                        "displayName": "Network Sent Bytes",
-                        "id": "gcp.instance/network/sent_bytes_count",
-                        "job": {
-                            "filters": [
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "instance_id",
-                                    "type": "property"
-                                }
-                            ],
-                            "resolution": 300000,
-                            "template": "NETWORK_OUT = data(\"instance/network/sent_bytes_count\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"rate\", extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"instance_name\"])",
-                            "varName": "NETWORK_OUT"
-                        },
-                        "metricSelectors": [
-                            "instance/network/sent_bytes_count"
-                        ],
-                        "type": "metric",
-                        "valueFormat": null,
-                        "valueLabel": null,
-                        "valueType": null
+                    "description" : "Color hosts based on network bytes in per second",
+                    "displayName" : "Network Sent Bytes",
+                    "id" : "gcp.instance/network/sent_bytes_count",
+                    "job" : {
+                        "filters" : [ {
+                            "not" : false,
+                            "property" : "_exists_",
+                            "propertyValue" : "instance_id",
+                            "type" : "property"
+                        } ],
+                        "resolution" : 300000,
+                        "template" : "NETWORK_OUT = data(\"instance/network/sent_bytes_count\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"rate\", extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"instance_name\"])",
+                        "varName" : "NETWORK_OUT"
                     },
-                    {
-                        "coloring": {
-                            "limits": null,
-                            "maxValue": null,
-                            "method": "quantile",
-                            "minValue": 0,
-                            "range": null
-                        },
-                        "description": "Color hosts based on bytes written to disk per second",
-                        "displayName": "Disk Write Bytes",
-                        "id": "gcp.instance/disk/write_bytes_count",
-                        "job": {
-                            "filters": [
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "instance_id",
-                                    "type": "property"
-                                },
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "instance_name",
-                                    "type": "property"
-                                }
-                            ],
-                            "resolution": 300000,
-                            "template": "DISK_WRITE_BYTES = data(\"instance/disk/write_bytes_count\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"rate\", extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"instance_name\"])",
-                            "varName": "DISK_WRITE_BYTES"
-                        },
-                        "metricSelectors": [
-                            "instance/disk/write_bytes_count"
-                        ],
-                        "type": "metric",
-                        "valueFormat": null,
-                        "valueLabel": null,
-                        "valueType": null
+                    "metricSelectors" : [ "instance/network/sent_bytes_count" ],
+                    "type" : "metric",
+                    "valueFormat" : null,
+                    "valueLabel" : null,
+                    "valueType" : null
+                }, {
+                    "coloring" : {
+                        "limits" : null,
+                        "maxValue" : null,
+                        "method" : "quantile",
+                        "minValue" : 0,
+                        "range" : null
                     },
-                    {
-                        "coloring": {
-                            "limits": null,
-                            "maxValue": null,
-                            "method": "quantile",
-                            "minValue": 0,
-                            "range": null
-                        },
-                        "description": "Color hosts based on bytes read from disk per second",
-                        "displayName": "Disk Read Bytes",
-                        "id": "gcp.instance/disk/read_bytes_count",
-                        "job": {
-                            "filters": [
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "instance_id",
-                                    "type": "property"
-                                }
-                            ],
-                            "resolution": 300000,
-                            "template": "DISK_READ_BYTES = data(\"instance/disk/read_bytes_count\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"rate\", extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"instance_name\"])",
-                            "varName": "DISK_READ_BYTES"
-                        },
-                        "metricSelectors": [
-                            "instance/disk/read_bytes_count"
-                        ],
-                        "type": "metric",
-                        "valueFormat": null,
-                        "valueLabel": null,
-                        "valueType": null
+                    "description" : "Color hosts based on bytes written to disk per second",
+                    "displayName" : "Disk Write Bytes",
+                    "id" : "gcp.instance/disk/write_bytes_count",
+                    "job" : {
+                        "filters" : [ {
+                            "not" : false,
+                            "property" : "_exists_",
+                            "propertyValue" : "instance_id",
+                            "type" : "property"
+                        }, {
+                            "not" : false,
+                            "property" : "_exists_",
+                            "propertyValue" : "instance_name",
+                            "type" : "property"
+                        } ],
+                        "resolution" : 300000,
+                        "template" : "DISK_WRITE_BYTES = data(\"instance/disk/write_bytes_count\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"rate\", extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"instance_name\"])",
+                        "varName" : "DISK_WRITE_BYTES"
                     },
-                    {
-                        "coloring": {
-                            "limits": null,
-                            "maxValue": null,
-                            "method": "quantile",
-                            "minValue": 0,
-                            "range": null
-                        },
-                        "description": "Color hosts based on disk write operations per second",
-                        "displayName": "Disk Write Ops",
-                        "id": "gcp.instance/disk/write_ops_count",
-                        "job": {
-                            "filters": [
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "instance_id",
-                                    "type": "property"
-                                }
-                            ],
-                            "resolution": 300000,
-                            "template": "DISK_WRITE_OPS = data(\"instance/disk/write_ops_count\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"rate\", extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"instance_name\"])",
-                            "varName": "DISK_WRITE_OPS"
-                        },
-                        "metricSelectors": [
-                            "instance/disk/write_ops_count"
-                        ],
-                        "type": "metric",
-                        "valueFormat": null,
-                        "valueLabel": null,
-                        "valueType": null
+                    "metricSelectors" : [ "instance/disk/write_bytes_count" ],
+                    "type" : "metric",
+                    "valueFormat" : null,
+                    "valueLabel" : null,
+                    "valueType" : null
+                }, {
+                    "coloring" : {
+                        "limits" : null,
+                        "maxValue" : null,
+                        "method" : "quantile",
+                        "minValue" : 0,
+                        "range" : null
                     },
-                    {
-                        "coloring": {
-                            "limits": null,
-                            "maxValue": null,
-                            "method": "quantile",
-                            "minValue": 0,
-                            "range": null
-                        },
-                        "description": "Color hosts based on disk read operations per second",
-                        "displayName": "Disk Read Ops",
-                        "id": "gcp.instance/disk/read_ops_count",
-                        "job": {
-                            "filters": [
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "instance_id",
-                                    "type": "property"
-                                }
-                            ],
-                            "resolution": 300000,
-                            "template": "DISK_READ_OPS = data(\"instance/disk/read_ops_count\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"rate\", extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"instance_name\"])",
-                            "varName": "DISK_READ_OPS"
-                        },
-                        "metricSelectors": [
-                            "instance/disk/read_ops_count"
-                        ],
-                        "type": "metric",
-                        "valueFormat": null,
-                        "valueLabel": null,
-                        "valueType": null
-                    }
-                ],
-                "mtsQuery": "sf_metric:instance\\/cpu\\/utilization AND _exists_:gcp_id AND service:compute",
-                "o11yMetricName": "Running Instances",
-                "o11yMetricUnit": null,
-                "o11yProductName": "Compute Engine",
-                "o11ySignalflowTemplate": "A = data('instance/uptime', filter=filter('instance_id', '*'), rollup='rate').count().publish(label='A')",
-                "o11yTrendDisplayMode": "absolute",
-                "propertyColumns": [
-                    [
-                        {
-                            "header": "Other",
-                            "properties": []
-                        }
-                    ]
-                ],
-                "proxyProperties": null,
-                "requiredProperties": [
-                    "instance_name"
-                ],
-                "singleHostSystemDashboardName": "Compute Engine Instance",
-                "systemDashboardName": null,
-                "systemDashboardPrefix": "Compute Engine Instances",
-                "tooltipKeyList": [
-                    {
-                        "displayName": "Name",
-                        "format": null,
-                        "isSummaryProperty": true,
-                        "property": "instance_name"
+                    "description" : "Color hosts based on bytes read from disk per second",
+                    "displayName" : "Disk Read Bytes",
+                    "id" : "gcp.instance/disk/read_bytes_count",
+                    "job" : {
+                        "filters" : [ {
+                            "not" : false,
+                            "property" : "_exists_",
+                            "propertyValue" : "instance_id",
+                            "type" : "property"
+                        } ],
+                        "resolution" : 300000,
+                        "template" : "DISK_READ_BYTES = data(\"instance/disk/read_bytes_count\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"rate\", extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"instance_name\"])",
+                        "varName" : "DISK_READ_BYTES"
                     },
-                    {
-                        "displayName": "Project",
-                        "format": null,
-                        "isSummaryProperty": true,
-                        "property": "project_id"
+                    "metricSelectors" : [ "instance/disk/read_bytes_count" ],
+                    "type" : "metric",
+                    "valueFormat" : null,
+                    "valueLabel" : null,
+                    "valueType" : null
+                }, {
+                    "coloring" : {
+                        "limits" : null,
+                        "maxValue" : null,
+                        "method" : "quantile",
+                        "minValue" : 0,
+                        "range" : null
                     },
-                    {
-                        "displayName": "Value",
-                        "format": "Number",
-                        "isSummaryProperty": true,
-                        "property": "value"
-                    }
-                ],
-                "type": "elemental",
-                "unreleased": false
+                    "description" : "Color hosts based on disk write operations per second",
+                    "displayName" : "Disk Write Ops",
+                    "id" : "gcp.instance/disk/write_ops_count",
+                    "job" : {
+                        "filters" : [ {
+                            "not" : false,
+                            "property" : "_exists_",
+                            "propertyValue" : "instance_id",
+                            "type" : "property"
+                        } ],
+                        "resolution" : 300000,
+                        "template" : "DISK_WRITE_OPS = data(\"instance/disk/write_ops_count\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"rate\", extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"instance_name\"])",
+                        "varName" : "DISK_WRITE_OPS"
+                    },
+                    "metricSelectors" : [ "instance/disk/write_ops_count" ],
+                    "type" : "metric",
+                    "valueFormat" : null,
+                    "valueLabel" : null,
+                    "valueType" : null
+                }, {
+                    "coloring" : {
+                        "limits" : null,
+                        "maxValue" : null,
+                        "method" : "quantile",
+                        "minValue" : 0,
+                        "range" : null
+                    },
+                    "description" : "Color hosts based on disk read operations per second",
+                    "displayName" : "Disk Read Ops",
+                    "id" : "gcp.instance/disk/read_ops_count",
+                    "job" : {
+                        "filters" : [ {
+                            "not" : false,
+                            "property" : "_exists_",
+                            "propertyValue" : "instance_id",
+                            "type" : "property"
+                        } ],
+                        "resolution" : 300000,
+                        "template" : "DISK_READ_OPS = data(\"instance/disk/read_ops_count\"{{#filter}}, filter={{{filter}}}{{/filter}}, rollup=\"rate\", extrapolation=\"last_value\", maxExtrapolations=2).sum(by=[\"instance_name\"])",
+                        "varName" : "DISK_READ_OPS"
+                    },
+                    "metricSelectors" : [ "instance/disk/read_ops_count" ],
+                    "type" : "metric",
+                    "valueFormat" : null,
+                    "valueLabel" : null,
+                    "valueType" : null
+                } ],
+                "mtsQuery" : "sf_metric:instance\\/cpu\\/utilization AND _exists_:gcp_id AND service:compute",
+                "o11yMetricName" : "Running Instances",
+                "o11yMetricUnit" : null,
+                "o11yProductName" : "Compute Engine",
+                "o11ySignalflowTemplate" : "A = data('instance/cpu/utilization', filter=filter('instance_id', '*') and filter('monitored_resource', 'gce_instance') and filter('gcp_id', '*'), extrapolation='last_value', maxExtrapolations=2).mean(by=['instance_name']).count().publish(label='A')",
+                "o11yTrendDisplayMode" : "absolute",
+                "propertyColumns" : [ [ {
+                    "header" : "Other",
+                    "properties" : [ ]
+                } ] ],
+                "proxyProperties" : null,
+                "requiredProperties" : [ "instance_name" ],
+                "singleHostSystemDashboardName" : "Compute Engine Instance",
+                "systemDashboardName" : null,
+                "systemDashboardPrefix" : "Compute Engine Instances",
+                "tooltipKeyList" : [ {
+                    "displayName" : "Name",
+                    "format" : null,
+                    "isSummaryProperty" : true,
+                    "property" : "instance_name"
+                }, {
+                    "displayName" : "Project",
+                    "format" : null,
+                    "isSummaryProperty" : true,
+                    "property" : "project_id"
+                }, {
+                    "displayName" : "Value",
+                    "format" : "Number",
+                    "isSummaryProperty" : true,
+                    "property" : "value"
+                } ],
+                "type" : "elemental",
+                "unreleased" : false
             }
         }
     },
-    "packageType": "NAVIGATOR"
+    "packageType" : "NAVIGATOR"
 }

--- a/navigators/Google Cloud Platform/gcp containerengine.json
+++ b/navigators/Google Cloud Platform/gcp containerengine.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -1496113363,
+  "hashCode" : 1846772145,
   "id" : "DiVVG5EAcAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -147,7 +147,7 @@
         "o11yMetricName" : "Running Clusters",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Container Engine",
-        "o11ySignalflowTemplate" : "A = data('container/disk/bytes_used', filter=filter('gcp_id', '*')).sum(by=['cluster_name']).count().mean(over='1m').publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('container/memory/bytes_used', extrapolation='last_value', maxExtrapolations=2).sum(by=['cluster_name', 'project_id']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "Other",

--- a/navigators/Google Cloud Platform/gcp spanner.json
+++ b/navigators/Google Cloud Platform/gcp spanner.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 2107211983,
+  "hashCode" : 2045555270,
   "id" : "DiVVN0hAgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -122,7 +122,7 @@
           },
           "description" : "Color hosts based on number of bytes received",
           "displayName" : "API Received Bytes",
-          "id" : "gcp.api/sent_bytes_count",
+          "id" : "gcp.api/received_bytes_count",
           "job" : {
             "filters" : [ {
               "not" : false,

--- a/navigators/Google Cloud Platform/gcp_k8s_clusters.json
+++ b/navigators/Google Cloud Platform/gcp_k8s_clusters.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -387757077,
+  "hashCode" : 1375631956,
   "id" : "Ea1OhQzAYJE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -113,7 +113,7 @@
         "o11yMetricName" : "Running Clusters",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Kubernetes Engine",
-        "o11ySignalflowTemplate" : "A = data('node/memory/total_bytes').sum(by=['project_id', 'cluster_name']).count().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('container/cpu/request_utilization' , filter=filter('cluster_name', '*')).mean(by=['project_id', 'cluster_name']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "AWS",

--- a/navigators/Hosts/collectd hosts.json
+++ b/navigators/Hosts/collectd hosts.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -43770749,
+  "hashCode" : -950492608,
   "id" : "DiVVQHAAcAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -236,7 +236,7 @@
         "o11yMetricName" : "Running Hosts",
         "o11yMetricUnit" : null,
         "o11yProductName" : "Hosts",
-        "o11ySignalflowTemplate" : "A = data('cpu.utilization', filter=(not filter('agent', '*')), extrapolation='last_value', maxExtrapolations=5).count().publish(label='A')",
+        "o11ySignalflowTemplate" : "A = data('cpu.utilization', filter=filter('host', '*'), extrapolation='last_value', maxExtrapolations=2).mean(by=['host']).count().publish(label='A')",
         "o11yTrendDisplayMode" : "absolute",
         "propertyColumns" : [ [ {
           "header" : "Memory",


### PR DESCRIPTION
Adjusted o11ySignalflowTemplate for various navs to bring the signalflow in line with the signalflow used for the Entity Nav heatmap.

Modified ElastiCache nav to show Running Nodes on olly landing page.

Fixed bug in ECS (AWS) dashboard so that it now shows up on the ECS Infra Navigator (underneath the heatmap).