### PR TITLE
Fixing Azure VMs aggregate dashboard discovery

### DIFF
--- a/group/Azure Virtual Machines.json
+++ b/group/Azure Virtual Machines.json
@@ -6902,7 +6902,7 @@
           "query": "(_exists_:resource_type AND resource_type:\"Microsoft.Compute/virtualMachines\") OR (cloud.provider:azure AND cloud.platform:azure_vm AND _exists_:host.id)",
           "selectors": [
             "sf_key:host.id",
-            "sf_key:azure_resource_id"
+            "_exists_:azure_resource_id"
           ]
         },
         "eventOverlays": null,
@@ -7546,7 +7546,7 @@
       "teams": null
     }
   },
-  "hashCode": -1094855403,
+  "hashCode": -1932687524,
   "id": "DiVWc-rAcAA",
   "modelVersion": 1,
   "packageType": "GROUP"


### PR DESCRIPTION
The new unified Azure VMs aggregate dashboard was not being displayed in the Infra Nav in olly due to faulty discoveryOptions. This PR addresses that issue.