### PR TITLE
Fixing GCE, Azure VMs aggregate dashboard discovery

### DIFF
--- a/group/Azure Virtual Machines.json
+++ b/group/Azure Virtual Machines.json
@@ -6902,7 +6902,7 @@
           "query": "(_exists_:resource_type AND resource_type:\"Microsoft.Compute/virtualMachines\") OR (cloud.provider:azure AND cloud.platform:azure_vm AND _exists_:host.id)",
           "selectors": [
             "sf_key:host.id",
-            "sf_key:azure_resource_id"
+            "_exists_:azure_resource_id"
           ]
         },
         "eventOverlays": null,
@@ -7546,7 +7546,7 @@
       "teams": null
     }
   },
-  "hashCode": -1094855403,
+  "hashCode": -1932687524,
   "id": "DiVWc-rAcAA",
   "modelVersion": 1,
   "packageType": "GROUP"

--- a/group/Google Compute Engine.json
+++ b/group/Google Compute Engine.json
@@ -6072,7 +6072,7 @@
           "query": "_exists_:gcp_id OR (_exists_:host.id AND cloud.provider:gcp AND cloud.platform:gcp_compute_engine)",
           "selectors": [
             "sf_key:host.id",
-            "sf_key:gcp_id",
+            "_exists_:gcp_id",
             "sf_key:instance_id"
           ]
         },
@@ -6553,7 +6553,7 @@
       "teams": null
     }
   },
-  "hashCode": 1696016427,
+  "hashCode": 387897650,
   "id": "DiVWJDGAgGY",
   "modelVersion": 1,
   "packageType": "GROUP"


### PR DESCRIPTION
The new unified GCE and Azure VMs aggregate dashboards were not being displayed in the Infra Nav in olly due to their discoveryOptions. This commit addresses that issue.