### PR TITLE
Azure VMs unified instance dashboard variable change

### DIFF
--- a/group/Azure Virtual Machines.json
+++ b/group/Azure Virtual Machines.json
@@ -7087,13 +7087,13 @@
           "time": null,
           "variables": [
             {
-              "alias": "azure_resource_name",
+              "alias": "azure_resource_id",
               "applyIfExists": false,
               "description": "",
               "preferredSuggestions": [],
-              "property": "azure_resource_name",
+              "property": "azure_resource_id",
               "propertyMappings": [
-                "azure_resource_name"
+                "azure_resource_id"
               ],
               "replaceOnly": false,
               "required": false,
@@ -7577,7 +7577,7 @@
       "teams": null
     }
   },
-  "hashCode": -1390184146,
+  "hashCode": 1456260456,
   "id": "DiVWc-rAcAA",
   "modelVersion": 1,
   "packageType": "GROUP"


### PR DESCRIPTION
The new Azure VMs unified instance dashboard had a dashboard variable for azure_resource_name, but this variable isn't guaranteed to be collected from otel hosts, and it also was not being aggregated on in the heatmap signalflow, leading to issues when opening a chart from the new Entity Nav. Changed the dashboard variable to azure_resource_id instead to resolve that issue.