### PR TITLE
Fix My Data Center olly nav to show SmartAgent hosts

### DIFF
--- a/navigators/Hosts/hosts - my data center.json
+++ b/navigators/Hosts/hosts - my data center.json
@@ -1,330 +1,234 @@
 {
-    "hashCode": -458393015,
-    "id": "ExtGXIGAgDI",
-    "modelVersion": 1,
-    "navigatorExport": {
-        "navigator": {
-            "created": 0,
-            "creator": null,
-            "description": "",
-            "id": "ExtGXIGAgDI",
-            "importQualifiers": [
-                {
-                    "filters": [
-                        {
-                            "not": false,
-                            "property": "sf_key",
-                            "values": [
-                                "host"
-                            ]
-                        }
-                    ],
-                    "metric": "cpu.utilization"
-                }
-            ],
-            "lastUpdated": 0,
-            "lastUpdatedBy": null,
-            "name": "Data Center Hosts",
-            "navigatorCategory": "Hosts",
-            "navigatorType": "elemental",
-            "sites": "o11y",
-            "uiModel": {
-                "alertQuery": "_exists_:host AND _exists_:os.type AND NOT _exist_:cloud.provider",
-                "category": "Hosts",
-                "categoryPriority": 0,
-                "discoveryQuery": [
-                    "sf_key:host"
-                ],
-                "displayName": "Hosts",
-                "filterProperties": null,
-                "id": "datacenter hosts",
-                "idName": "Host",
-                "idTemplate": "{{host}}",
-                "listColumns": [],
-                "metrics": [
-                    {
-                        "coloring": {
-                            "limits": null,
-                            "maxValue": 100,
-                            "method": "quantile",
-                            "minValue": 0,
-                            "range": null
-                        },
-                        "description": "Color hosts based on percentage of CPU utilized: under 20% (green) to over 80% (red)",
-                        "displayName": "cpu.utilization",
-                        "id": "agent.cpu.utilization",
-                        "job": {
-                            "filters": [
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "host",
-                                    "type": "property"
-                                },
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "os.type",
-                                    "type": "property"
-                                }
-                            ],
-                            "resolution": 60000,
-                            "template": "CPU_UTILIZATION = data(\"cpu.utilization\"{{#filter}}, filter=(not filter('cloud.provider', '*')) and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
-                            "varName": "CPU_UTILIZATION"
-                        },
-                        "metricSelectors": [
-                            "cpu.utilization"
-                        ],
-                        "type": "metric",
-                        "valueFormat": "Percentage",
-                        "valueLabel": "CPU Use",
-                        "valueType": null
+    "hashCode" : -2051280833,
+    "id" : "ExtGXIGAgDI",
+    "modelVersion" : 1,
+    "navigatorExport" : {
+        "navigator" : {
+            "created" : 0,
+            "creator" : null,
+            "description" : "",
+            "id" : "ExtGXIGAgDI",
+            "importQualifiers" : [ {
+                "filters" : [ {
+                    "not" : false,
+                    "property" : "sf_key",
+                    "values" : [ "host" ]
+                } ],
+                "metric" : "cpu.utilization"
+            } ],
+            "lastUpdated" : 0,
+            "lastUpdatedBy" : null,
+            "name" : "Data Center Hosts",
+            "navigatorCategory" : "Hosts",
+            "navigatorType" : "elemental",
+            "sites" : "o11y",
+            "uiModel" : {
+                "alertQuery" : "_exists_:host AND _exists_:os.type AND NOT _exist_:cloud.provider",
+                "category" : "Hosts",
+                "categoryPriority" : 0,
+                "discoveryQuery" : [ "sf_key:host" ],
+                "displayName" : "Hosts",
+                "filterProperties" : null,
+                "id" : "datacenter hosts",
+                "idName" : "Host",
+                "idTemplate" : "{{host}}",
+                "listColumns" : [ ],
+                "metrics" : [ {
+                    "coloring" : {
+                        "limits" : null,
+                        "maxValue" : 100,
+                        "method" : "quantile",
+                        "minValue" : 0,
+                        "range" : null
                     },
-                    {
-                        "coloring": {
-                            "limits": null,
-                            "maxValue": 100,
-                            "method": "quantile",
-                            "minValue": 0,
-                            "range": null
-                        },
-                        "description": "Color hosts based on percentage of available memory being used: under 20% (green) to over 80% (red)",
-                        "displayName": "memory.utilization",
-                        "id": "agent.memory.utilization",
-                        "job": {
-                            "filters": [
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "host",
-                                    "type": "property"
-                                },
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "os.type",
-                                    "type": "property"
-                                }
-                            ],
-                            "resolution": 60000,
-                            "template": "MEMORY_UTILIZATION = data(\"memory.utilization\"{{#filter}}, filter=(not filter('cloud.provider', '*')) and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
-                            "varName": "MEMORY_UTILIZATION"
-                        },
-                        "metricSelectors": [
-                            "memory.utilization"
-                        ],
-                        "type": "metric",
-                        "valueFormat": "Percentage",
-                        "valueLabel": "Memory Use",
-                        "valueType": null
+                    "description" : "Color hosts based on percentage of CPU utilized: under 20% (green) to over 80% (red)",
+                    "displayName" : "cpu.utilization",
+                    "id" : "agent.cpu.utilization",
+                    "job" : {
+                        "filters" : [ {
+                            "not" : false,
+                            "property" : "_exists_",
+                            "propertyValue" : "host",
+                            "type" : "property"
+                        } ],
+                        "resolution" : 60000,
+                        "template" : "CPU_UTILIZATION = data(\"cpu.utilization\"{{#filter}}, filter=(not filter('cloud.provider', '*')) and (not filter('AWSUniqueId', '*')) and (not filter('azure_resource_id', '*')) and (not filter('gcp_id', '*')) and (not filter('kubernetes_node', '*')) and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
+                        "varName" : "CPU_UTILIZATION"
                     },
-                    {
-                        "coloring": {
-                            "limits": null,
-                            "maxValue": 100,
-                            "method": "quantile",
-                            "minValue": 0,
-                            "range": null
-                        },
-                        "description": "Color hosts based on percentage of available disk space being used: under 20% (green) to over 80% (red)",
-                        "displayName": "disk.summary_utilization",
-                        "id": "agent.disk.summary_utilization",
-                        "job": {
-                            "filters": [
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "host",
-                                    "type": "property"
-                                },
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "os.type",
-                                    "type": "property"
-                                }
-                            ],
-                            "resolution": 60000,
-                            "template": "DISK_UTILIZATION = data(\"disk.summary_utilization\"{{#filter}}, filter=(not filter('cloud.provider', '*')) and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
-                            "varName": "DISK_UTILIZATION"
-                        },
-                        "metricSelectors": [
-                            "disk.summary_utilization"
-                        ],
-                        "type": "metric",
-                        "valueFormat": "Percentage",
-                        "valueLabel": "Disk Use",
-                        "valueType": null
+                    "metricSelectors" : [ "cpu.utilization" ],
+                    "type" : "metric",
+                    "valueFormat" : "Percentage",
+                    "valueLabel" : "CPU Use",
+                    "valueType" : null
+                }, {
+                    "coloring" : {
+                        "limits" : null,
+                        "maxValue" : 100,
+                        "method" : "quantile",
+                        "minValue" : 0,
+                        "range" : null
                     },
-                    {
-                        "coloring": {
-                            "limits": null,
-                            "maxValue": null,
-                            "method": "quantile",
-                            "minValue": 0,
-                            "range": null
-                        },
-                        "description": "Color hosts by relative amount of network traffic in bits per second: lowest 20% of traffic (green) to highest 20% of traffic (red)",
-                        "displayName": "network.total",
-                        "id": "agent.network.total",
-                        "job": {
-                            "filters": [
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "host",
-                                    "type": "property"
-                                },
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "os.type",
-                                    "type": "property"
-                                }
-                            ],
-                            "resolution": 60000,
-                            "template": "NETWORK_TOTAL = data(\"network.total\"{{#filter}}, filter=(not filter('cloud.provider', '*')) and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
-                            "varName": "NETWORK_TOTAL"
-                        },
-                        "metricSelectors": [
-                            "network.total"
-                        ],
-                        "type": "metric",
-                        "valueFormat": null,
-                        "valueLabel": null,
-                        "valueType": null
+                    "description" : "Color hosts based on percentage of available memory being used: under 20% (green) to over 80% (red)",
+                    "displayName" : "memory.utilization",
+                    "id" : "agent.memory.utilization",
+                    "job" : {
+                        "filters" : [ {
+                            "not" : false,
+                            "property" : "_exists_",
+                            "propertyValue" : "host",
+                            "type" : "property"
+                        } ],
+                        "resolution" : 60000,
+                        "template" : "MEMORY_UTILIZATION = data(\"memory.utilization\"{{#filter}}, filter=(not filter('cloud.provider', '*')) and (not filter('AWSUniqueId', '*')) and (not filter('azure_resource_id', '*')) and (not filter('gcp_id', '*')) and (not filter('kubernetes_node', '*')) and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
+                        "varName" : "MEMORY_UTILIZATION"
                     },
-                    {
-                        "coloring": {
-                            "limits": null,
-                            "maxValue": null,
-                            "method": "quantile",
-                            "minValue": 0,
-                            "range": null
-                        },
-                        "description": "Color hosts by the relative number of disk operations per second: lowest 20% of disk operations (green) to highest 20% of disk operations (red)",
-                        "displayName": "disk_ops.total",
-                        "id": "agent.disk_ops.total",
-                        "job": {
-                            "filters": [
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "host",
-                                    "type": "property"
-                                },
-                                {
-                                    "not": false,
-                                    "property": "_exists_",
-                                    "propertyValue": "os.type",
-                                    "type": "property"
-                                }
-                            ],
-                            "resolution": 60000,
-                            "template": "DISK_OPS_TOTAL = data(\"disk_ops.total\"{{#filter}}, filter=(not filter('cloud.provider', '*')) and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
-                            "varName": "DISK_OPS_TOTAL"
-                        },
-                        "metricSelectors": [
-                            "disk_ops.total"
-                        ],
-                        "type": "metric",
-                        "valueFormat": null,
-                        "valueLabel": null,
-                        "valueType": null
-                    }
-                ],
-                "mtsQuery": "_exists_:host AND _exists_:os.type AND NOT _exists_:cloud.provider",
-                "o11yMetricName": "Running Hosts",
-                "o11yMetricUnit": null,
-                "o11yProductName": "Hosts",
-                "o11ySignalflowTemplate": "A = data('cpu.utilization', filter=filter('host', '*') and filter('os.type', '*') and not filter('cloud.provider', '*'), extrapolation='last_value', maxExtrapolations=2).mean(by=['host']).count().publish(label='A')",
-                "o11yTrendDisplayMode": "absolute",
-                "propertyColumns": [
-                    [
-                        {
-                            "header": "Memory",
-                            "properties": [
-                                "host_mem_total"
-                            ]
-                        },
-                        {
-                            "header": "Processor",
-                            "properties": [
-                                "host_processor",
-                                "host_cpu_model",
-                                "host_logical_cpus",
-                                "host_physical_cpus"
-                            ]
-                        },
-                        {
-                            "header": "OS",
-                            "properties": [
-                                "host_kernel_name",
-                                "host_kernel_release",
-                                "host_kernel_version"
-                            ]
-                        }
-                    ],
-                    [
-                        {
-                            "header": "AWS",
-                            "properties": []
-                        },
-                        {
-                            "header": "Tags",
-                            "properties": [
-                                "sf_tags"
-                            ]
-                        },
-                        {
-                            "header": "Other",
-                            "properties": []
-                        }
-                    ]
-                ],
-                "proxyProperties": null,
-                "requiredProperties": [
-                    "host"
-                ],
-                "singleHostSystemDashboardName": "Host",
-                "systemDashboardName": "Hosts",
-                "systemDashboardPrefix": "Host",
-                "tooltipKeyList": [
-                    {
-                        "displayName": "Name",
-                        "format": null,
-                        "isSummaryProperty": true,
-                        "property": "aws_tag_Name"
+                    "metricSelectors" : [ "memory.utilization" ],
+                    "type" : "metric",
+                    "valueFormat" : "Percentage",
+                    "valueLabel" : "Memory Use",
+                    "valueType" : null
+                }, {
+                    "coloring" : {
+                        "limits" : null,
+                        "maxValue" : 100,
+                        "method" : "quantile",
+                        "minValue" : 0,
+                        "range" : null
                     },
-                    {
-                        "displayName": "Value",
-                        "format": "Number",
-                        "isSummaryProperty": true,
-                        "property": "value"
+                    "description" : "Color hosts based on percentage of available disk space being used: under 20% (green) to over 80% (red)",
+                    "displayName" : "disk.summary_utilization",
+                    "id" : "agent.disk.summary_utilization",
+                    "job" : {
+                        "filters" : [ {
+                            "not" : false,
+                            "property" : "_exists_",
+                            "propertyValue" : "host",
+                            "type" : "property"
+                        } ],
+                        "resolution" : 60000,
+                        "template" : "DISK_UTILIZATION = data(\"disk.summary_utilization\"{{#filter}}, filter=(not filter('cloud.provider', '*')) and (not filter('AWSUniqueId', '*')) and (not filter('azure_resource_id', '*')) and (not filter('gcp_id', '*')) and (not filter('kubernetes_node', '*')) and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
+                        "varName" : "DISK_UTILIZATION"
                     },
-                    {
-                        "displayName": "OS",
-                        "format": null,
-                        "isSummaryProperty": false,
-                        "property": "host_kernel_name"
+                    "metricSelectors" : [ "disk.summary_utilization" ],
+                    "type" : "metric",
+                    "valueFormat" : "Percentage",
+                    "valueLabel" : "Disk Use",
+                    "valueType" : null
+                }, {
+                    "coloring" : {
+                        "limits" : null,
+                        "maxValue" : null,
+                        "method" : "quantile",
+                        "minValue" : 0,
+                        "range" : null
                     },
-                    {
-                        "displayName": "Memory",
-                        "format": "Kilobytes",
-                        "isSummaryProperty": false,
-                        "property": "host_mem_total"
+                    "description" : "Color hosts by relative amount of network traffic in bits per second: lowest 20% of traffic (green) to highest 20% of traffic (red)",
+                    "displayName" : "network.total",
+                    "id" : "agent.network.total",
+                    "job" : {
+                        "filters" : [ {
+                            "not" : false,
+                            "property" : "_exists_",
+                            "propertyValue" : "host",
+                            "type" : "property"
+                        } ],
+                        "resolution" : 60000,
+                        "template" : "NETWORK_TOTAL = data(\"network.total\"{{#filter}}, filter=(not filter('cloud.provider', '*')) and (not filter('AWSUniqueId', '*')) and (not filter('azure_resource_id', '*')) and (not filter('gcp_id', '*')) and (not filter('kubernetes_node', '*')) and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
+                        "varName" : "NETWORK_TOTAL"
                     },
-                    {
-                        "displayName": "vCPU",
-                        "format": null,
-                        "isSummaryProperty": false,
-                        "property": "host_logical_cpus"
-                    }
-                ],
-                "type": "elemental",
-                "unreleased": false
+                    "metricSelectors" : [ "network.total" ],
+                    "type" : "metric",
+                    "valueFormat" : null,
+                    "valueLabel" : null,
+                    "valueType" : null
+                }, {
+                    "coloring" : {
+                        "limits" : null,
+                        "maxValue" : null,
+                        "method" : "quantile",
+                        "minValue" : 0,
+                        "range" : null
+                    },
+                    "description" : "Color hosts by the relative number of disk operations per second: lowest 20% of disk operations (green) to highest 20% of disk operations (red)",
+                    "displayName" : "disk_ops.total",
+                    "id" : "agent.disk_ops.total",
+                    "job" : {
+                        "filters" : [ {
+                            "not" : false,
+                            "property" : "_exists_",
+                            "propertyValue" : "host",
+                            "type" : "property"
+                        } ],
+                        "resolution" : 60000,
+                        "template" : "DISK_OPS_TOTAL = data(\"disk_ops.total\"{{#filter}}, filter=(not filter('cloud.provider', '*')) and (not filter('AWSUniqueId', '*')) and (not filter('azure_resource_id', '*')) and (not filter('gcp_id', '*')) and (not filter('kubernetes_node', '*')) and {{{filter}}}{{/filter}}, extrapolation=\"last_value\", maxExtrapolations=2).mean(by=[\"host\"])",
+                        "varName" : "DISK_OPS_TOTAL"
+                    },
+                    "metricSelectors" : [ "disk_ops.total" ],
+                    "type" : "metric",
+                    "valueFormat" : null,
+                    "valueLabel" : null,
+                    "valueType" : null
+                } ],
+                "mtsQuery" : "_exists_:host AND _exists_:os.type AND NOT _exists_:cloud.provider",
+                "o11yMetricName" : "Running Hosts",
+                "o11yMetricUnit" : null,
+                "o11yProductName" : "Hosts",
+                "o11ySignalflowTemplate" : "A = data('cpu.utilization', filter=filter('host', '*') and not filter('cloud.provider', '*') and (not filter('AWSUniqueId', '*')) and (not filter('azure_resource_id', '*')) and (not filter('gcp_id', '*')) and (not filter('kubernetes_node', '*')), extrapolation='last_value', maxExtrapolations=2).mean(by=['host']).count().publish(label='A')",
+                "o11yTrendDisplayMode" : "absolute",
+                "propertyColumns" : [ [ {
+                    "header" : "Memory",
+                    "properties" : [ "host_mem_total" ]
+                }, {
+                    "header" : "Processor",
+                    "properties" : [ "host_processor", "host_cpu_model", "host_logical_cpus", "host_physical_cpus" ]
+                }, {
+                    "header" : "OS",
+                    "properties" : [ "host_kernel_name", "host_kernel_release", "host_kernel_version" ]
+                } ], [ {
+                    "header" : "AWS",
+                    "properties" : [ ]
+                }, {
+                    "header" : "Tags",
+                    "properties" : [ "sf_tags" ]
+                }, {
+                    "header" : "Other",
+                    "properties" : [ ]
+                } ] ],
+                "proxyProperties" : null,
+                "requiredProperties" : [ "host" ],
+                "singleHostSystemDashboardName" : "Host",
+                "systemDashboardName" : "Hosts",
+                "systemDashboardPrefix" : "Host",
+                "tooltipKeyList" : [ {
+                    "displayName" : "Name",
+                    "format" : null,
+                    "isSummaryProperty" : true,
+                    "property" : "aws_tag_Name"
+                }, {
+                    "displayName" : "Value",
+                    "format" : "Number",
+                    "isSummaryProperty" : true,
+                    "property" : "value"
+                }, {
+                    "displayName" : "OS",
+                    "format" : null,
+                    "isSummaryProperty" : false,
+                    "property" : "host_kernel_name"
+                }, {
+                    "displayName" : "Memory",
+                    "format" : "Kilobytes",
+                    "isSummaryProperty" : false,
+                    "property" : "host_mem_total"
+                }, {
+                    "displayName" : "vCPU",
+                    "format" : null,
+                    "isSummaryProperty" : false,
+                    "property" : "host_logical_cpus"
+                } ],
+                "type" : "elemental",
+                "unreleased" : false
             }
         }
     },
-    "packageType": "NAVIGATOR"
+    "packageType" : "NAVIGATOR"
 }


### PR DESCRIPTION
Modify signalflow templates in the My Data Center olly nav so that SmartAgent hosts are shown as well as Otel hosts.