### PR TITLE
Fix My Data Center olly nav to show SmartAgent hosts

### DIFF
--- a/navigators/Hosts/hosts - my data center.json
+++ b/navigators/Hosts/hosts - my data center.json
@@ -1,5 +1,5 @@
 {
-    "hashCode" : -2051280833,
+    "hashCode" : 471942760,
     "id" : "ExtGXIGAgDI",
     "modelVersion" : 1,
     "navigatorExport" : {
@@ -169,7 +169,7 @@
                     "valueLabel" : null,
                     "valueType" : null
                 } ],
-                "mtsQuery" : "_exists_:host AND _exists_:os.type AND NOT _exists_:cloud.provider",
+                "mtsQuery" : "(sf_key:host OR sf_key:host.name) AND NOT _exists_:AWSUniqueId AND NOT _exists_:azure_resource_id AND NOT _exists_:gcp_id AND NOT _exists_:kubernetes_node AND NOT _exists_:k8s.node.name AND NOT _exists_:cloud.provider",
                 "o11yMetricName" : "Running Hosts",
                 "o11yMetricUnit" : null,
                 "o11yProductName" : "Hosts",


### PR DESCRIPTION
Fixing mtsQuery on the navigator so the aggregate dashboard is shown when an org only has SmartAgent hosts.