### PR TITLE
Fix importQualifiers for ELB, k8s navs

### DIFF
--- a/navigators/AWS/elb.json
+++ b/navigators/AWS/elb.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -1589625821,
+  "hashCode" : 160734939,
   "id" : "DiVVOB3AYAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -11,7 +11,7 @@
       "importQualifiers" : [ {
         "filters" : [ {
           "not" : false,
-          "property" : "_exists_",
+          "property" : "sf_key",
           "values" : [ "LoadBalancerName" ]
         } ],
         "metric" : "RequestCount"

--- a/navigators/Kubernetes/kubernetes containers.json
+++ b/navigators/Kubernetes/kubernetes containers.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : 646144153,
+  "hashCode" : -838225153,
   "id" : "D85Z_TlAcFE",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -13,6 +13,13 @@
           "not" : false,
           "property" : "sf_key",
           "values" : [ "kubernetes_cluster" ]
+        } ],
+        "metric" : "cpu.utilization"
+      }, {
+        "filters" : [ {
+          "not" : false,
+          "property" : "sf_key",
+          "values" : [ "k8s.cluster.name" ]
         } ],
         "metric" : "cpu.utilization"
       } ],

--- a/navigators/Kubernetes/kubernetes nodes.json
+++ b/navigators/Kubernetes/kubernetes nodes.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -266474902,
+  "hashCode" : 686274448,
   "id" : "DiVVM3IAgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -13,6 +13,13 @@
           "not" : false,
           "property" : "sf_key",
           "values" : [ "kubernetes_cluster" ]
+        } ],
+        "metric" : "cpu.utilization"
+      }, {
+        "filters" : [ {
+          "not" : false,
+          "property" : "sf_key",
+          "values" : [ "k8s.cluster.name" ]
         } ],
         "metric" : "cpu.utilization"
       } ],

--- a/navigators/Kubernetes/kubernetes pods.json
+++ b/navigators/Kubernetes/kubernetes pods.json
@@ -1,5 +1,5 @@
 {
-  "hashCode" : -1016546515,
+  "hashCode" : -2098055286,
   "id" : "DiVVQ6FAgAA",
   "modelVersion" : 1,
   "navigatorExport" : {
@@ -17,6 +17,17 @@
           "not" : false,
           "property" : "sf_key",
           "values" : [ "kubernetes_pod_name" ]
+        } ],
+        "metric" : "container_cpu_utilization"
+      }, {
+        "filters" : [ {
+          "not" : false,
+          "property" : "sf_key",
+          "values" : [ "k8s.cluster.name" ]
+        }, {
+          "not" : false,
+          "property" : "sf_key",
+          "values" : [ "k8s.pod.uid" ]
         } ],
         "metric" : "container_cpu_utilization"
       } ],


### PR DESCRIPTION
The importQualifier for the ELB navigator uses _exists_ as the property, which does not seem to be handled properly in signalbuddy, leading to the ELB nav not being imported into orgs despite sending the appropriate data.

Updating the k8s navigators importQualifiers for otel data.