### PR TITLE
Fix importQualifiers for My Data Center nav

### DIFF
--- a/navigators/Hosts/hosts - my data center.json
+++ b/navigators/Hosts/hosts - my data center.json
@@ -1,5 +1,5 @@
 {
-    "hashCode" : 471942760,
+    "hashCode" : -1698542240,
     "id" : "ExtGXIGAgDI",
     "modelVersion" : 1,
     "navigatorExport" : {
@@ -13,6 +13,13 @@
                     "not" : false,
                     "property" : "sf_key",
                     "values" : [ "host" ]
+                } ],
+                "metric" : "cpu.utilization"
+            }, {
+                "filters" : [ {
+                    "not" : false,
+                    "property" : "sf_key",
+                    "values" : [ "host.name" ]
                 } ],
                 "metric" : "cpu.utilization"
             } ],


### PR DESCRIPTION
The importQualifiers for the My Data Center nav did not include "host.name", just "host"...since the mapping service isn't used on properties in the importQualifiers when determining whether to import content or not, customers that only had hosts that reported "host.name" were not seeing the My Data Center nav. This commit addresses that issue.